### PR TITLE
Add scoped raster source caches

### DIFF
--- a/specs/003-raster-review-webapp/contracts/api.md
+++ b/specs/003-raster-review-webapp/contracts/api.md
@@ -16,6 +16,17 @@ Next.js App Router route handlers under `webapp/src/app/api/raster/`. All routes
 | PUT | `/api/raster/input-sets/{id}/groups/{groupId}` | admin | Review/correct group metadata, including six-team normal 6er vs 6er Doppelrunde mode (FR-008a) |
 | POST | `/api/raster/input-sets/{id}/validate` | admin | Validate completeness/schema; returns errors or `ready` (FR-008) |
 
+## Source hierarchy and caches
+
+| Method | Path | Role | Purpose |
+|--------|------|------|---------|
+| GET | `/api/raster/sources?district=&sourceType=` | any | List source documents/links/caches visible to a district, including ancestor scope sources (e.g. OWL + WTTV + DE) |
+| POST | `/api/raster/sources` | admin | Register or update a source for a scope (`scopeCode`, `sourceType`, `sourceRef`, `displayName`, optional `contentHash`, optional `parsedJson`) |
+| POST | `/api/raster/sources/upload` | admin | Upload a replacement source file for a scope and register it as a `RasterSource` |
+| POST | `/api/raster/sources/{id}/refresh` | admin | Explicitly parse/refresh a stored source cache for supported source types such as `GROUP_ASSIGNMENT` and `WISHES_PDF` |
+
+Source records belong to the hierarchy level where the source is valid. For example, a WTTV-wide group PDF is stored under WTTV and inherited by OWL flows. Registering a source does not reparse it; parse/cache refresh happens only when explicitly requested by a parser/upload flow.
+
 ## Hall capacity
 
 | Method | Path | Role | Purpose |

--- a/specs/003-raster-review-webapp/data-model.md
+++ b/specs/003-raster-review-webapp/data-model.md
@@ -1,6 +1,39 @@
 # Data Model: Raster Generation & Review Webapp
 
-Prisma models added to `webapp/prisma/schema.prisma` (+ `schema.postgres.prisma`). Users, Role, and Audit come from the existing baseline and are referenced, not redefined. All review entities carry a `district` scope (FR-025).
+Prisma models added to `webapp/prisma/schema.prisma` (+ `schema.postgres.prisma`). Users, Role, and Audit come from the existing baseline and are referenced, not redefined. Review entities carry a district key for district-scale views, while shared source material is attached to the hierarchy scope where it is valid (FR-008b/008c/025).
+
+## Scope
+
+Existing baseline scope, extended for raster hierarchy. Initial hierarchy: `DE` → `WTTV` → `OWL`.
+
+| Field    | Type          | Notes                                                   |
+| -------- | ------------- | ------------------------------------------------------- |
+| id       | string (cuid) | PK                                                      |
+| code     | string        | Unique key, e.g. `DE`, `WTTV`, `OWL`                    |
+| name     | string        | Unique display name                                     |
+| parentId | string?       | FK → Scope; null for root                               |
+
+Relations: parent/children, user assignments, audit entries, raster sources.
+
+Access rule: a user assigned to a parent scope can access child district data according to their role. Child access does not grant sibling access.
+
+## RasterSource
+
+A registered document/link/cache used to build input sets. It belongs to the scope where the source is valid, not necessarily the target district.
+
+| Field       | Type          | Notes                                                             |
+| ----------- | ------------- | ----------------------------------------------------------------- |
+| id          | string (cuid) | PK                                                                |
+| scopeId     | string        | FK → Scope                                                        |
+| sourceType  | string        | e.g. `GROUP_ASSIGNMENT`, `WISHES_PDF`, `FIXED_RASTERZAHL`         |
+| sourceRef   | string        | URL, file id, or stable source identifier                         |
+| displayName | string        | User-facing label                                                 |
+| contentHash | string?       | Optional replacement/change detection                             |
+| parsedJson  | string?       | Parsed cache; updated only on explicit refresh/upload             |
+| createdAt   | datetime      |                                                                   |
+| updatedAt   | datetime      |                                                                   |
+
+Uniqueness: (scopeId, sourceType, sourceRef). District flows list sources from the district scope and ancestors.
 
 ## InputSet
 
@@ -15,6 +48,8 @@ A named collection of inputs used for one generation run.
 | createdAt       | datetime              |                                                                                                      |
 | status          | enum(`draft`,`ready`) | `ready` = validated, runnable (FR-008)                                                               |
 | seasonModelJson | string?               | Validated structured season model (`clubs`, `teams`, `groups` including reviewed `rasterMode`, relational wishes) used by the solver |
+| groupAssignmentJson | string?          | Cached parsed group assignment source used for the input set; refreshed only on explicit source refresh/upload |
+| wishesJson      | string?               | Cached parsed/uploaded wishes source used for the input set; refreshed only on explicit source refresh/upload |
 
 Relations: has many Wish, HallCapacity, FixedRasterzahl; has many OptimizationRun.
 

--- a/specs/003-raster-review-webapp/quickstart.md
+++ b/specs/003-raster-review-webapp/quickstart.md
@@ -32,12 +32,15 @@ cd webapp && pnpm worker        # or docker compose up worker
 ## Happy-path smoke test (US1)
 
 1. Sign in as **admin**. Create an InputSet for a district.
-2. Upload a wishes PDF → verify deterministic parse shows clubs/teams marked *review*; correct any.
-3. Upload hall-capacity CSV (or add via form); search a club to confirm.
-4. Add fixed upper-league Rasterzahlen (manual entry).
-5. Validate the InputSet → status `ready`.
-6. Start a run → it goes `pending`→`running` asynchronously; the UI stays responsive.
-7. When it finishes, open the snapshot → confirm optimality label (proven-optimal/feasible) and that **no fixed Rasterzahl is violated** (SC-003).
+2. Register source material at the right hierarchy level: WTTV-wide group documents under `WTTV`, district-only wishes under `OWL`, and shared national material under `DE`.
+3. Open `/raster?district=OWL` and verify inherited WTTV sources are visible without being copied into OWL.
+4. Upload or explicitly refresh wishes/group sources only when the underlying PDF/link changed; reopening the input set should reuse the stored cache.
+5. Upload a wishes PDF → verify deterministic parse shows clubs/teams marked *review*; correct any.
+6. Upload hall-capacity CSV (or add via form); search a club to confirm.
+7. Add fixed upper-league Rasterzahlen (manual entry).
+8. Validate the InputSet → status `ready`.
+9. Start a run → it goes `pending`→`running` asynchronously; the UI stays responsive.
+10. When it finishes, open the snapshot → confirm optimality label (proven-optimal/feasible) and that **no fixed Rasterzahl is violated** (SC-003).
 
 ## Review checks (US2–US4)
 

--- a/specs/003-raster-review-webapp/spec.md
+++ b/specs/003-raster-review-webapp/spec.md
@@ -27,6 +27,7 @@ Raw inputs arrive today mostly as PDFs; the app must accept structured versions 
 - Q: In what form do the fixed upper-league Rasterzahlen arrive? → A: PDF or manual entry (volume is small), structured import also acceptable. They are treated as hard constraints the optimizer must not violate.
 - Q: How does the app run the optimization? → A: Wrap the existing Rasterzahl optimizer as an asynchronous background job. The app prepares the reviewed input set, invokes the existing optimizer, and ingests its output into the snapshot model. It does not reimplement the solver.
 - Q: What data scale must the app handle? → A: ~100–1,000 assignments and up to a few hundred conflicts per district snapshot. The system may later hold county-wide data (~1,400 clubs/teams), but review views remain scoped to a selected district, so a single view stays at the hundreds scale.
+- Q: How should shared documents and links be scoped if OWL is only one WTTV district? → A: Model a hierarchy of scopes, initially Germany → WTTV → OWL. Input sets still target a district such as OWL, but source documents/links and parsed caches belong to the scope where they are valid. An OWL input set may use OWL sources plus ancestor sources from WTTV and Germany.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -49,6 +50,7 @@ An admin/scheduler provides the district inputs (club wishes, hall capacities, f
 7. **Given** no valid assignment exists under the hard constraints, **When** the run finishes, **Then** the app reports that no feasible solution was found and shows the relevant blocking constraints where available.
 8. **Given** two same-club teams share one group, **When** a generated assignment uses the Spieltag-4 derby fallback, **Then** the snapshot shows that fallback in the objective breakdown; Spieltag 5 or later is treated as infeasible/invalid and is never persisted as a valid generated assignment.
 9. **Given** the parsed input set contains any six-team group, **When** an admin reviews the input set before starting a run, **Then** the app shows those groups on a confirmation step and lets the admin choose normal 6er or 6er Doppelrunde for each group; the run cannot start until every six-team group has an explicit mode.
+10. **Given** a WTTV-level group document or link exists, **When** an admin prepares an OWL input set, **Then** the app offers that WTTV source as an inherited source without copying or reclassifying it as OWL-only.
 
 ---
 
@@ -163,6 +165,10 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **FR-007**: Authorized users MUST be able to provide the fixed upper-league Rasterzahlen as a PDF, manual entry, or structured upload, and the system MUST treat them as hard constraints that generated assignments never violate.
 - **FR-008**: The system MUST validate an input set for completeness and schema before a run and surface clear errors for missing or malformed inputs.
 - **FR-008a**: The system MUST include a group-review step before validation/run start. For every six-team group, an admin MUST explicitly select `normal 6er` or `6er Doppelrunde`; this selected group mode is persisted in the input set's season model and is passed to the optimizer.
+- **FR-008b**: The system MUST model raster geography as a hierarchy of scopes, initially Germany → WTTV → OWL, so users and source material can be assigned at the level where they are valid.
+- **FR-008c**: The system MUST store raster source documents/links and parsed source caches with an owning scope. A district input set MUST be able to list and use sources from its own district scope and ancestor scopes.
+- **FR-008d**: The system MUST allow authorized admins to register or update source metadata and parsed cache content for a selected scope without reparsing or rescraping existing sources.
+- **FR-008e**: The system MUST only refresh group assignment and wishes caches when an authorized user explicitly requests a click-TT parse/refresh or uploads/replaces source PDFs or structured source data.
 
 #### Generation / Optimization
 
@@ -188,6 +194,7 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **FR-023**: Users MUST be able to mark a conflict or club summary as reviewed, needs data correction, or accepted as unavoidable.
 - **FR-024**: The system MUST provide clear empty and error states for missing snapshots, no conflicts, run/import failures, and permission-denied actions.
 - **FR-025**: The system MUST let users scope review to a selected district so that a single conflict/assignment/capacity view stays at district scale (hundreds of rows) even when the underlying data spans multiple districts (up to county-wide, ~1,400 clubs/teams).
+- **FR-025a**: A user assigned to a parent scope, such as WTTV, MUST be authorized for child district review such as OWL according to their role; a child-scope assignment MUST NOT grant access to unrelated sibling districts.
 
 #### Roles, Audit & Import
 
@@ -203,6 +210,8 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **User**: A person who signs into the app, with permissions via a role.
 - **Role**: A permission level (admin, scheduler, viewer) governing upload, run, capacity edit, review, and user management.
 - **Input Set**: A named collection of the wishes, hall capacities, and fixed upper-league Rasterzahlen used for one generation run.
+- **Scope**: A hierarchy node such as Germany, WTTV, or OWL. Users and raster source material may be assigned at the level where they are valid.
+- **Raster Source**: A document, link, or parsed cache attached to a Scope, such as a WTTV group PDF or an OWL wishes PDF. Input sets can consume sources from their district and ancestors.
 - **Group Review**: A reviewed group roster and mode selection. Six-team groups require an explicit normal-vs-Doppelrunde mode before validation.
 - **Wish**: A club's scheduling preference/constraint for its teams (uploaded structured or extracted from PDF, reviewable/correctable).
 - **Fixed Rasterzahl (Upper League)**: A pre-set, immovable Rasterzahl an upper-league team already holds; a hard constraint on generation.
@@ -230,6 +239,8 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **SC-010**: After a capacity or input edit, all affected snapshot views visibly indicate stale review data before the user can treat the old conflicts as final.
 - **SC-011**: Input validation identifies mismatched or incomplete input sets before a run starts.
 - **SC-011a**: A run cannot start while any six-team group lacks a reviewed mode, and a generated six-team Doppelrunde assignment uses the Doppelrunde rulebook table for penalties, conflicts, and derby display.
+- **SC-011b**: An OWL admin can see WTTV-level source material in the OWL preparation flow within 5 seconds, while source records remain visibly associated with WTTV.
+- **SC-011c**: Reopening an existing input set does not reparse click-TT or PDF sources unless the user explicitly requests refresh or uploads replacement source material.
 - **SC-012**: At least 95% of completed runs display their final outcome, objective value, and generated snapshot link without manual log inspection.
 - **SC-013**: Users can distinguish proven-optimal, feasible-only, and imported heuristic snapshots within 5 seconds of opening a snapshot.
 - **SC-014**: If a generated snapshot uses any Spieltag-4 same-club derby fallback, a scheduler can see the count and affected objective component within 5 seconds of opening the snapshot; no Spieltag-5-or-later same-club derby is stored as a valid generated snapshot.
@@ -246,6 +257,7 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - User login, user administration, and basic role management are provided by the existing internal application baseline (webapp-template).
 - Reviewed capacity and input data are maintained separately from snapshots so old snapshots remain historically understandable.
 - First release targets district scale (hundreds of assignments/conflicts per snapshot). The data model should not preclude later county-wide scale (~1,400 clubs/teams) with district-scoped views.
+- WTTV-level documents may apply to multiple districts. Source ownership follows the administrative level where the document is valid; input sets consume inherited sources instead of duplicating them per district.
 - Desktop/tablet review is the primary workflow for the first release; mobile is useful but secondary.
 - A new snapshot is required after capacity/input edits before conflict counts can be considered final.
 </content>

--- a/specs/003-raster-review-webapp/tasks.md
+++ b/specs/003-raster-review-webapp/tasks.md
@@ -147,6 +147,29 @@
 
 ---
 
+## Phase 10: Source Hierarchy & DB-Backed Input Caches
+
+**Goal**: Model Germany / WTTV / district hierarchy, store source documents and parsed caches at the scope where they are valid, and refresh cached parsing only on explicit request.
+
+**Independent Test**: Register a WTTV group source, open an OWL raster flow, verify the WTTV source is visible to OWL users with parent-scope access, and verify reopening the input set does not reparse until refresh/upload is requested.
+
+- [x] T054 [US1] Extend `webapp/prisma/schema.postgres.prisma` and migrations with hierarchical `Scope.parentId` for Germany → WTTV → OWL.
+- [x] T055 [US1] Update `webapp/prisma/seed.ts` to seed `DE`, `WTTV`, and `OWL` hierarchy while preserving demo OWL users.
+- [x] T056 [US5] Update `webapp/src/lib/raster/access.ts` so users assigned to parent scopes can access child district raster data according to role.
+- [x] T057 [P] [US5] Add hierarchy access tests in `webapp/tests/unit/raster-access.test.ts`.
+- [x] T058 [US1] Add `RasterSource` model and migration for scoped documents/links/parsed cache in `webapp/prisma/schema.postgres.prisma`.
+- [x] T059 [US1] Add DB-backed cache fields `groupAssignmentJson` and `wishesJson` to `RasterInputSet` and migration.
+- [x] T060 [US1] Update `webapp/src/services/raster/inputSets.ts` and `webapp/src/services/raster/wishes.ts` so caches are written only on source upload/update paths.
+- [x] T061 [P] [US1] Add source service helpers and tests in `webapp/src/services/raster/sources.ts`, `webapp/tests/unit/raster-sources-service.test.ts`, and `webapp/tests/unit/raster-wishes-service.test.ts`.
+- [x] T062 [US1] Add `GET/POST /api/raster/sources` in `webapp/src/app/api/raster/sources/route.ts` with route tests in `webapp/tests/unit/raster-sources-route.test.ts`.
+- [x] T063 [US1] Add Raster page source list/manual source-cache form in `webapp/src/components/raster/sources/raster-sources-panel.tsx` and wire it into `webapp/src/app/(dashboard)/raster/page.tsx`.
+- [x] T064 [US1] Add explicit parser refresh action for a stored `RasterSource` in `webapp/src/app/api/raster/sources/[id]/refresh/route.ts`, supporting group assignment and wishes PDF source types without refreshing on ordinary page load.
+- [x] T065 [US1] Add source upload/link UI controls in `webapp/src/components/raster/sources/raster-sources-panel.tsx` so admins can upload replacement PDFs or trigger click-TT parsing for a selected hierarchy scope.
+- [x] T066 [US1] Wire refreshed `RasterSource.parsedJson` into input-set preparation in `webapp/src/services/raster/inputSets.ts`, allowing OWL input sets to consume inherited WTTV group assignment cache plus OWL wishes cache.
+- [x] T067 [P] [US1] Add Playwright coverage in `webapp/tests/e2e/raster-generate.spec.ts` proving an inherited WTTV source appears in the OWL flow and is not reparsed on reload.
+
+---
+
 ## Dependencies & Execution Order
 
 - **Setup (Phase 1)**: T001 governance blocker first; T002→T003 (schema→migration) ordered; T004/T005/T006 parallel after.
@@ -158,6 +181,7 @@
 - **US5 (Phase 7)**: gates apply across all prior routes — do after routes exist, before release.
 - **US6 (Phase 8)**: reuses review layer (US2/US3).
 - **Polish (Phase 9)**: after target stories.
+- **Source hierarchy/cache (Phase 10)**: schema/access tasks T054–T059 before APIs/UI; T064–T066 complete parser integration; T067 verifies behavior end-to-end.
 
 ### Parallel Opportunities
 
@@ -166,6 +190,7 @@
 - T016, T017, T018, T019 (distinct input types) parallel.
 - T025, T026, T028 parallel; T031, T032, T034 parallel.
 - US2 and US3 can proceed in parallel once US1 produces a snapshot.
+- T064 and T065 can proceed in parallel after T062/T063.
 
 ### MVP
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,1 @@
+export * from "./auth.ts";

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export * from "./config.ts";

--- a/src/raster/ingest/assignment-table.js
+++ b/src/raster/ingest/assignment-table.js
@@ -1,0 +1,1 @@
+export * from "./assignment-table.ts";

--- a/src/raster/ingest/clicktt-assignments.js
+++ b/src/raster/ingest/clicktt-assignments.js
@@ -1,0 +1,1 @@
+export * from "./clicktt-assignments.ts";

--- a/src/raster/ingest/groups-pdf.js
+++ b/src/raster/ingest/groups-pdf.js
@@ -1,0 +1,1 @@
+export * from "./groups-pdf.ts";

--- a/src/raster/ingest/model.js
+++ b/src/raster/ingest/model.js
@@ -1,0 +1,1 @@
+export * from "./model.ts";

--- a/src/raster/ingest/pdf-text.js
+++ b/src/raster/ingest/pdf-text.js
@@ -1,0 +1,1 @@
+export * from "./pdf-text.ts";

--- a/src/raster/ingest/scrape.js
+++ b/src/raster/ingest/scrape.js
@@ -1,0 +1,1 @@
+export * from "./scrape.ts";

--- a/src/raster/ingest/scrape.ts
+++ b/src/raster/ingest/scrape.ts
@@ -25,7 +25,11 @@ const groupText =
   /gruppen.*raster|raster.*gruppen|gruppeneinteilung|rasterzahl|tabelle.*spielplan|gruppen-spielplan|ScheduleReportFOP/i;
 
 function safeName(prefix: string, url: string): string {
-  const name = new URL(url).pathname.split("/").at(-1)?.replace(/[^a-z0-9.-]+/gi, "-") || `${prefix}.pdf`;
+  const name =
+    new URL(url).pathname
+      .split("/")
+      .at(-1)
+      ?.replace(/[^a-z0-9.-]+/gi, "-") || `${prefix}.pdf`;
   return name.toLowerCase().endsWith(".pdf") ? name : `${name}.pdf`;
 }
 
@@ -35,7 +39,11 @@ function sameOrigin(url: string, base: string): boolean {
 
 function canDownload(url: string, base: string): boolean {
   const host = new URL(url).hostname;
-  return sameOrigin(url, base) || host === "www.click-tt.de" || host.endsWith(".click-tt.de");
+  return (
+    sameOrigin(url, base) ||
+    host === "www.click-tt.de" ||
+    host.endsWith(".click-tt.de")
+  );
 }
 
 async function collectLinks(page: Page): Promise<LinkSnapshot[]> {
@@ -48,8 +56,15 @@ async function collectLinks(page: Page): Promise<LinkSnapshot[]> {
   );
 }
 
-async function downloadPdf(request: APIRequestContext, url: string, outDir: string, prefix: string): Promise<string | null> {
-  const response = await request.get(url, { timeout: 15_000 }).catch(() => null);
+async function downloadPdf(
+  request: APIRequestContext,
+  url: string,
+  outDir: string,
+  prefix: string
+): Promise<string | null> {
+  const response = await request
+    .get(url, { timeout: 15_000 })
+    .catch(() => null);
   if (!response?.ok()) return null;
   const contentType = response.headers()["content-type"] ?? "";
   if (!/pdf/i.test(contentType) && !/\.pdf(?:$|[?#])/i.test(url)) return null;
@@ -61,7 +76,10 @@ async function downloadPdf(request: APIRequestContext, url: string, outDir: stri
 }
 
 function interesting(link: LinkSnapshot): boolean {
-  return crawlText.test(`${link.text} ${link.href}`) && !/abmelden|logout|löschen|loeschen|speichern|genehmig/i.test(link.text);
+  return (
+    crawlText.test(`${link.text} ${link.href}`) &&
+    !/abmelden|logout|löschen|loeschen|speichern|genehmig/i.test(link.text)
+  );
 }
 
 export async function scrapeSeasonModel(
@@ -69,7 +87,10 @@ export async function scrapeSeasonModel(
   publicLeagueUrl?: string
 ): Promise<SeasonModel> {
   const config = loadConfig();
-  const browser = await chromium.launch({ headless: !config.headed, slowMo: config.slowMoMs });
+  const browser = await chromium.launch({
+    headless: !config.headed,
+    slowMo: config.slowMoMs
+  });
   const context = await browser.newContext({ acceptDownloads: true });
   const page = await context.newPage();
   const outDir = path.resolve("reports/raster/clicktt-downloads");
@@ -84,22 +105,40 @@ export async function scrapeSeasonModel(
     await login(page, config.baseUrl, config.username, config.password);
     const assignmentRows = await scrapeTeamRasterAssignments(page);
     const assignmentClubNames = new Set(
-      assignmentRows.map((row) => row.team.replace(/\s+(?:II|III|IV|V|VI|VII|VIII|IX|X)$/i, "").trim().toLowerCase())
+      assignmentRows.map((row) =>
+        row.team
+          .replace(/\s+(?:II|III|IV|V|VI|VII|VIII|IX|X)$/i, "")
+          .trim()
+          .toLowerCase()
+      )
     );
-    const allPublicRows = publicLeagueUrl ? await scrapePublicLeagueAssignments(page, publicLeagueUrl) : [];
-    const adminTeams = new Set(assignmentRows.map((row) => row.team.toLowerCase()));
+    const allPublicRows = publicLeagueUrl
+      ? await scrapePublicLeagueAssignments(page, publicLeagueUrl)
+      : [];
+    const adminTeams = new Set(
+      assignmentRows.map((row) => row.team.toLowerCase())
+    );
     const publicAdminGroups = new Set(
-      allPublicRows.flatMap((row) => (adminTeams.has(row.team.toLowerCase()) ? [row.sourceUrl] : []))
+      allPublicRows.flatMap((row) =>
+        adminTeams.has(row.team.toLowerCase()) ? [row.sourceUrl] : []
+      )
     );
     const relevantPublicGroups = new Set(
       allPublicRows.flatMap((row) =>
         !publicAdminGroups.has(row.sourceUrl) &&
-        assignmentClubNames.has(row.team.replace(/\s+(?:II|III|IV|V|VI|VII|VIII|IX|X)$/i, "").trim().toLowerCase())
+        assignmentClubNames.has(
+          row.team
+            .replace(/\s+(?:II|III|IV|V|VI|VII|VIII|IX|X)$/i, "")
+            .trim()
+            .toLowerCase()
+        )
           ? [row.group]
           : []
       )
     );
-    const publicRows = allPublicRows.filter((row) => relevantPublicGroups.has(row.group));
+    const publicRows = allPublicRows.filter((row) =>
+      relevantPublicGroups.has(row.group)
+    );
     const modelRows = assignmentRows;
     await fs.mkdir("reports/raster", { recursive: true });
     await fs.writeFile(
@@ -115,18 +154,30 @@ export async function scrapeSeasonModel(
     if (publicRows.length > 0) {
       await fs.writeFile(
         "reports/raster/public-team-context.csv",
-        assignmentRowsToCsv(publicRows).replace(/^league,group,division,rasterzahl,/, "league,group,division,rank,"),
+        assignmentRowsToCsv(publicRows).replace(
+          /^league,group,division,rasterzahl,/,
+          "league,group,division,rank,"
+        ),
         "utf8"
       );
     }
     const wishFilesByUrl = new Map<string, string>();
     for (const row of assignmentRows) {
       if (!row.wishUrl || wishFilesByUrl.has(row.wishUrl)) continue;
-      const wish = await downloadPdf(context.request, row.wishUrl, outDir, "wishes");
+      const wish = await downloadPdf(
+        context.request,
+        row.wishUrl,
+        outDir,
+        "wishes"
+      );
       if (wish) wishFilesByUrl.set(row.wishUrl, wish);
     }
     if (modelRows.length > 0) {
-      return await buildSeasonModelFromAssignments(modelRows, wishFilesByUrl, fixedRows);
+      return await buildSeasonModelFromAssignments(
+        modelRows,
+        wishFilesByUrl,
+        fixedRows
+      );
     }
 
     queue.push(page.url());
@@ -135,22 +186,46 @@ export async function scrapeSeasonModel(
       const url = queue.shift()!;
       if (seen.has(url) || !sameOrigin(url, config.baseUrl)) continue;
       seen.add(url);
-      await page.goto(url, { waitUntil: "domcontentloaded", timeout: 20_000 }).catch(() => undefined);
+      await page
+        .goto(url, { waitUntil: "domcontentloaded", timeout: 20_000 })
+        .catch(() => undefined);
 
       for (const link of await collectLinks(page)) {
         const label = `${link.text} -> ${link.href}`;
         if (sampledLinks.length < 30) sampledLinks.push(label);
         if (!interesting(link)) continue;
 
-        if (!groups && canDownload(link.href, config.baseUrl) && groupText.test(`${link.text} ${link.href}`)) {
-          groups = await downloadPdf(context.request, link.href, outDir, "groups");
+        if (
+          !groups &&
+          canDownload(link.href, config.baseUrl) &&
+          groupText.test(`${link.text} ${link.href}`)
+        ) {
+          groups = await downloadPdf(
+            context.request,
+            link.href,
+            outDir,
+            "groups"
+          );
         }
-        if (canDownload(link.href, config.baseUrl) && wishText.test(`${link.text} ${link.href}`) && !downloaded.has(link.href)) {
+        if (
+          canDownload(link.href, config.baseUrl) &&
+          wishText.test(`${link.text} ${link.href}`) &&
+          !downloaded.has(link.href)
+        ) {
           downloaded.add(link.href);
-          const wish = await downloadPdf(context.request, link.href, outDir, "wishes");
+          const wish = await downloadPdf(
+            context.request,
+            link.href,
+            outDir,
+            "wishes"
+          );
           if (wish) wishes.push(wish);
         }
-        if (sameOrigin(link.href, config.baseUrl) && !seen.has(link.href) && queue.length < 60) {
+        if (
+          sameOrigin(link.href, config.baseUrl) &&
+          !seen.has(link.href) &&
+          queue.length < 60
+        ) {
           queue.push(link.href);
         }
       }
@@ -163,6 +238,26 @@ export async function scrapeSeasonModel(
     }
 
     return await buildSeasonModel(wishes, groups);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+export async function scrapeCurrentTeamRasterAssignments(): Promise<
+  TeamRasterAssignmentRow[]
+> {
+  const config = loadConfig();
+  const browser = await chromium.launch({
+    headless: !config.headed,
+    slowMo: config.slowMoMs
+  });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    await login(page, config.baseUrl, config.username, config.password);
+    return await scrapeTeamRasterAssignments(page);
   } finally {
     await context.close();
     await browser.close();

--- a/src/raster/ingest/wishes-freetext.js
+++ b/src/raster/ingest/wishes-freetext.js
@@ -1,0 +1,1 @@
+export * from "./wishes-freetext.ts";

--- a/src/raster/ingest/wishes-pdf.js
+++ b/src/raster/ingest/wishes-pdf.js
@@ -1,0 +1,1 @@
+export * from "./wishes-pdf.ts";

--- a/src/raster/rulebook/rulebook.js
+++ b/src/raster/rulebook/rulebook.js
@@ -1,0 +1,1 @@
+export * from "./rulebook.ts";

--- a/webapp/prisma/migrations-postgres/20260710124500_add_raster_input_caches/migration.sql
+++ b/webapp/prisma/migrations-postgres/20260710124500_add_raster_input_caches/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "RasterInputSet" ADD COLUMN "groupAssignmentJson" TEXT;
+ALTER TABLE "RasterInputSet" ADD COLUMN "wishesJson" TEXT;

--- a/webapp/prisma/migrations-postgres/20260710130000_add_scope_hierarchy/migration.sql
+++ b/webapp/prisma/migrations-postgres/20260710130000_add_scope_hierarchy/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "Scope" ADD COLUMN "parentId" TEXT;
+
+CREATE INDEX "Scope_parentId_idx" ON "Scope"("parentId");
+
+ALTER TABLE "Scope" ADD CONSTRAINT "Scope_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Scope"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/webapp/prisma/migrations-postgres/20260710131000_add_raster_sources/migration.sql
+++ b/webapp/prisma/migrations-postgres/20260710131000_add_raster_sources/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "RasterSource" (
+    "id" TEXT NOT NULL,
+    "scopeId" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceRef" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "contentHash" TEXT,
+    "parsedJson" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RasterSource_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "RasterSource_scopeId_sourceType_idx" ON "RasterSource"("scopeId", "sourceType");
+
+CREATE UNIQUE INDEX "RasterSource_scopeId_sourceType_sourceRef_key" ON "RasterSource"("scopeId", "sourceType", "sourceRef");
+
+ALTER TABLE "RasterSource" ADD CONSTRAINT "RasterSource_scopeId_fkey" FOREIGN KEY ("scopeId") REFERENCES "Scope"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/webapp/prisma/schema.postgres.prisma
+++ b/webapp/prisma/schema.postgres.prisma
@@ -269,10 +269,32 @@ model Scope {
   id              String                @id @default(cuid())
   name            String                @unique
   code            String                @unique
+  parentId        String?
   createdAt       DateTime              @default(now())
   updatedAt       DateTime              @updatedAt
+  parent          Scope?                @relation("ScopeHierarchy", fields: [parentId], references: [id], onDelete: SetNull)
+  children        Scope[]               @relation("ScopeHierarchy")
   userAssignments UserScopeAssignment[]
   auditEntries    AuditEntry[]
+  rasterSources   RasterSource[]
+
+  @@index([parentId])
+}
+
+model RasterSource {
+  id          String   @id @default(cuid())
+  scopeId     String
+  sourceType  String
+  sourceRef   String
+  displayName String
+  contentHash String?
+  parsedJson  String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  scope       Scope    @relation(fields: [scopeId], references: [id], onDelete: Cascade)
+
+  @@unique([scopeId, sourceType, sourceRef])
+  @@index([scopeId, sourceType])
 }
 
 model UserScopeAssignment {
@@ -550,17 +572,19 @@ model TeamsDelegatedGrant {
 }
 
 model RasterInputSet {
-  id                String                  @id @default(cuid())
-  name              String
-  district          String
-  createdById       String
-  createdAt         DateTime                @default(now())
-  status            InputSetStatus          @default(DRAFT)
-  seasonModelJson   String?
-  createdBy         User                    @relation("RasterInputSetCreator", fields: [createdById], references: [id], onDelete: Restrict)
-  wishes            RasterWish[]
-  fixedRasterzahlen RasterFixedRasterzahl[]
-  runs              RasterOptimizationRun[]
+  id                  String                  @id @default(cuid())
+  name                String
+  district            String
+  createdById         String
+  createdAt           DateTime                @default(now())
+  status              InputSetStatus          @default(DRAFT)
+  seasonModelJson     String?
+  groupAssignmentJson String?
+  wishesJson          String?
+  createdBy           User                    @relation("RasterInputSetCreator", fields: [createdById], references: [id], onDelete: Restrict)
+  wishes              RasterWish[]
+  fixedRasterzahlen   RasterFixedRasterzahl[]
+  runs                RasterOptimizationRun[]
 
   @@index([district, createdAt])
   @@index([createdById])

--- a/webapp/prisma/seed.ts
+++ b/webapp/prisma/seed.ts
@@ -113,10 +113,24 @@ async function main() {
     },
   });
 
+  const germanyScope = await prisma.scope.create({
+    data: {
+      code: "DE",
+      name: "Germany",
+    },
+  });
+  const wttvScope = await prisma.scope.create({
+    data: {
+      code: "WTTV",
+      name: "Westdeutscher Tischtennis-Verband",
+      parentId: germanyScope.id,
+    },
+  });
   const demoScope = await prisma.scope.create({
     data: {
       code: "OWL",
       name: "Ostwestfalen-Lippe",
+      parentId: wttvScope.id,
     },
   });
 
@@ -149,7 +163,7 @@ async function main() {
   }
 
   console.log(`Seeded initial admin user ${email}.`);
-  console.log("Seeded demo Raster district OWL and review users.");
+  console.log("Seeded demo Raster hierarchy DE > WTTV > OWL and review users.");
 }
 
 main()

--- a/webapp/src/app/(dashboard)/raster/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/page.tsx
@@ -4,7 +4,9 @@ import {
   GroupModeReview,
   type GroupModeReviewRow,
 } from "@/components/raster/group-mode-review";
-import { listInputSets } from "@/services/raster";
+import { RasterSourcesPanel } from "@/components/raster/sources/raster-sources-panel";
+import { Role } from "../../../../generated/prisma/enums";
+import { listInputSets, listRasterSourcesForDistrict } from "@/services/raster";
 
 type SeasonGroup = {
   id?: string;
@@ -30,7 +32,10 @@ export default async function RasterPage({
     );
   }
 
-  const inputSets = await listInputSets(district);
+  const [inputSets, sources] = await Promise.all([
+    listInputSets(district),
+    listRasterSourcesForDistrict(district),
+  ]);
 
   return (
     <div className="space-y-7">
@@ -42,6 +47,12 @@ export default async function RasterPage({
           Raster
         </h1>
       </section>
+
+      <RasterSourcesPanel
+        canEdit={user.role === Role.PLATFORM_ADMIN}
+        district={district}
+        sources={sources}
+      />
 
       <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
         <div className="grid grid-cols-[minmax(12rem,1fr)_8rem_8rem_8rem] gap-3 border-b border-[var(--border)] px-4 py-3 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">

--- a/webapp/src/app/api/raster/sources/[id]/refresh/route.ts
+++ b/webapp/src/app/api/raster/sources/[id]/refresh/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/route-auth";
+import { assertRasterAccess } from "@/lib/raster/access";
+import { prisma } from "@/lib/db";
+import { refreshRasterSource } from "@/services/raster";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireApiUser(request);
+  if ("error" in auth) return auth.error;
+
+  const source = await prisma.rasterSource.findUnique({
+    where: { id: (await params).id },
+    include: { scope: true },
+  });
+  if (!source) {
+    return NextResponse.json({ error: "Source not found" }, { status: 404 });
+  }
+
+  const access = await assertRasterAccess(auth.user, source.scope.code, "admin");
+  if (access !== true) return access.error;
+
+  try {
+    return NextResponse.json({
+      source: await refreshRasterSource(source.id),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Source refresh failed",
+      },
+      { status: 422 },
+    );
+  }
+}

--- a/webapp/src/app/api/raster/sources/route.ts
+++ b/webapp/src/app/api/raster/sources/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireApiUser } from "@/lib/route-auth";
+import { assertRasterAccess } from "@/lib/raster/access";
+import { prisma } from "@/lib/db";
+import { listRasterSourcesForDistrict, upsertRasterSource } from "@/services/raster";
+
+const sourceBodySchema = z.object({
+  scopeCode: z.string().trim().min(1),
+  sourceType: z.string().trim().min(1),
+  sourceRef: z.string().trim().min(1),
+  displayName: z.string().trim().min(1),
+  contentHash: z.string().trim().optional(),
+  parsedJson: z.string().trim().optional(),
+});
+
+export async function GET(request: Request) {
+  const auth = await requireApiUser(request);
+  if ("error" in auth) return auth.error;
+
+  const search = new URL(request.url).searchParams;
+  const district = search.get("district")?.trim();
+  if (!district) {
+    return NextResponse.json(
+      { error: "district is required" },
+      { status: 400 },
+    );
+  }
+
+  const access = await assertRasterAccess(auth.user, district, "viewer");
+  if (access !== true) return access.error;
+
+  return NextResponse.json({
+    sources: await listRasterSourcesForDistrict(
+      district,
+      search.get("sourceType")?.trim() || undefined,
+    ),
+  });
+}
+
+export async function POST(request: Request) {
+  const auth = await requireApiUser(request);
+  if ("error" in auth) return auth.error;
+
+  const parsed = sourceBodySchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid source payload" }, { status: 422 });
+  }
+
+  const access = await assertRasterAccess(auth.user, parsed.data.scopeCode, "admin");
+  if (access !== true) return access.error;
+
+  const scope = await prisma.scope.findFirst({
+    where: {
+      OR: [{ code: parsed.data.scopeCode }, { name: parsed.data.scopeCode }],
+    },
+    select: { id: true },
+  });
+  if (!scope) {
+    return NextResponse.json({ error: "Scope not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    {
+      source: await upsertRasterSource({
+        scopeId: scope.id,
+        sourceType: parsed.data.sourceType,
+        sourceRef: parsed.data.sourceRef,
+        displayName: parsed.data.displayName,
+        contentHash: parsed.data.contentHash,
+        parsedJson: parsed.data.parsedJson,
+      }),
+    },
+    { status: 201 },
+  );
+}

--- a/webapp/src/app/api/raster/sources/upload/route.ts
+++ b/webapp/src/app/api/raster/sources/upload/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/route-auth";
+import { assertRasterAccess } from "@/lib/raster/access";
+import { prisma } from "@/lib/db";
+import { saveFile } from "@/lib/file-storage";
+import { upsertRasterSource } from "@/services/raster";
+
+export async function POST(request: Request) {
+  const auth = await requireApiUser(request);
+  if ("error" in auth) return auth.error;
+
+  const formData = await request.formData();
+  const scopeCode = String(formData.get("scopeCode") ?? "").trim();
+  const sourceType = String(formData.get("sourceType") ?? "").trim();
+  const displayName = String(formData.get("displayName") ?? "").trim();
+  const file = formData.get("file");
+  if (!scopeCode || !sourceType || !displayName || !(file instanceof File)) {
+    return NextResponse.json({ error: "Invalid source upload" }, { status: 422 });
+  }
+
+  const access = await assertRasterAccess(auth.user, scopeCode, "admin");
+  if (access !== true) return access.error;
+
+  const scope = await prisma.scope.findFirst({
+    where: { OR: [{ code: scopeCode }, { name: scopeCode }] },
+    select: { id: true },
+  });
+  if (!scope) {
+    return NextResponse.json({ error: "Scope not found" }, { status: 404 });
+  }
+
+  const sourceRef = await saveFile(
+    Buffer.from(await file.arrayBuffer()),
+    file.name || "source.bin",
+  );
+  return NextResponse.json(
+    {
+      source: await upsertRasterSource({
+        scopeId: scope.id,
+        sourceType,
+        sourceRef,
+        displayName,
+      }),
+    },
+    { status: 201 },
+  );
+}

--- a/webapp/src/components/raster/sources/raster-sources-panel.tsx
+++ b/webapp/src/components/raster/sources/raster-sources-panel.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { withBasePath } from "@/lib/base-path";
+
+type RasterSourceRow = {
+  id: string;
+  scopeId: string;
+  sourceType: string;
+  sourceRef: string;
+  displayName: string;
+  contentHash: string | null;
+  parsedJson: string | null;
+  updatedAt: Date | string;
+};
+
+export function RasterSourcesPanel({
+  district,
+  sources,
+  canEdit,
+}: {
+  district: string;
+  sources: RasterSourceRow[];
+  canEdit: boolean;
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [refreshingId, setRefreshingId] = useState<string | null>(null);
+
+  async function submitLink(formData: FormData) {
+    setMessage(null);
+    const payload = {
+      scopeCode: String(formData.get("scopeCode") ?? ""),
+      sourceType: String(formData.get("sourceType") ?? ""),
+      sourceRef: String(formData.get("sourceRef") ?? ""),
+      displayName: String(formData.get("displayName") ?? ""),
+      contentHash: String(formData.get("contentHash") ?? "") || undefined,
+      parsedJson: String(formData.get("parsedJson") ?? "") || undefined,
+    };
+    const response = await fetch(withBasePath("/api/raster/sources"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      setMessage(body.error ?? `Failed (${response.status})`);
+      return;
+    }
+    setMessage("Saved");
+    router.refresh();
+  }
+
+  async function uploadSource(formData: FormData) {
+    setMessage(null);
+    const response = await fetch(withBasePath("/api/raster/sources/upload"), {
+      method: "POST",
+      body: formData,
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      setMessage(body.error ?? `Upload failed (${response.status})`);
+      return;
+    }
+    setMessage("Uploaded");
+    router.refresh();
+  }
+
+  async function refreshSource(sourceId: string) {
+    setRefreshingId(sourceId);
+    setMessage(null);
+    try {
+      const response = await fetch(
+        withBasePath(`/api/raster/sources/${sourceId}/refresh`),
+        { method: "POST" },
+      );
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setMessage(body.error ?? `Refresh failed (${response.status})`);
+        return;
+      }
+      setMessage("Refreshed");
+      router.refresh();
+    } finally {
+      setRefreshingId(null);
+    }
+  }
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
+      <div className="border-b border-[var(--border)] px-4 py-3">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+          Sources
+        </h2>
+      </div>
+      <div className="divide-y divide-[var(--border)]">
+        {sources.length ? (
+          sources.map((source) => (
+            <div
+              key={source.id}
+              className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[10rem_minmax(12rem,1fr)_12rem_7rem]"
+            >
+              <span className="font-medium">{source.sourceType}</span>
+              <span className="break-all">{source.displayName}</span>
+              <span className="text-[var(--muted-foreground)]">
+                {new Date(source.updatedAt).toLocaleDateString()}
+              </span>
+              {canEdit ? (
+                <button
+                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
+                  disabled={refreshingId === source.id}
+                  onClick={() => void refreshSource(source.id)}
+                  type="button"
+                >
+                  {refreshingId === source.id ? "..." : "Refresh"}
+                </button>
+              ) : null}
+              <a
+                className="break-all text-[var(--primary)] md:col-span-4"
+                href={source.sourceRef}
+                rel="noreferrer"
+                target="_blank"
+              >
+                {source.sourceRef}
+              </a>
+            </div>
+          ))
+        ) : (
+          <p className="px-4 py-6 text-sm text-[var(--muted-foreground)]">
+            No sources for {district}.
+          </p>
+        )}
+      </div>
+      {canEdit ? (
+        <div className="space-y-4 border-t border-[var(--border)] p-4">
+        <form action={uploadSource} className="grid gap-3 md:grid-cols-2">
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
+            defaultValue="WTTV"
+            name="scopeCode"
+            placeholder="Scope"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
+            defaultValue="GROUP_ASSIGNMENT"
+            name="sourceType"
+            placeholder="Type"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
+            name="displayName"
+            placeholder="Name"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 py-2 text-sm md:col-span-2"
+            name="file"
+            type="file"
+          />
+          <button
+            className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
+            type="submit"
+          >
+            Upload
+          </button>
+        </form>
+        <form action={submitLink} className="grid gap-3 md:grid-cols-2">
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
+            defaultValue="WTTV"
+            name="scopeCode"
+            placeholder="Scope"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
+            defaultValue="GROUP_ASSIGNMENT"
+            name="sourceType"
+            placeholder="Type"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
+            name="displayName"
+            placeholder="Name"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
+            name="sourceRef"
+            placeholder="URL or document id"
+          />
+          <input
+            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
+            name="contentHash"
+            placeholder="Content hash"
+          />
+          <textarea
+            className="min-h-24 rounded-md border border-[var(--border)] bg-transparent p-3 text-sm md:col-span-2"
+            name="parsedJson"
+            placeholder="Parsed JSON"
+          />
+          <div className="flex items-center gap-3 md:col-span-2">
+            <button
+              className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
+              type="submit"
+            >
+              Save
+            </button>
+            {message ? (
+              <span className="text-sm text-[var(--muted-foreground)]">
+                {message}
+              </span>
+            ) : null}
+          </div>
+        </form>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/webapp/src/lib/raster/access.ts
+++ b/webapp/src/lib/raster/access.ts
@@ -33,8 +33,20 @@ export async function canAccessRasterDistrict(
 
   const scope = await prisma.scope.findFirst({
     where: {
-      OR: [{ code: district }, { name: district }],
-      userAssignments: { some: { userId: user.id } },
+      AND: [
+        { OR: [{ code: district }, { name: district }] },
+        {
+          OR: [
+            { userAssignments: { some: { userId: user.id } } },
+            { parent: { userAssignments: { some: { userId: user.id } } } },
+            {
+              parent: {
+                parent: { userAssignments: { some: { userId: user.id } } },
+              },
+            },
+          ],
+        },
+      ],
     },
     select: { id: true },
   });

--- a/webapp/src/lib/raster/pipeline.ts
+++ b/webapp/src/lib/raster/pipeline.ts
@@ -1,7 +1,15 @@
-import type { WishParseResult } from "../../../../src/raster/ingest/index.js";
+import type {
+  TeamRasterAssignmentRow,
+  WishParseResult,
+} from "../../../../src/raster/ingest/index.js";
 
 type WishesPdfModule = {
   parseWishesPdf(filePath: string): Promise<WishParseResult>;
+  readAssignmentTable(filePath: string): Promise<TeamRasterAssignmentRow[]>;
+};
+
+type ClickTtScrapeModule = {
+  scrapeCurrentTeamRasterAssignments(): Promise<TeamRasterAssignmentRow[]>;
 };
 
 function parseCsvLine(line: string): string[] {
@@ -27,14 +35,43 @@ function parseCsvLine(line: string): string[] {
 }
 
 async function parseWishesPdf(filePath: string): Promise<WishParseResult> {
-  const modulePath = "../../../../src/raster/ingest/wishes-pdf.js";
+  const modulePath = new URL(
+    "../../../../src/raster/ingest/wishes-pdf.ts",
+    import.meta.url,
+  ).href;
   const wishesPdf = (await import(
     /* webpackIgnore: true */ modulePath
   )) as WishesPdfModule;
   return wishesPdf.parseWishesPdf(filePath);
 }
 
+async function readAssignmentTable(
+  filePath: string,
+): Promise<TeamRasterAssignmentRow[]> {
+  const modulePath = new URL(
+    "../../../../src/raster/ingest/index.ts",
+    import.meta.url,
+  ).href;
+  const ingest = (await import(
+    /* webpackIgnore: true */ modulePath
+  )) as WishesPdfModule;
+  return ingest.readAssignmentTable(filePath);
+}
+
+async function scrapeClickTtAssignments(): Promise<TeamRasterAssignmentRow[]> {
+  const modulePath = new URL(
+    "../../../../src/raster/ingest/scrape.ts",
+    import.meta.url,
+  ).href;
+  const scrape = (await import(
+    /* webpackIgnore: true */ modulePath
+  )) as ClickTtScrapeModule;
+  return scrape.scrapeCurrentTeamRasterAssignments();
+}
+
 export const rasterIngest = {
   parseCsvLine,
   parseWishesPdf,
+  readAssignmentTable,
+  scrapeClickTtAssignments,
 };

--- a/webapp/src/lib/raster/run-outcome.ts
+++ b/webapp/src/lib/raster/run-outcome.ts
@@ -1,16 +1,16 @@
 import {
   derbySpieltag,
   rasterSizeForGroupSize,
-} from "../../../../src/raster/rulebook/index.js";
+} from "../../../../src/raster/rulebook/rulebook.ts";
 import {
   evaluate,
   overUsageFairnessCost,
-} from "../../../../src/raster/score/index.js";
+} from "../../../../src/raster/score/index.ts";
 import {
   defaultWeights,
   type Assignment,
   type SeasonModel,
-} from "../../../../src/raster/types.js";
+} from "../../../../src/raster/types.ts";
 import {
   OptimizationRunOutcome,
   SnapshotOptimality,

--- a/webapp/src/services/raster/index.ts
+++ b/webapp/src/services/raster/index.ts
@@ -3,4 +3,5 @@ export * from "./fixedRasterzahlen";
 export * from "./inputSets";
 export * from "./runs";
 export * from "./snapshots";
+export * from "./sources";
 export * from "./wishes";

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/db";
 import { rasterDistrictWhere } from "@/lib/raster/access";
 import { seasonModelSchema, type SeasonModelInput } from "@/lib/raster/schemas";
 import { InputSetStatus } from "../../../generated/prisma/enums";
+import { listRasterSourcesForDistrict } from "./sources";
 
 type SeasonGroup = Record<string, unknown> & {
   id?: string;
@@ -44,6 +45,7 @@ export async function getInputSet(id: string) {
 }
 
 export async function validateInputSet(id: string) {
+  await syncInputSetSourceCaches(id);
   const inputSet = await getInputSet(id);
   if (!inputSet) return null;
 
@@ -85,6 +87,47 @@ export async function validateInputSet(id: string) {
   return { inputSet: { ...inputSet, status }, errors };
 }
 
+export async function syncInputSetSourceCaches(inputSetId: string) {
+  const inputSet = await prisma.rasterInputSet.findUnique({
+    where: { id: inputSetId },
+    select: { id: true, district: true },
+  });
+  if (!inputSet) return null;
+
+  const sources = await listRasterSourcesForDistrict(inputSet.district);
+  const groupSource = sources.find(
+    (source) =>
+      source.sourceType.toUpperCase() === "GROUP_ASSIGNMENT" &&
+      source.parsedJson,
+  );
+  const wishSources = sources.filter(
+    (source) =>
+      source.sourceType.toUpperCase() === "WISHES_PDF" && source.parsedJson,
+  );
+  const data: {
+    groupAssignmentJson?: string;
+    wishesJson?: string;
+  } = {};
+  if (groupSource?.parsedJson) {
+    data.groupAssignmentJson = groupSource.parsedJson;
+  }
+  if (wishSources.length) {
+    data.wishesJson = JSON.stringify({
+      sources: wishSources.map((source) => ({
+        sourceId: source.id,
+        sourceRef: source.sourceRef,
+        parsed: JSON.parse(source.parsedJson ?? "{}"),
+      })),
+    });
+  }
+  if (!data.groupAssignmentJson && !data.wishesJson) return inputSet;
+
+  return prisma.rasterInputSet.update({
+    where: { id: inputSet.id },
+    data,
+  });
+}
+
 export async function updateSeasonModel(
   inputSetId: string,
   model: SeasonModelInput,
@@ -94,6 +137,7 @@ export async function updateSeasonModel(
     where: { id: inputSetId },
     data: {
       seasonModelJson: JSON.stringify(parsed),
+      groupAssignmentJson: JSON.stringify(parsed.groups),
       status: InputSetStatus.DRAFT,
     },
   });

--- a/webapp/src/services/raster/snapshots.ts
+++ b/webapp/src/services/raster/snapshots.ts
@@ -4,7 +4,7 @@ import type { Prisma } from "../../../generated/prisma/client";
 import {
   derbySpieltag,
   rasterSizeForGroupSize,
-} from "../../../../src/raster/rulebook/index.js";
+} from "../../../../src/raster/rulebook/rulebook.ts";
 import {
   SnapshotOptimality,
   SnapshotOrigin,

--- a/webapp/src/services/raster/sources.ts
+++ b/webapp/src/services/raster/sources.ts
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { prisma } from "@/lib/db";
+import { getFilePath } from "@/lib/file-storage";
+import { rasterIngest } from "@/lib/raster/pipeline";
+
+export async function listRasterSourcesForDistrict(
+  district: string,
+  sourceType?: string,
+) {
+  const scope = await prisma.scope.findFirst({
+    where: { OR: [{ code: district }, { name: district }] },
+    select: {
+      id: true,
+      parent: {
+        select: {
+          id: true,
+          parent: { select: { id: true } },
+        },
+      },
+    },
+  });
+  if (!scope) return [];
+
+  const scopeIds = [
+    scope.id,
+    scope.parent?.id,
+    scope.parent?.parent?.id,
+  ].filter((id): id is string => Boolean(id));
+
+  return prisma.rasterSource.findMany({
+    where: {
+      scopeId: { in: scopeIds },
+      ...(sourceType ? { sourceType } : {}),
+    },
+    orderBy: [{ updatedAt: "desc" }, { displayName: "asc" }],
+  });
+}
+
+export async function upsertRasterSource(params: {
+  scopeId: string;
+  sourceType: string;
+  sourceRef: string;
+  displayName: string;
+  contentHash?: string;
+  parsedJson?: string;
+}) {
+  return prisma.rasterSource.upsert({
+    where: {
+      scopeId_sourceType_sourceRef: {
+        scopeId: params.scopeId,
+        sourceType: params.sourceType,
+        sourceRef: params.sourceRef,
+      },
+    },
+    update: {
+      displayName: params.displayName,
+      contentHash: params.contentHash,
+      parsedJson: params.parsedJson,
+    },
+    create: params,
+  });
+}
+
+export async function refreshRasterSource(id: string) {
+  const source = await prisma.rasterSource.findUnique({
+    where: { id },
+    include: { scope: true },
+  });
+  if (!source) return null;
+
+  const parsed = await parseSource(source.sourceType, source.sourceRef);
+  return prisma.rasterSource.update({
+    where: { id },
+    data: {
+      contentHash: parsed.contentHash,
+      parsedJson: JSON.stringify(parsed.value),
+    },
+    include: { scope: true },
+  });
+}
+
+async function parseSource(sourceType: string, sourceRef: string) {
+  const normalizedType = sourceType.trim().toUpperCase();
+  if (
+    normalizedType === "GROUP_ASSIGNMENT" &&
+    /^clicktt:\/\//i.test(sourceRef)
+  ) {
+    const assignments = await rasterIngest.scrapeClickTtAssignments();
+    const payload = { assignments };
+    return {
+      contentHash: hash(Buffer.from(JSON.stringify(payload))),
+      value: payload,
+    };
+  }
+
+  const file = await readSourceFile(sourceRef);
+  try {
+    if (normalizedType === "WISHES_PDF") {
+      return {
+        contentHash: file.contentHash,
+        value: await rasterIngest.parseWishesPdf(file.path),
+      };
+    }
+    if (normalizedType === "GROUP_ASSIGNMENT") {
+      return {
+        contentHash: file.contentHash,
+        value: {
+          assignments: await rasterIngest.readAssignmentTable(file.path),
+        },
+      };
+    }
+    throw new Error(`Unsupported raster source type: ${sourceType}`);
+  } finally {
+    if (file.cleanup) await file.cleanup();
+  }
+}
+
+async function readSourceFile(sourceRef: string) {
+  if (/^https?:\/\//i.test(sourceRef)) {
+    const response = await fetch(sourceRef);
+    if (!response.ok) {
+      throw new Error(`Source download failed: ${response.status}`);
+    }
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const dir = await mkdtemp(path.join(tmpdir(), "raster-source-"));
+    const extension = path.extname(new URL(sourceRef).pathname) || ".bin";
+    const filePath = path.join(dir, `source${extension}`);
+    await writeFile(filePath, buffer);
+    return {
+      path: filePath,
+      contentHash: hash(buffer),
+      cleanup: () => rm(dir, { recursive: true, force: true }),
+    };
+  }
+
+  const filePath = getFilePath(sourceRef);
+  const buffer = await readFile(filePath);
+  return {
+    path: filePath,
+    contentHash: hash(buffer),
+  };
+}
+
+function hash(buffer: Buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}

--- a/webapp/src/services/raster/wishes.ts
+++ b/webapp/src/services/raster/wishes.ts
@@ -23,29 +23,37 @@ export async function replaceParsedWishes(
   parsed: WishParseResult,
 ) {
   const clubsById = new Map(parsed.clubs.map((club) => [club.id, club]));
-  await prisma.rasterWish.deleteMany({ where: { inputSetId } });
-  if (!parsed.teams.length) return { count: 0 };
-
-  return prisma.rasterWish.createMany({
-    data: parsed.teams.map((team) => ({
-      inputSetId,
-      clubId: team.clubId,
-      clubName: clubsById.get(team.clubId)?.name ?? team.clubId,
-      teamLabel: team.label,
-      homeWeekday: weekdayMap[team.homeWeekday],
-      hall: team.hall,
-      startTime: team.startTime,
-      spielwochePref: team.spielwochePref,
-      requestedRasterzahl: team.requestedRasterzahl
-        ? JSON.stringify(team.requestedRasterzahl)
-        : undefined,
-      source: RasterWishSource.PDF_PARSED,
-      confidence:
-        team.confidence === "ok"
-          ? RasterConfidence.OK
-          : RasterConfidence.REVIEW,
-    })),
+  await prisma.$transaction(async (tx) => {
+    await tx.rasterInputSet.update({
+      where: { id: inputSetId },
+      data: { wishesJson: JSON.stringify(parsed) },
+    });
+    await tx.rasterWish.deleteMany({ where: { inputSetId } });
+    if (parsed.teams.length) {
+      await tx.rasterWish.createMany({
+        data: parsed.teams.map((team) => ({
+          inputSetId,
+          clubId: team.clubId,
+          clubName: clubsById.get(team.clubId)?.name ?? team.clubId,
+          teamLabel: team.label,
+          homeWeekday: weekdayMap[team.homeWeekday],
+          hall: team.hall,
+          startTime: team.startTime,
+          spielwochePref: team.spielwochePref,
+          requestedRasterzahl: team.requestedRasterzahl
+            ? JSON.stringify(team.requestedRasterzahl)
+            : undefined,
+          source: RasterWishSource.PDF_PARSED,
+          confidence:
+            team.confidence === "ok"
+              ? RasterConfidence.OK
+              : RasterConfidence.REVIEW,
+        })),
+      });
+    }
   });
+
+  return { count: parsed.teams.length };
 }
 
 export async function replaceJsonWishes(
@@ -53,28 +61,36 @@ export async function replaceJsonWishes(
   wishes: WishJsonInput[],
   source: RasterWishSource = RasterWishSource.LLM_PASTED,
 ) {
-  await prisma.rasterWish.deleteMany({ where: { inputSetId } });
-  if (!wishes.length) return { count: 0 };
-
-  return prisma.rasterWish.createMany({
-    data: wishes.map((wish) => ({
-      inputSetId,
-      clubId: wish.clubId,
-      clubName: wish.clubName,
-      teamLabel: wish.teamLabel,
-      homeWeekday: wish.homeWeekday,
-      hall: wish.hall,
-      startTime: wish.startTime,
-      spielwochePref: wish.spielwochePref,
-      requestedRasterzahl:
-        wish.requestedRasterzahl === undefined
-          ? undefined
-          : JSON.stringify(wish.requestedRasterzahl),
-      notes: wish.notes,
-      source,
-      confidence: RasterConfidence.REVIEW,
-    })),
+  await prisma.$transaction(async (tx) => {
+    await tx.rasterInputSet.update({
+      where: { id: inputSetId },
+      data: { wishesJson: JSON.stringify({ wishes }) },
+    });
+    await tx.rasterWish.deleteMany({ where: { inputSetId } });
+    if (wishes.length) {
+      await tx.rasterWish.createMany({
+        data: wishes.map((wish) => ({
+          inputSetId,
+          clubId: wish.clubId,
+          clubName: wish.clubName,
+          teamLabel: wish.teamLabel,
+          homeWeekday: wish.homeWeekday,
+          hall: wish.hall,
+          startTime: wish.startTime,
+          spielwochePref: wish.spielwochePref,
+          requestedRasterzahl:
+            wish.requestedRasterzahl === undefined
+              ? undefined
+              : JSON.stringify(wish.requestedRasterzahl),
+          notes: wish.notes,
+          source,
+          confidence: RasterConfidence.REVIEW,
+        })),
+      });
+    }
   });
+
+  return { count: wishes.length };
 }
 
 export async function updateWish(wishId: string, wish: WishJsonInput) {

--- a/webapp/tests/e2e/helpers/db-worker.ts
+++ b/webapp/tests/e2e/helpers/db-worker.ts
@@ -17,6 +17,8 @@ type Operation =
   | "findUserByEmail"
   | "updateUserStatus"
   | "assignUserToScope"
+  | "seedRasterScopeHierarchy"
+  | "seedRasterSource"
   | "addAuditEntryFixture"
   | "seedBackgroundJob"
   | "seedNotificationTypeConfiguration"
@@ -36,6 +38,7 @@ async function readJson<T>() {
   return (input ? JSON.parse(input) : {}) as T;
 }
 
+// eslint-disable-next-line complexity, sonarjs/cognitive-complexity
 async function main() {
   const operation = process.argv[2] as Operation | undefined;
   if (!operation) {
@@ -222,6 +225,90 @@ async function main() {
       });
 
       process.stdout.write(JSON.stringify(scopeRecord.id));
+      break;
+    }
+
+    case "seedRasterScopeHierarchy": {
+      const de = await prisma.scope.upsert({
+        where: { code: "DE" },
+        update: { name: "Germany", parentId: null },
+        create: { code: "DE", name: "Germany" },
+        select: { id: true },
+      });
+      const wttv = await prisma.scope.upsert({
+        where: { code: "WTTV" },
+        update: { name: "WTTV", parentId: de.id },
+        create: { code: "WTTV", name: "WTTV", parentId: de.id },
+        select: { id: true },
+      });
+      const owl = await prisma.scope.upsert({
+        where: { code: "OWL" },
+        update: { name: "Ostwestfalen-Lippe", parentId: wttv.id },
+        create: {
+          code: "OWL",
+          name: "Ostwestfalen-Lippe",
+          parentId: wttv.id,
+        },
+        select: { id: true },
+      });
+
+      process.stdout.write(
+        JSON.stringify({ de: de.id, wttv: wttv.id, owl: owl.id }),
+      );
+      break;
+    }
+
+    case "seedRasterSource": {
+      const input = await readJson<{
+        scopeCode: string;
+        sourceType: string;
+        sourceRef: string;
+        displayName: string;
+        contentHash?: string | null;
+        parsedJson?: unknown;
+      }>();
+      const scope = await prisma.scope.findUnique({
+        where: { code: input.scopeCode },
+        select: { id: true },
+      });
+
+      if (!scope) {
+        throw new Error(
+          `Scope not found for raster source: ${input.scopeCode}`,
+        );
+      }
+
+      const source = await prisma.rasterSource.upsert({
+        where: {
+          scopeId_sourceType_sourceRef: {
+            scopeId: scope.id,
+            sourceType: input.sourceType,
+            sourceRef: input.sourceRef,
+          },
+        },
+        update: {
+          displayName: input.displayName,
+          contentHash: input.contentHash ?? null,
+          parsedJson:
+            input.parsedJson === undefined
+              ? null
+              : JSON.stringify(input.parsedJson),
+        },
+        create: {
+          scopeId: scope.id,
+          sourceType: input.sourceType,
+          sourceRef: input.sourceRef,
+          displayName: input.displayName,
+          contentHash: input.contentHash ?? null,
+          parsedJson:
+            input.parsedJson === undefined
+              ? null
+              : JSON.stringify(input.parsedJson),
+        },
+        select: { id: true },
+      });
+
+      process.stdout.write(JSON.stringify(source.id));
       break;
     }
 

--- a/webapp/tests/e2e/helpers/db.ts
+++ b/webapp/tests/e2e/helpers/db.ts
@@ -135,6 +135,24 @@ export function assignUserToScope(
   });
 }
 
+export function seedRasterScopeHierarchy() {
+  return runDbWorker<
+    Record<string, never>,
+    { de: string; wttv: string; owl: string }
+  >("seedRasterScopeHierarchy", {});
+}
+
+export function seedRasterSource(input: {
+  scopeCode: string;
+  sourceType: string;
+  sourceRef: string;
+  displayName: string;
+  contentHash?: string | null;
+  parsedJson?: unknown;
+}) {
+  return runDbWorker<typeof input, string>("seedRasterSource", input);
+}
+
 export function addAuditEntryFixture(input: {
   actorEmail: string;
   action: AuditAction;

--- a/webapp/tests/e2e/raster-generate.spec.ts
+++ b/webapp/tests/e2e/raster-generate.spec.ts
@@ -7,10 +7,61 @@ import {
   expectOnDashboard,
   loginWithPassword,
 } from "./helpers/auth";
-import { assignUserToScope, seedLocalUser } from "./helpers/db";
+import {
+  assignUserToScope,
+  seedLocalUser,
+  seedRasterScopeHierarchy,
+  seedRasterSource,
+} from "./helpers/db";
 
 const district = "OWL";
 const scope = { code: district, name: "Ostwestfalen-Lippe" };
+
+test("OWL raster page shows inherited WTTV sources without refreshing them on reload", async ({
+  page,
+}) => {
+  const suffix = Date.now();
+  const email = `e2e-raster-source-${suffix}@example.com`;
+  const password = "RasterSource123";
+  const sourceName = `E2E WTTV assignment ${suffix}`;
+
+  await seedRasterScopeHierarchy();
+  await seedLocalUser({
+    email,
+    name: "E2E Raster Source Viewer",
+    role: Role.SCOPE_USER,
+    password,
+    mustChangePassword: false,
+  });
+  await assignUserToScope(email, scope);
+  await seedRasterSource({
+    scopeCode: "WTTV",
+    sourceType: "GROUP_ASSIGNMENT",
+    sourceRef: `e2e://wttv-assignment-${suffix}`,
+    displayName: sourceName,
+    contentHash: `hash-${suffix}`,
+    parsedJson: { groups: [] },
+  });
+
+  const refreshRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (url.includes("/api/raster/sources/") && url.endsWith("/refresh")) {
+      refreshRequests.push(url);
+    }
+  });
+
+  await loginWithPassword(page, email, password);
+  await expectOnDashboard(page);
+
+  await page.goto(`${appBasePath}/raster?district=${district}`);
+  await expect(page.getByText(sourceName)).toBeVisible();
+  expect(refreshRequests).toEqual([]);
+
+  await page.reload();
+  await expect(page.getByText(sourceName)).toBeVisible();
+  expect(refreshRequests).toEqual([]);
+});
 
 test("admin can generate and review a raster snapshot", async ({ page }) => {
   const suffix = Date.now();

--- a/webapp/tests/unit/raster-access.test.ts
+++ b/webapp/tests/unit/raster-access.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { canAccessRasterDistrict } from "@/lib/raster/access";
+import { Role } from "../../generated/prisma/enums";
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+describe("raster access", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows scoped users through assigned parent scopes", async () => {
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "owl" } as never);
+
+    await expect(
+      canAccessRasterDistrict(
+        { id: "user-1", role: Role.SCOPE_USER },
+        "OWL",
+      ),
+    ).resolves.toBe(true);
+
+    expect(prismaMock.scope.findFirst).toHaveBeenCalledWith({
+      where: {
+        AND: [
+          { OR: [{ code: "OWL" }, { name: "OWL" }] },
+          {
+            OR: [
+              { userAssignments: { some: { userId: "user-1" } } },
+              {
+                parent: { userAssignments: { some: { userId: "user-1" } } },
+              },
+              {
+                parent: {
+                  parent: {
+                    userAssignments: { some: { userId: "user-1" } },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      select: { id: true },
+    });
+  });
+});

--- a/webapp/tests/unit/raster-input-sets-service.test.ts
+++ b/webapp/tests/unit/raster-input-sets-service.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { prismaMock } from "@/lib/__mocks__/db";
-import { validateInputSet, updateGroupRasterMode } from "@/services/raster";
+import {
+  syncInputSetSourceCaches,
+  updateGroupRasterMode,
+  validateInputSet,
+} from "@/services/raster";
 import { InputSetStatus } from "../../generated/prisma/enums";
 
 vi.mock("@/lib/db", () => ({
@@ -28,7 +32,12 @@ describe("raster input set service", () => {
   });
 
   it("blocks unconfirmed six-team groups", async () => {
-    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+    prismaMock.rasterInputSet.findUnique.mockResolvedValueOnce({
+      id: "input-1",
+      district: "OWL",
+    } as never);
+    prismaMock.scope.findFirst.mockResolvedValue(null);
+    prismaMock.rasterInputSet.findUnique.mockResolvedValueOnce({
       id: "input-1",
       status: InputSetStatus.DRAFT,
       seasonModelJson: JSON.stringify(model),
@@ -42,6 +51,11 @@ describe("raster input set service", () => {
 
   it("accepts reviewed six-team group modes", async () => {
     for (const rasterMode of ["single", "double"] as const) {
+      prismaMock.rasterInputSet.findUnique.mockResolvedValueOnce({
+        id: `input-${rasterMode}`,
+        district: "OWL",
+      } as never);
+      prismaMock.scope.findFirst.mockResolvedValueOnce(null);
       prismaMock.rasterInputSet.findUnique.mockResolvedValueOnce({
         id: `input-${rasterMode}`,
         status: InputSetStatus.DRAFT,
@@ -78,8 +92,45 @@ describe("raster input set service", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           seasonModelJson: expect.stringContaining('"rasterMode":"double"'),
+          groupAssignmentJson: expect.stringContaining('"rasterMode":"double"'),
         }),
       }),
     );
+  });
+
+  it("syncs inherited source caches into input sets", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      id: "input-1",
+      district: "OWL",
+    } as never);
+    prismaMock.scope.findFirst.mockResolvedValue({
+      id: "owl",
+      parent: { id: "wttv", parent: { id: "de" } },
+    } as never);
+    prismaMock.rasterSource.findMany.mockResolvedValue([
+      {
+        id: "group-source",
+        sourceType: "GROUP_ASSIGNMENT",
+        sourceRef: "uploads/group.csv",
+        parsedJson: '{"assignments":[]}',
+      },
+      {
+        id: "wish-source",
+        sourceType: "WISHES_PDF",
+        sourceRef: "uploads/wishes.pdf",
+        parsedJson: '{"teams":[]}',
+      },
+    ] as never);
+    prismaMock.rasterInputSet.update.mockResolvedValue({} as never);
+
+    await syncInputSetSourceCaches("input-1");
+
+    expect(prismaMock.rasterInputSet.update).toHaveBeenCalledWith({
+      where: { id: "input-1" },
+      data: {
+        groupAssignmentJson: '{"assignments":[]}',
+        wishesJson: expect.stringContaining("wish-source"),
+      },
+    });
   });
 });

--- a/webapp/tests/unit/raster-sources-refresh-route.test.ts
+++ b/webapp/tests/unit/raster-sources-refresh-route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const { refreshRasterSource, requireApiUser } = vi.hoisted(() => ({
+  refreshRasterSource: vi.fn(),
+  requireApiUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/route-auth", () => ({
+  requireApiUser,
+}));
+
+vi.mock("@/services/raster", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/raster")>()),
+  refreshRasterSource,
+}));
+
+import { POST } from "@/app/api/raster/sources/[id]/refresh/route";
+
+describe("raster source refresh route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes an existing source for platform admins", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.rasterSource.findUnique.mockResolvedValue({
+      id: "source-1",
+      scope: { code: "WTTV" },
+    } as never);
+    refreshRasterSource.mockResolvedValue({ id: "source-1" });
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/sources/source-1/refresh", {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ id: "source-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(refreshRasterSource).toHaveBeenCalledWith("source-1");
+  });
+
+  it("returns 404 for missing sources", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.rasterSource.findUnique.mockResolvedValue(null);
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/sources/missing/refresh", {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(refreshRasterSource).not.toHaveBeenCalled();
+  });
+});

--- a/webapp/tests/unit/raster-sources-route.test.ts
+++ b/webapp/tests/unit/raster-sources-route.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const { requireApiUser } = vi.hoisted(() => ({
+  requireApiUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/route-auth", () => ({
+  requireApiUser,
+}));
+
+import { GET, POST } from "@/app/api/raster/sources/route";
+
+describe("raster sources route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists sources visible to a district viewer", async () => {
+    requireApiUser.mockResolvedValue({
+      user: { id: "user-1", role: Role.SCOPE_USER, status: UserStatus.ACTIVE },
+    });
+    prismaMock.scope.findFirst
+      .mockResolvedValueOnce({ id: "owl" } as never)
+      .mockResolvedValueOnce({
+        id: "owl",
+        parent: { id: "wttv", parent: { id: "de" } },
+      } as never);
+    prismaMock.rasterSource.findMany.mockResolvedValue([] as never);
+
+    const response = await GET(
+      new Request("http://localhost/api/raster/sources?district=OWL"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.rasterSource.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { scopeId: { in: ["owl", "wttv", "de"] } },
+      }),
+    );
+  });
+
+  it("upserts sources for raster admins", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "wttv" } as never);
+    prismaMock.rasterSource.upsert.mockResolvedValue({ id: "source-1" } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/sources", {
+        method: "POST",
+        body: JSON.stringify({
+          scopeCode: "WTTV",
+          sourceType: "GROUP_ASSIGNMENT",
+          sourceRef: "https://example.test/groups.pdf",
+          displayName: "WTTV groups",
+          parsedJson: "{}",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.rasterSource.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          scopeId: "wttv",
+          sourceType: "GROUP_ASSIGNMENT",
+        }),
+      }),
+    );
+  });
+});

--- a/webapp/tests/unit/raster-sources-service.test.ts
+++ b/webapp/tests/unit/raster-sources-service.test.ts
@@ -1,0 +1,120 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import {
+  listRasterSourcesForDistrict,
+  refreshRasterSource,
+} from "@/services/raster";
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/raster/pipeline", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/raster/pipeline")>();
+  return {
+    ...actual,
+    rasterIngest: {
+      ...actual.rasterIngest,
+      scrapeClickTtAssignments: vi.fn(),
+    },
+  };
+});
+
+describe("raster sources service", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists district and ancestor scope sources", async () => {
+    prismaMock.scope.findFirst.mockResolvedValue({
+      id: "owl",
+      parent: { id: "wttv", parent: { id: "de" } },
+    } as never);
+    prismaMock.rasterSource.findMany.mockResolvedValue([] as never);
+
+    await listRasterSourcesForDistrict("OWL", "GROUP_ASSIGNMENT");
+
+    expect(prismaMock.rasterSource.findMany).toHaveBeenCalledWith({
+      where: {
+        scopeId: { in: ["owl", "wttv", "de"] },
+        sourceType: "GROUP_ASSIGNMENT",
+      },
+      orderBy: [{ updatedAt: "desc" }, { displayName: "asc" }],
+    });
+  });
+
+  it("refreshes group assignment sources into parsed JSON", async () => {
+    const uploadDir = path.join(process.cwd(), "uploads", "test");
+    const sourceRef = "uploads/test/group-assignment.csv";
+    await mkdir(uploadDir, { recursive: true });
+    await writeFile(
+      path.join(process.cwd(), sourceRef),
+      [
+        "league,group,division,rasterzahl,team,sourceUrl,wishUrl",
+        '"Liga","Gruppe 1","Erwachsene","1","Club A","https://example.test/group",""',
+      ].join("\n"),
+      "utf8",
+    );
+    try {
+      prismaMock.rasterSource.findUnique.mockResolvedValue({
+        id: "source-1",
+        sourceType: "GROUP_ASSIGNMENT",
+        sourceRef,
+        scope: { id: "wttv", code: "WTTV" },
+      } as never);
+      prismaMock.rasterSource.update.mockResolvedValue({
+        id: "source-1",
+      } as never);
+
+      await refreshRasterSource("source-1");
+
+      expect(prismaMock.rasterSource.update).toHaveBeenCalledWith({
+        where: { id: "source-1" },
+        data: {
+          contentHash: expect.any(String),
+          parsedJson: expect.stringContaining('"assignments"'),
+        },
+        include: { scope: true },
+      });
+    } finally {
+      await rm(uploadDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes click-TT group assignment sources on request", async () => {
+    const { rasterIngest } = await import("@/lib/raster/pipeline");
+    vi.mocked(rasterIngest.scrapeClickTtAssignments).mockResolvedValue([
+      {
+        league: "Liga",
+        group: "Gruppe 1",
+        division: "Erwachsene",
+        rasterzahl: 1,
+        team: "Club A",
+        sourceUrl: "https://example.test/group",
+      },
+    ]);
+    prismaMock.rasterSource.findUnique.mockResolvedValue({
+      id: "source-clicktt",
+      sourceType: "GROUP_ASSIGNMENT",
+      sourceRef: "clicktt://group-assignment",
+      scope: { id: "wttv", code: "WTTV" },
+    } as never);
+    prismaMock.rasterSource.update.mockResolvedValue({
+      id: "source-clicktt",
+    } as never);
+
+    await refreshRasterSource("source-clicktt");
+
+    expect(rasterIngest.scrapeClickTtAssignments).toHaveBeenCalledWith();
+    expect(prismaMock.rasterSource.update).toHaveBeenCalledWith({
+      where: { id: "source-clicktt" },
+      data: {
+        contentHash: expect.any(String),
+        parsedJson: expect.stringContaining('"assignments"'),
+      },
+      include: { scope: true },
+    });
+  });
+});

--- a/webapp/tests/unit/raster-sources-upload-route.test.ts
+++ b/webapp/tests/unit/raster-sources-upload-route.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const { requireApiUser, saveFile, upsertRasterSource } = vi.hoisted(() => ({
+  requireApiUser: vi.fn(),
+  saveFile: vi.fn(),
+  upsertRasterSource: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/route-auth", () => ({
+  requireApiUser,
+}));
+
+vi.mock("@/lib/file-storage", () => ({
+  saveFile,
+}));
+
+vi.mock("@/services/raster", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/raster")>()),
+  upsertRasterSource,
+}));
+
+import { POST } from "@/app/api/raster/sources/upload/route";
+
+describe("raster source upload route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("saves uploaded files as scoped raster sources", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "wttv" } as never);
+    saveFile.mockResolvedValue("uploads/2026/07/source.pdf");
+    upsertRasterSource.mockResolvedValue({ id: "source-1" });
+
+    const formData = new FormData();
+    formData.set("scopeCode", "WTTV");
+    formData.set("sourceType", "WISHES_PDF");
+    formData.set("displayName", "WTTV wishes");
+    formData.set("file", new File(["pdf"], "wishes.pdf"));
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/sources/upload", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(saveFile).toHaveBeenCalledWith(expect.any(Buffer), "wishes.pdf");
+    expect(upsertRasterSource).toHaveBeenCalledWith({
+      scopeId: "wttv",
+      sourceType: "WISHES_PDF",
+      sourceRef: "uploads/2026/07/source.pdf",
+      displayName: "WTTV wishes",
+    });
+  });
+});

--- a/webapp/tests/unit/raster-wishes-service.test.ts
+++ b/webapp/tests/unit/raster-wishes-service.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { replaceJsonWishes } from "@/services/raster";
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+describe("raster wishes service", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("caches uploaded wishes before replacing normalized rows", async () => {
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(prismaMock),
+    );
+
+    await expect(
+      replaceJsonWishes("input-1", [
+        {
+          clubId: "club-a",
+          clubName: "Club A",
+          homeWeekday: "FRIDAY",
+        },
+      ]),
+    ).resolves.toEqual({ count: 1 });
+
+    expect(prismaMock.rasterInputSet.update).toHaveBeenCalledWith({
+      where: { id: "input-1" },
+      data: {
+        wishesJson: JSON.stringify({
+          wishes: [
+            {
+              clubId: "club-a",
+              clubName: "Club A",
+              homeWeekday: "FRIDAY",
+            },
+          ],
+        }),
+      },
+    });
+    expect(prismaMock.rasterWish.deleteMany).toHaveBeenCalledWith({
+      where: { inputSetId: "input-1" },
+    });
+    expect(prismaMock.rasterWish.createMany).toHaveBeenCalledOnce();
+  });
+});

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- add DE > WTTV > OWL scope hierarchy and scoped RasterSource cache storage
- add source upload/link/refresh APIs and Raster page source controls
- cache group assignments and wishes in the database, including inherited WTTV sources for OWL
- add clicktt:// group assignment refresh via the existing scraper

## Tests
- pnpm run typecheck
- pnpm run lint
- pnpm test -- tests/unit/raster-sources-service.test.ts tests/unit/raster-input-sets-service.test.ts tests/unit/raster-sources-route.test.ts tests/unit/raster-sources-refresh-route.test.ts tests/unit/raster-sources-upload-route.test.ts tests/unit/raster-wishes-service.test.ts tests/unit/raster-access.test.ts tests/unit/raster-penalties.test.ts tests/unit/run-outcome.test.ts tests/unit/fixed-constraint.test.ts
- pnpm exec playwright test tests/e2e/raster-generate.spec.ts