### PR TITLE
Raster webapp updates and 004 comparison spec

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-raster-review-webapp"
+  "feature_directory": "specs/004-compare-raster-runs"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
-﻿# click-tt-automation Development Guidelines
+# click-tt-automation Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-10
+Auto-generated from all feature plans. Last updated: 2026-07-12
 
 ## Active Technologies
+- TypeScript 5.9 strict for webapp/root raster code; Python 3.12 for the existing CP-SAT subprocess + Existing Next.js 16, React 19, Prisma 7, better-auth, next-intl, zod, Tailwind/shadcn; existing root `src/raster/*`; existing Python OR-Tools CP-SAT script (004-compare-raster-runs)
+- Existing Prisma SQLite dev / PostgreSQL prod schema, extended with scenario/manual-assignment fields as needed (004-compare-raster-runs)
 
 - TypeScript 5.x, Node.js LTS (22.x) + Playwright (browser automation), dotenv (credentials), minimist (CLI args) (main)
 
@@ -22,6 +24,7 @@ npm test; npm run lint
 TypeScript 5.x, Node.js LTS (22.x): Follow standard conventions
 
 ## Recent Changes
+- 004-compare-raster-runs: Added TypeScript 5.9 strict for webapp/root raster code; Python 3.12 for the existing CP-SAT subprocess + Existing Next.js 16, React 19, Prisma 7, better-auth, next-intl, zod, Tailwind/shadcn; existing root `src/raster/*`; existing Python OR-Tools CP-SAT script
 
 - main: Added TypeScript 5.x, Node.js LTS (22.x) + Playwright (browser automation), dotenv (credentials), minimist (CLI args)
 

--- a/scripts/solve-raster-cpsat.py
+++ b/scripts/solve-raster-cpsat.py
@@ -37,6 +37,8 @@ DEFAULT_WEIGHTS = {
 
 def raster_key_for_group(group: dict[str, Any]) -> str:
     size = int(group["size"])
+    if size == 5:
+        return "6"
     if size == 6 and group.get("rasterMode") == "double":
         return "6d"
     if size == 6:
@@ -49,7 +51,7 @@ def raster_key_for_group(group: dict[str, Any]) -> str:
         return "12"
     if size in (13, 14):
         return "14"
-    raise ValueError(f"Unsupported group size {size}; supported district sizes are 6..14.")
+    raise ValueError(f"Unsupported group size {size}; supported district sizes are 5..14.")
 
 
 def raster_size_for_group_size(size: int) -> int:
@@ -80,10 +82,15 @@ def circle_pairs(size: str) -> list[list[dict[str, int]]]:
     return rounds
 
 
-def home_weeks_for_group(group: dict[str, Any], rasterzahl: int) -> list[int]:
+def raster_values_for_group(group: dict[str, Any]) -> range:
+    return range(1, numeric_raster_size(raster_key_for_group(group)) + 1)
+
+
+def home_weeks_for_group(group: dict[str, Any], rasterzahl: int, bye: int | None = None) -> list[int]:
     size = raster_key_for_group(group)
     group_size = int(group["size"])
-    bye = int(size) if group_size % 2 == 1 else None
+    if bye is None and group_size % 2 == 1:
+        bye = numeric_raster_size(size)
     if rasterzahl == bye:
         return []
     weeks: list[int] = []
@@ -120,8 +127,8 @@ def home_weeks(group_size: int, rasterzahl: int) -> list[int]:
     return home_weeks_for_group({"size": group_size}, rasterzahl)
 
 
-def week_slot_for_group(group: dict[str, Any], rasterzahl: int) -> str:
-    weeks = home_weeks_for_group(group, rasterzahl)
+def week_slot_for_group(group: dict[str, Any], rasterzahl: int, bye: int | None = None) -> str:
+    weeks = home_weeks_for_group(group, rasterzahl, bye)
     odd = sum(1 for week in weeks if week % 2 == 1)
     return "A" if odd >= len(weeks) - odd else "B"
 
@@ -136,9 +143,25 @@ def derby_spieltag_for_group(group: dict[str, Any], a: int, b: int) -> int | Non
     return None
 
 
-def relation(group_a: dict[str, Any], rz_a: int, group_b: dict[str, Any], rz_b: int) -> str:
+def relation(
+    group_a: dict[str, Any],
+    rz_a: int,
+    group_b: dict[str, Any],
+    rz_b: int,
+    bye_a: int | None = None,
+    bye_b: int | None = None,
+) -> str:
     size_a = raster_key_for_group(group_a)
     size_b = raster_key_for_group(group_b)
+    if bye_a is not None or bye_b is not None:
+        weeks_a = set(home_weeks_for_group(group_a, rz_a, bye_a))
+        weeks_b = set(home_weeks_for_group(group_b, rz_b, bye_b))
+        overlap = len(weeks_a & weeks_b)
+        if overlap == 0:
+            return "wechsel"
+        if overlap == min(len(weeks_a), len(weeks_b)):
+            return "zeitgleich"
+        return "neither"
     if size_a == size_b:
         rows = HOME_ROWS[size_a]
         a_home = {index + 1 for index, homes in enumerate(rows) if rz_a in homes}
@@ -217,17 +240,24 @@ def main() -> None:
         for team_id in group["teamIds"]
     }
     rz: dict[str, cp_model.IntVar] = {}
+    bye: dict[str, cp_model.IntVar] = {}
     for group in season["groups"]:
         group_vars = []
         for team_id in group["teamIds"]:
             team = teams[team_id]
-            var = model.new_int_var(1, int(group["size"]), f"rz_{team_id}")
+            var = model.new_int_var(1, numeric_raster_size(raster_key_for_group(group)), f"rz_{team_id}")
             rz[team_id] = var
             group_vars.append(var)
             kind = team["rasterzahl"]["kind"]
             if kind in ("fixed", "pinned"):
                 model.add(var == int(team["rasterzahl"]["value"]))
-        model.add_all_different(group_vars)
+        if int(group["size"]) % 2 == 1:
+            group_key = str(group["ref"]["league"]) + "::" + str(group["ref"]["name"])
+            bye_var = model.new_int_var(1, numeric_raster_size(raster_key_for_group(group)), f"bye_{len(bye)}")
+            bye[group_key] = bye_var
+            model.add_all_different([*group_vars, bye_var])
+        else:
+            model.add_all_different(group_vars)
 
     objective_terms: list[cp_model.LinearExpr] = []
 
@@ -241,8 +271,8 @@ def main() -> None:
                     continue
                 allowed = []
                 is_st4 = model.new_bool_var(f"same_club_st4_{left_id}_{right_id}")
-                for a in range(1, int(group["size"]) + 1):
-                    for b in range(1, int(group["size"]) + 1):
+                for a in raster_values_for_group(group):
+                    for b in raster_values_for_group(group):
                         if a == b:
                             continue
                         day = derby_spieltag_for_group(group, a, b)
@@ -256,11 +286,27 @@ def main() -> None:
         group = team_group.get(team_id)
         if not group:
             continue
-        all_weeks = sorted({week for value in range(1, int(group["size"]) + 1) for week in home_weeks_for_group(group, value)})
+        group_key = str(group["ref"]["league"]) + "::" + str(group["ref"]["name"])
+        bye_var = bye.get(group_key)
+        all_weeks = sorted({
+            week
+            for value in raster_values_for_group(group)
+            for bye_value in (raster_values_for_group(group) if bye_var is not None else [None])
+            for week in home_weeks_for_group(group, value, bye_value)
+        })
         for week in all_weeks:
             var = model.new_bool_var(f"home_{team_id}_{week}")
-            table = [(value, int(week in home_weeks_for_group(group, value))) for value in range(1, int(group["size"]) + 1)]
-            model.add_allowed_assignments([rz[team_id], var], table)
+            if bye_var is not None:
+                table = [
+                    (value, bye_value, int(week in home_weeks_for_group(group, value, bye_value)))
+                    for value in raster_values_for_group(group)
+                    for bye_value in raster_values_for_group(group)
+                    if value != bye_value
+                ]
+                model.add_allowed_assignments([rz[team_id], bye_var, var], table)
+            else:
+                table = [(value, int(week in home_weeks_for_group(group, value))) for value in raster_values_for_group(group)]
+                model.add_allowed_assignments([rz[team_id], var], table)
             home_bool[(team_id, week)] = var
 
     excess_by_club: dict[str, list[cp_model.IntVar]] = {}
@@ -268,8 +314,16 @@ def main() -> None:
         {
             (team["clubId"], team["hall"], team["homeWeekday"], week)
             for team in season["teams"]
-            for week in sorted({week for value in range(1, int(team_group.get(team["id"], {"size": 0})["size"]) + 1) for week in home_weeks_for_group(team_group.get(team["id"], {"size": 0}), value)})
             if capacity_for(season, team) is not None and team["id"] in team_group
+            for group in [team_group[team["id"]]]
+            for week in sorted(
+                {
+                    week
+                    for value in raster_values_for_group(group)
+                    for bye_value in (raster_values_for_group(group) if int(group["size"]) % 2 == 1 else [None])
+                    for week in home_weeks_for_group(group, value, bye_value)
+                }
+            )
         }
     )
     for club_id, hall, weekday, week in slot_keys:
@@ -310,14 +364,37 @@ def main() -> None:
         if not team_a or not team_b or not group_a or not group_b:
             continue
         ok_pairs = []
-        for a in range(1, int(group_a["size"]) + 1):
-            for b in range(1, int(group_b["size"]) + 1):
-                if relation(group_a, a, group_b, b) == wish["relation"]:
-                    ok_pairs.append((a, b, 0))
-                else:
-                    ok_pairs.append((a, b, 1))
+        key_a = str(group_a["ref"]["league"]) + "::" + str(group_a["ref"]["name"])
+        key_b = str(group_b["ref"]["league"]) + "::" + str(group_b["ref"]["name"])
+        bye_a = bye.get(key_a)
+        bye_b = bye.get(key_b)
+        same_bye = bye_a is not None and bye_a is bye_b
+        for a in raster_values_for_group(group_a):
+            for b in raster_values_for_group(group_b):
+                for ba in (raster_values_for_group(group_a) if bye_a is not None else [None]):
+                    for bb in (raster_values_for_group(group_b) if bye_b is not None else [None]):
+                        if same_bye and ba != bb:
+                            continue
+                        if a == ba or b == bb:
+                            continue
+                        broken_value = int(relation(group_a, a, group_b, b, ba, bb) != wish["relation"])
+                        row = [a]
+                        if bye_a is not None:
+                            row.append(int(ba))
+                        row.append(b)
+                        if bye_b is not None and not same_bye:
+                            row.append(int(bb))
+                        row.append(broken_value)
+                        ok_pairs.append(tuple(row))
         broken = model.new_bool_var(f"wish_{wish['teamA']}_{wish['teamB']}")
-        model.add_allowed_assignments([rz[wish["teamA"]], rz[wish["teamB"]], broken], ok_pairs)
+        variables = [rz[wish["teamA"]]]
+        if bye_a is not None:
+            variables.append(bye_a)
+        variables.append(rz[wish["teamB"]])
+        if bye_b is not None and not same_bye:
+            variables.append(bye_b)
+        variables.append(broken)
+        model.add_allowed_assignments(variables, ok_pairs)
         objective_terms.append(broken * int(weights[wish["relation"]]))
 
     if int(weights["spielwoche"]):
@@ -327,8 +404,19 @@ def main() -> None:
             if not pref or not group:
                 continue
             miss = model.new_bool_var(f"spielwoche_{team_id}")
-            table = [(value, int(week_slot_for_group(group, value) != pref)) for value in range(1, int(group["size"]) + 1)]
-            model.add_allowed_assignments([rz[team_id], miss], table)
+            key = str(group["ref"]["league"]) + "::" + str(group["ref"]["name"])
+            bye_var = bye.get(key)
+            if bye_var is not None:
+                table = [
+                    (value, bye_value, int(week_slot_for_group(group, value, bye_value) != pref))
+                    for value in raster_values_for_group(group)
+                    for bye_value in raster_values_for_group(group)
+                    if value != bye_value
+                ]
+                model.add_allowed_assignments([rz[team_id], bye_var, miss], table)
+            else:
+                table = [(value, int(week_slot_for_group(group, value) != pref)) for value in raster_values_for_group(group)]
+                model.add_allowed_assignments([rz[team_id], miss], table)
             objective_terms.append(miss * int(weights["spielwoche"]))
 
     model.minimize(sum(objective_terms) if objective_terms else 0)

--- a/specs/003-raster-review-webapp/contracts/api.md
+++ b/specs/003-raster-review-webapp/contracts/api.md
@@ -6,8 +6,8 @@ Next.js App Router route handlers under `webapp/src/app/api/raster/`. All routes
 
 | Method | Path | Role | Purpose |
 |--------|------|------|---------|
-| POST | `/api/raster/input-sets` | admin | Create an InputSet (name, district) |
-| GET | `/api/raster/input-sets?district=` | any | List input sets |
+| POST | `/api/raster/input-sets` | admin | Create an InputSet (`name`, `district`, `season`) |
+| GET | `/api/raster/input-sets?district=&season=` | any | List input sets for a district/scope and season |
 | POST | `/api/raster/input-sets/{id}/wishes/pdf` | admin | Upload wishes PDF → deterministic parse (FR-002); returns parsed Wishes marked `confidence` |
 | GET | `/api/raster/input-sets/{id}/wishes/prompt` | admin | Get the ready-made LLM extraction prompt (embedded PDF text + JSON schema) — fallback (FR-002a) |
 | POST | `/api/raster/input-sets/{id}/wishes/json` | admin | Submit pasted/structured wishes JSON → schema-validated (FR-002a/003); 422 on schema error |
@@ -21,11 +21,18 @@ Next.js App Router route handlers under `webapp/src/app/api/raster/`. All routes
 | Method | Path | Role | Purpose |
 |--------|------|------|---------|
 | GET | `/api/raster/sources?district=&sourceType=` | any | List source documents/links/caches visible to a district, including ancestor scope sources (e.g. OWL + WTTV + DE) |
-| POST | `/api/raster/sources` | admin | Register or update a source for a scope (`scopeCode`, `sourceType`, `sourceRef`, `displayName`, optional `contentHash`, optional `parsedJson`) |
-| POST | `/api/raster/sources/upload` | admin | Upload a replacement source file for a scope and register it as a `RasterSource` |
+| POST | `/api/raster/sources` | admin | Register or update a source for a scope/season (`scopeCode`, `season`, `sourceType`, `sourceRef`, `displayName`, optional `contentHash`, optional `parsedJson`) |
+| POST | `/api/raster/sources/upload` | admin | Upload one or more source files for a scope/season and register each as a `RasterSource`; `*_PDF` uploads must be valid PDF files |
+| DELETE | `/api/raster/sources/{id}` | admin | Delete a source; also deletes the app-stored upload file when `sourceRef` points inside app-controlled upload storage |
 | POST | `/api/raster/sources/{id}/refresh` | admin | Explicitly parse/refresh a stored source cache for supported source types such as `GROUP_ASSIGNMENT` and `WISHES_PDF` |
 
-Source records belong to the hierarchy level where the source is valid. For example, a WTTV-wide group PDF is stored under WTTV and inherited by OWL flows. Registering a source does not reparse it; parse/cache refresh happens only when explicitly requested by a parser/upload flow.
+Source records belong to the hierarchy level where the source is valid and to one season. For example, a WTTV-wide click-TT group-assignment URL is stored under WTTV for `2026/27` and inherited by OWL flows for that season. Registering a source does not reparse it; parse/cache refresh happens only when explicitly requested by a parser/upload flow.
+
+Normal guided source flow:
+
+- group assignment: register a click-TT league page URL as `GROUP_ASSIGNMENT`
+- wish PDFs: upload one or more PDFs as `WISHES_PDF`
+- fixed schedule numbers: edit optional fixed rows on an InputSet, not as a normal source URL
 
 ## Hall capacity
 

--- a/specs/003-raster-review-webapp/data-model.md
+++ b/specs/003-raster-review-webapp/data-model.md
@@ -4,12 +4,12 @@ Prisma models added to `webapp/prisma/schema.prisma` (+ `schema.postgres.prisma`
 
 ## Scope
 
-Existing baseline scope, extended for raster hierarchy. Initial hierarchy: `DE` → `WTTV` → `OWL`.
+Existing baseline scope, extended for raster hierarchy. Initial hierarchy: `DE` → `WTTV` → configured WTTV districts, including OWL.
 
 | Field    | Type          | Notes                                                   |
 | -------- | ------------- | ------------------------------------------------------- |
 | id       | string (cuid) | PK                                                      |
-| code     | string        | Unique key, e.g. `DE`, `WTTV`, `OWL`                    |
+| code     | string        | Unique key, e.g. `DE`, `WTTV`, `OWL`, `AACHEN_EUREGIO`  |
 | name     | string        | Unique display name                                     |
 | parentId | string?       | FK → Scope; null for root                               |
 
@@ -25,6 +25,7 @@ A registered document/link/cache used to build input sets. It belongs to the sco
 | ----------- | ------------- | ----------------------------------------------------------------- |
 | id          | string (cuid) | PK                                                                |
 | scopeId     | string        | FK → Scope                                                        |
+| season      | string        | Season key, e.g. `2026/27`                                        |
 | sourceType  | string        | e.g. `GROUP_ASSIGNMENT`, `WISHES_PDF`, `FIXED_RASTERZAHL`         |
 | sourceRef   | string        | URL, file id, or stable source identifier                         |
 | displayName | string        | User-facing label                                                 |
@@ -33,7 +34,9 @@ A registered document/link/cache used to build input sets. It belongs to the sco
 | createdAt   | datetime      |                                                                   |
 | updatedAt   | datetime      |                                                                   |
 
-Uniqueness: (scopeId, sourceType, sourceRef). District flows list sources from the district scope and ancestors.
+Uniqueness: (scopeId, season, sourceType, sourceRef). District flows list sources from the selected season in the district scope and ancestors.
+
+Wrongly registered sources can be deleted by an admin. If `sourceRef` points at app-controlled upload storage, the stored file is deleted with the source row.
 
 ## InputSet
 
@@ -44,6 +47,7 @@ A named collection of inputs used for one generation run.
 | id              | string (cuid)         | PK                                                                                                   |
 | name            | string                | User-facing label                                                                                    |
 | district        | string                | Scope key (indexed)                                                                                  |
+| season          | string                | Season key, e.g. `2026/27`                                                                           |
 | createdById     | string                | FK → User                                                                                            |
 | createdAt       | datetime              |                                                                                                      |
 | status          | enum(`draft`,`ready`) | `ready` = validated, runnable (FR-008)                                                               |
@@ -51,7 +55,7 @@ A named collection of inputs used for one generation run.
 | groupAssignmentJson | string?          | Cached parsed group assignment source used for the input set; refreshed only on explicit source refresh/upload |
 | wishesJson      | string?               | Cached parsed/uploaded wishes source used for the input set; refreshed only on explicit source refresh/upload |
 
-Relations: has many Wish, HallCapacity, FixedRasterzahl; has many OptimizationRun.
+Relations: has many Wish, HallCapacity, FixedRasterzahl; has many OptimizationRun. Input sets are listed and created for one district/scope and season.
 
 Group rows inside `seasonModelJson` include `size` and optional `rasterMode` (`single` or `double`). Six-team groups must be reviewed so that `rasterMode: "double"` selects the official 6er Doppelrunde table; missing mode blocks validation.
 

--- a/specs/003-raster-review-webapp/spec.md
+++ b/specs/003-raster-review-webapp/spec.md
@@ -27,7 +27,16 @@ Raw inputs arrive today mostly as PDFs; the app must accept structured versions 
 - Q: In what form do the fixed upper-league Rasterzahlen arrive? → A: PDF or manual entry (volume is small), structured import also acceptable. They are treated as hard constraints the optimizer must not violate.
 - Q: How does the app run the optimization? → A: Wrap the existing Rasterzahl optimizer as an asynchronous background job. The app prepares the reviewed input set, invokes the existing optimizer, and ingests its output into the snapshot model. It does not reimplement the solver.
 - Q: What data scale must the app handle? → A: ~100–1,000 assignments and up to a few hundred conflicts per district snapshot. The system may later hold county-wide data (~1,400 clubs/teams), but review views remain scoped to a selected district, so a single view stays at the hundreds scale.
-- Q: How should shared documents and links be scoped if OWL is only one WTTV district? → A: Model a hierarchy of scopes, initially Germany → WTTV → OWL. Input sets still target a district such as OWL, but source documents/links and parsed caches belong to the scope where they are valid. An OWL input set may use OWL sources plus ancestor sources from WTTV and Germany.
+- Q: How should shared documents and links be scoped if OWL is only one WTTV district? → A: Model a hierarchy of scopes: Germany → WTTV → configured WTTV districts. Input sets still target a district such as OWL, but source documents/links and parsed caches belong to the scope where they are valid. A district input set may use district sources plus ancestor sources from WTTV and Germany.
+
+### Session 2026-07-11
+
+- Q: Is a group assignment the same as fixed Rasterzahlen? → A: No. Group assignment means which teams play in which league/group. Fixed Rasterzahlen are optional preassigned schedule numbers inside a group and are hard constraints if provided. In English UI copy, use "schedule number" or "fixed schedule number" for Rasterzahl where a non-German term is needed.
+- Q: Should group assignments be uploaded as PDFs? → A: Not in the primary flow. The primary group-assignment source is a click-TT league page URL for the selected season/scope. Group-assignment file upload may remain as a hidden/advanced fallback, but the visible flow must not suggest it as the normal path.
+- Q: How should wish PDFs be handled? → A: Wish PDFs are independent of group assignment and must support multi-file upload. Each uploaded PDF is stored as a separate source and later parsed/refreshed explicitly.
+- Q: Can the app run without any fixed Rasterzahlen? → A: Yes. Fixed schedule numbers are optional. A full WTTV or district run may proceed with zero fixed numbers; the optimizer assigns schedule numbers subject to the available group, wish, and capacity inputs.
+- Q: How should districts and seasons be selected? → A: District/scope selection must come from configured scope data, not free text, and should show or sort by hierarchy. The seeded WTTV hierarchy includes WTTV plus all listed WTTV districts. Season is part of the input-set/source identity and must be selectable in the UI.
+- Q: How are wrong uploads handled? → A: Admins must be able to delete wrongly registered sources. PDF uploads must at least be checked as real PDF files before storage, and explicit parser refresh must report when a document cannot be parsed as the expected source type.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -51,6 +60,11 @@ An admin/scheduler provides the district inputs (club wishes, hall capacities, f
 8. **Given** two same-club teams share one group, **When** a generated assignment uses the Spieltag-4 derby fallback, **Then** the snapshot shows that fallback in the objective breakdown; Spieltag 5 or later is treated as infeasible/invalid and is never persisted as a valid generated assignment.
 9. **Given** the parsed input set contains any six-team group, **When** an admin reviews the input set before starting a run, **Then** the app shows those groups on a confirmation step and lets the admin choose normal 6er or 6er Doppelrunde for each group; the run cannot start until every six-team group has an explicit mode.
 10. **Given** a WTTV-level group document or link exists, **When** an admin prepares an OWL input set, **Then** the app offers that WTTV source as an inherited source without copying or reclassifying it as OWL-only.
+11. **Given** an admin prepares group assignments, **When** they enter a click-TT league page URL for a season/scope, **Then** the app registers it as a group-assignment source without requiring a PDF upload or free-text source type.
+12. **Given** an admin uploads club wishes, **When** they select multiple wish PDFs, **Then** each PDF is stored as its own wish source and can be refreshed/parsed independently.
+13. **Given** an admin accidentally uploads or registers the wrong source, **When** they delete it, **Then** the source is removed from the preparation flow and any stored upload file is removed from app-controlled storage.
+14. **Given** an input set has no fixed schedule numbers, **When** the admin validates and starts a run, **Then** validation does not fail solely because fixed schedule numbers are absent.
+15. **Given** a source has been uploaded or registered but not parsed, **When** the admin views the preparation page, **Then** the app clearly shows that parsing/refresh is still needed before the source can contribute to a runnable input set.
 
 ---
 
@@ -148,6 +162,7 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - A new snapshot is generated/imported after users already reviewed an older one.
 - An optimization run is still pending, fails, times out, is cancelled, or returns a feasible assignment without proof of optimality.
 - (Import path) A snapshot has assignments but no conflict file, or a conflict references a team missing from the assignment table.
+- A user uploads a non-PDF or a PDF whose content does not match the selected source type; upload/refresh must fail with a clear message and must not silently mark the source as parsed.
 
 ## Requirements *(mandatory)*
 
@@ -156,6 +171,8 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 #### Input Ingestion
 
 - **FR-001**: Authorized users MUST be able to provide club scheduling wishes either as a structured upload (JSON/CSV) or as a PDF.
+- **FR-001a**: The primary guided input flow MUST separate source types by user intent: click-TT league URL for group assignments, multi-file upload for wish PDFs, and optional fixed schedule number entry on an input set. Users MUST NOT have to type arbitrary source type strings in the normal flow.
+- **FR-001b**: Raster sources and input sets MUST be season-specific. Users MUST be able to select the season in the Raster UI, and data for one season MUST NOT overwrite or hide data for another season.
 - **FR-002**: For PDF wishes, the system MUST parse the known fixed-layout wishes PDF deterministically in-app (text extraction via `pdfjs-dist` + layout patterns, per the existing `src/raster/ingest/wishes-pdf.ts`), producing structured clubs/teams marked for user review. The system MUST NOT run an LLM itself. (First release assumes digital/text-based PDFs; OCR for scanned PDFs is out of scope.)
 - **FR-002a**: As an optional fallback when the deterministic parser is low-confidence or the PDF layout has drifted, the system MUST offer a ready-made, copyable prompt embedding the extracted PDF text plus the expected JSON schema and instructions, and MUST accept and schema-validate the JSON the user pastes back after running it in an external LLM.
 - **FR-003**: The system MUST let a user review and correct wishes — whether parsed from PDF, pasted as JSON, or uploaded structured — before they are used in a generation run, and MUST clearly report schema-validation errors on pasted JSON.
@@ -163,19 +180,25 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **FR-005**: The system MUST allow a hall capacity value to start as an inferred/guessed default and be corrected later, and MUST distinguish reviewed capacity from inferred/guessed or missing capacity.
 - **FR-006**: The system MUST provide search over hall-capacity records by club, hall, and weekday.
 - **FR-007**: Authorized users MUST be able to provide the fixed upper-league Rasterzahlen as a PDF, manual entry, or structured upload, and the system MUST treat them as hard constraints that generated assignments never violate.
+- **FR-007a**: Fixed Rasterzahlen / fixed schedule numbers are optional. Validation and run start MUST support zero fixed numbers when all other required inputs are present.
 - **FR-008**: The system MUST validate an input set for completeness and schema before a run and surface clear errors for missing or malformed inputs.
 - **FR-008a**: The system MUST include a group-review step before validation/run start. For every six-team group, an admin MUST explicitly select `normal 6er` or `6er Doppelrunde`; this selected group mode is persisted in the input set's season model and is passed to the optimizer.
-- **FR-008b**: The system MUST model raster geography as a hierarchy of scopes, initially Germany → WTTV → OWL, so users and source material can be assigned at the level where they are valid.
+- **FR-008b**: The system MUST model raster geography as a hierarchy of scopes, initially Germany → WTTV → configured WTTV districts, so users and source material can be assigned at the level where they are valid.
 - **FR-008c**: The system MUST store raster source documents/links and parsed source caches with an owning scope. A district input set MUST be able to list and use sources from its own district scope and ancestor scopes.
 - **FR-008d**: The system MUST allow authorized admins to register or update source metadata and parsed cache content for a selected scope without reparsing or rescraping existing sources.
 - **FR-008e**: The system MUST only refresh group assignment and wishes caches when an authorized user explicitly requests a click-TT parse/refresh or uploads/replaces source PDFs or structured source data.
+- **FR-008f**: The system MUST let authorized admins delete wrongly registered raster sources. If the source references an app-stored upload, the stored file MUST be removed as part of deletion.
+- **FR-008g**: The system MUST validate source files enough to catch obvious mismatches: wish PDF uploads MUST be real PDF files, and explicit parser refresh MUST fail clearly when a source cannot be parsed as its selected source type.
+- **FR-008h**: District/scope selection in the UI MUST come from configured Scope records, show or sort by hierarchy, and include WTTV plus all configured WTTV districts rather than relying on free-text district entry.
 
 #### Generation / Optimization
 
 - **FR-009**: Admin users MUST be able to start an optimization run from a reviewed input set.
+- **FR-009a**: The Raster preparation UI MUST guide admins through the next required action: register/refresh group source, upload/refresh wishes, create input set, review optional fixed schedule numbers, validate, start run, and open results.
 - **FR-010**: The system MUST process optimization runs asynchronously — by invoking the existing Rasterzahl optimizer as a background job (not a reimplemented solver) — so users can continue reviewing existing snapshots while a run is pending. The app prepares the optimizer's input from the reviewed input set and ingests its output into the snapshot model.
 - **FR-011**: Each completed run MUST report one of these outcomes: proven optimal, feasible but not proven optimal, infeasible, failed, or cancelled.
 - **FR-012**: For proven-optimal and feasible runs, the system MUST create a review snapshot containing assignment output, conflict output, objective value, solver status, run settings, and a reference to the input set used.
+- **FR-012a**: Completed runs MUST be reachable from the Raster UI through visible status/result links; users MUST NOT need to inspect logs or call APIs manually to find the generated snapshot.
 - **FR-013**: The system MUST clearly distinguish proven-optimal assignments from feasible-only or imported heuristic assignments in all snapshot and assignment views.
 - **FR-013a**: The system MUST preserve and display the optimizer objective breakdown, including hall overages, fairness, broken relational wishes, Spielwoche misses, and Spieltag-4 same-club derby fallback count. Same-club derbies on Spieltag 5 or later MUST be treated as hard invalid results and must not be persisted as valid generated snapshots.
 - **FR-013b**: The optimization pipeline MUST support official 6er, 6er Doppelrunde, and 7/8er groups in addition to 9/10er, 11/12er, and 13/14er groups, using the reviewed group mode and encoded WTTV rulebook tables.
@@ -210,7 +233,7 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **User**: A person who signs into the app, with permissions via a role.
 - **Role**: A permission level (admin, scheduler, viewer) governing upload, run, capacity edit, review, and user management.
 - **Input Set**: A named collection of the wishes, hall capacities, and fixed upper-league Rasterzahlen used for one generation run.
-- **Scope**: A hierarchy node such as Germany, WTTV, or OWL. Users and raster source material may be assigned at the level where they are valid.
+- **Scope**: A hierarchy node such as Germany, WTTV, or a WTTV district. Users and raster source material may be assigned at the level where they are valid.
 - **Raster Source**: A document, link, or parsed cache attached to a Scope, such as a WTTV group PDF or an OWL wishes PDF. Input sets can consume sources from their district and ancestors.
 - **Group Review**: A reviewed group roster and mode selection. Six-team groups require an explicit normal-vs-Doppelrunde mode before validation.
 - **Wish**: A club's scheduling preference/constraint for its teams (uploaded structured or extracted from PDF, reviewable/correctable).
@@ -241,6 +264,9 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - **SC-011a**: A run cannot start while any six-team group lacks a reviewed mode, and a generated six-team Doppelrunde assignment uses the Doppelrunde rulebook table for penalties, conflicts, and derby display.
 - **SC-011b**: An OWL admin can see WTTV-level source material in the OWL preparation flow within 5 seconds, while source records remain visibly associated with WTTV.
 - **SC-011c**: Reopening an existing input set does not reparse click-TT or PDF sources unless the user explicitly requests refresh or uploads replacement source material.
+- **SC-011d**: An admin can select any configured WTTV district from a hierarchy-sorted selector without typing the district code by hand.
+- **SC-011e**: An admin can remove an incorrectly uploaded source in under 30 seconds, and the source no longer appears in the preparation flow after refresh.
+- **SC-011f**: A non-PDF file selected as a wish PDF is rejected before it becomes a stored raster source.
 - **SC-012**: At least 95% of completed runs display their final outcome, objective value, and generated snapshot link without manual log inspection.
 - **SC-013**: Users can distinguish proven-optimal, feasible-only, and imported heuristic snapshots within 5 seconds of opening a snapshot.
 - **SC-014**: If a generated snapshot uses any Spieltag-4 same-club derby fallback, a scheduler can see the count and affected objective component within 5 seconds of opening the snapshot; no Spieltag-5-or-later same-club derby is stored as a valid generated snapshot.
@@ -257,7 +283,9 @@ An admin imports a snapshot produced by the legacy external optimizer into the s
 - User login, user administration, and basic role management are provided by the existing internal application baseline (webapp-template).
 - Reviewed capacity and input data are maintained separately from snapshots so old snapshots remain historically understandable.
 - First release targets district scale (hundreds of assignments/conflicts per snapshot). The data model should not preclude later county-wide scale (~1,400 clubs/teams) with district-scoped views.
-- WTTV-level documents may apply to multiple districts. Source ownership follows the administrative level where the document is valid; input sets consume inherited sources instead of duplicating them per district.
+- WTTV-level sources may apply to multiple districts. Source ownership follows the administrative level where the document or link is valid; input sets consume inherited sources instead of duplicating them per district.
+- Group assignments normally come from click-TT league page URLs for a selected season. Group-assignment file upload is an advanced fallback, not the expected admin path.
+- Fixed Rasterzahlen are optional hard constraints, not required input. The app can optimize a season/district with no pre-fixed schedule numbers.
 - Desktop/tablet review is the primary workflow for the first release; mobile is useful but secondary.
 - A new snapshot is required after capacity/input edits before conflict counts can be considered final.
 </content>

--- a/specs/003-raster-review-webapp/tasks.md
+++ b/specs/003-raster-review-webapp/tasks.md
@@ -153,8 +153,8 @@
 
 **Independent Test**: Register a WTTV group source, open an OWL raster flow, verify the WTTV source is visible to OWL users with parent-scope access, and verify reopening the input set does not reparse until refresh/upload is requested.
 
-- [x] T054 [US1] Extend `webapp/prisma/schema.postgres.prisma` and migrations with hierarchical `Scope.parentId` for Germany → WTTV → OWL.
-- [x] T055 [US1] Update `webapp/prisma/seed.ts` to seed `DE`, `WTTV`, and `OWL` hierarchy while preserving demo OWL users.
+- [x] T054 [US1] Extend `webapp/prisma/schema.postgres.prisma` and migrations with hierarchical `Scope.parentId` for Germany → WTTV → district scopes.
+- [x] T055 [US1] Update `webapp/prisma/seed.ts` to seed `DE`, `WTTV`, and WTTV district hierarchy while preserving demo OWL users.
 - [x] T056 [US5] Update `webapp/src/lib/raster/access.ts` so users assigned to parent scopes can access child district raster data according to role.
 - [x] T057 [P] [US5] Add hierarchy access tests in `webapp/tests/unit/raster-access.test.ts`.
 - [x] T058 [US1] Add `RasterSource` model and migration for scoped documents/links/parsed cache in `webapp/prisma/schema.postgres.prisma`.
@@ -170,6 +170,28 @@
 
 ---
 
+## Phase 11: Follow-Up Gap Closure From Admin Workflow Review
+
+**Goal**: Close the practical workflow gaps discovered during manual admin review: guided source preparation, season/district hierarchy, source cleanup, and visible run/results controls.
+
+**Independent Test**: As an admin, select a season and WTTV district from hierarchy-sorted controls, register a click-TT group URL, upload multiple wish PDFs, delete a wrong source, create/validate an input set with zero fixed schedule numbers, start a background run, and open the generated result view without API/manual log inspection.
+
+- [x] T068 [US1] Add season to `RasterSource` and `RasterInputSet`, migrations, source/input-set services, and route tests so sources/input sets are isolated per season.
+- [x] T069 [US5] Seed WTTV plus all listed WTTV districts and show district selection from configured scopes sorted/labeled by hierarchy instead of free-text district entry.
+- [x] T070 [US1] Change the visible source UI to use click-TT league URLs for group assignment and multi-file wish PDF upload; keep group-assignment file upload only as hidden/advanced fallback.
+- [x] T071 [US1] Add optional fixed schedule number editing on input sets and prove run creation does not require any fixed schedule numbers.
+- [x] T072 [US1] Add source deletion and PDF byte validation for wish uploads, with route tests.
+- [x] T073 [US1] Add visible source parse state and a single refresh/parse action flow, including clear errors when a source cannot be parsed as `GROUP_ASSIGNMENT` or `WISHES_PDF`.
+- [x] T074 [US1] Add guided next-step controls on the Raster page: create input set, validate, start run, and display why a run is blocked.
+- [x] T075 [US1] Wire the local/background worker command or dev workflow so `raster_run` jobs created by the webapp are actually processed in local development.
+- [x] T076 [US1] Add run status UI in the Raster page showing pending/running/failed/completed jobs with cancel where supported.
+- [x] T077 [US2] Add a reachable snapshot/results view from the Raster page using the existing assignment/conflict/snapshot APIs and components.
+- [x] T078 [US1] Add Playwright coverage for the real guided admin workflow: season + hierarchy district selection, click-TT URL source, multi-wish upload, delete wrong source, validate/start, and open results.
+
+**Checkpoint**: The admin can complete the intended workflow from the UI without knowing internal source types, API routes, or worker mechanics.
+
+---
+
 ## Dependencies & Execution Order
 
 - **Setup (Phase 1)**: T001 governance blocker first; T002→T003 (schema→migration) ordered; T004/T005/T006 parallel after.
@@ -182,6 +204,7 @@
 - **US6 (Phase 8)**: reuses review layer (US2/US3).
 - **Polish (Phase 9)**: after target stories.
 - **Source hierarchy/cache (Phase 10)**: schema/access tasks T054–T059 before APIs/UI; T064–T066 complete parser integration; T067 verifies behavior end-to-end.
+- **Gap closure (Phase 11)**: T068–T078 are implemented and covered by focused tests.
 
 ### Parallel Opportunities
 
@@ -194,7 +217,7 @@
 
 ### MVP
 
-US1 + US2 (generate a proposal and review its conflicts) is the minimum valuable release. US3–US6 are incremental.
+US1 + US2 (generate a proposal and review its conflicts) is the minimum valuable release. Phase 11 closes the manual-review gaps discovered during admin workflow testing.
 
 ---
 

--- a/specs/004-compare-raster-runs/checklists/requirements.md
+++ b/specs/004-compare-raster-runs/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Raster Run Comparison
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-07-12  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on 2026-07-12. The spec is ready for `/speckit.plan`.

--- a/specs/004-compare-raster-runs/contracts/api.md
+++ b/specs/004-compare-raster-runs/contracts/api.md
@@ -1,0 +1,130 @@
+# API Contract: Raster Run Comparison
+
+Base path: `/api/raster`
+
+## List scenarios
+
+`GET /scenarios?district=&season=&inputSetId=`
+
+Returns comparable optimizer/manual scenarios for one scope.
+
+Response:
+
+```json
+{
+  "scenarios": [
+    {
+      "id": "run_123",
+      "inputSetId": "set_123",
+      "district": "OWL",
+      "season": "2026/27",
+      "name": "CP-SAT 10 min",
+      "origin": "optimizer",
+      "strategy": "cp_sat",
+      "status": "feasible",
+      "settings": { "timeLimitSeconds": 600 },
+      "kpiSummary": {
+        "objective": 1234,
+        "totalHallExcess": 8,
+        "maxHallExcess": 2,
+        "affectedClubs": 5,
+        "wishMisses": 3,
+        "sameClubDerbyIssues": 0,
+        "status": "feasible"
+      },
+      "detailRef": "/raster/scenarios/run_123",
+      "stale": false,
+      "createdAt": "2026-07-12T10:00:00.000Z",
+      "finishedAt": "2026-07-12T10:06:00.000Z"
+    }
+  ]
+}
+```
+
+## Start optimizer strategy
+
+`POST /input-sets/{inputSetId}/runs`
+
+Extends the existing run-start route with an explicit `strategy`.
+
+Request:
+
+```json
+{
+  "strategy": "cp_sat",
+  "name": "CP-SAT 10 min",
+  "timeLimitSeconds": 600
+}
+```
+
+Allowed strategies: `initial_heuristic`, `cp_sat`.
+
+Response:
+
+```json
+{ "runId": "run_123", "scenarioId": "run_123", "status": "queued" }
+```
+
+## Create manual draft
+
+`POST /input-sets/{inputSetId}/manual-assignments`
+
+Request:
+
+```json
+{
+  "name": "Colleague draft",
+  "rows": [
+    { "groupName": "1. Bezirksliga Herren", "teamName": "ABC 1", "scheduleNumber": 4 }
+  ]
+}
+```
+
+Response:
+
+```json
+{ "draftId": "manual_123", "validationIssues": [] }
+```
+
+## Validate manual draft
+
+`POST /manual-assignments/{draftId}/validate`
+
+Response:
+
+```json
+{
+  "valid": false,
+  "issues": [
+    { "groupName": "1. Bezirksliga Herren", "teamName": "ABC 1", "message": "Duplicate schedule number 4 in group" }
+  ]
+}
+```
+
+## Score manual draft
+
+`POST /manual-assignments/{draftId}/score`
+
+Creates a manual scenario only when validation passes.
+
+Response:
+
+```json
+{ "scenarioId": "manual_123", "status": "completed" }
+```
+
+## Compare scenarios
+
+`POST /scenarios/compare`
+
+Request:
+
+```json
+{
+  "scenarioIds": ["run_123", "manual_123"],
+  "baselineScenarioId": "manual_123"
+}
+```
+
+Response includes selected scenarios plus KPI deltas against the baseline. The server rejects scenarios from different
+districts, seasons, input sets, or incompatible input versions.

--- a/specs/004-compare-raster-runs/data-model.md
+++ b/specs/004-compare-raster-runs/data-model.md
@@ -1,0 +1,97 @@
+# Data Model: Raster Run Comparison
+
+## Scenario
+
+A comparable scheduling result or attempted result for one district, season, and input set.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | string | Existing run/snapshot id or new manual scenario id |
+| inputSetId | string | Required compatibility boundary |
+| district | string | Copied from input set/snapshot |
+| season | string | Copied from input set/snapshot |
+| name | string | User-visible label |
+| origin | enum(`optimizer`,`manual`) | Source category |
+| strategy | enum(`initial_heuristic`,`cp_sat`,`manual`) | Comparison label |
+| status | enum(`queued`,`running`,`completed`,`feasible`,`failed`,`cancelled`,`no_solution`) | Honest user-visible state |
+| settings | json | Time budget, solver options, import source label |
+| kpiSummary | json? | Present only for valid scored scenarios |
+| detailRef | string? | Route/link to assignments and conflicts |
+| stale | boolean | True when input/scoring assumptions changed |
+| createdAt | datetime | |
+| finishedAt | datetime? | |
+
+Validation:
+- Scenarios are comparable only when `district`, `season`, and `inputSetId` match.
+- Failed/cancelled/no-solution scenarios remain in history but are not selected by default for KPI comparison.
+
+## KPI Summary
+
+Shared scoring output for optimizer and manual scenarios.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| objective | number | Existing objective score |
+| totalHallExcess | number | Sum of excesses |
+| maxHallExcess | number | Worst single excess |
+| affectedClubs | number | Count of clubs with excess/conflicts |
+| wishMisses | number | Existing wish miss count |
+| sameClubDerbyIssues | number | Existing derby issue count |
+| status | string | Solver/manual status label |
+
+Validation:
+- Computed by shared scoring code, not user-entered.
+- Missing for scenarios without a valid assignment.
+
+## Manual Assignment Draft
+
+Editable user-provided schedule-number assignment before scoring.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| id | string | |
+| inputSetId | string | |
+| name | string | Source/display name |
+| rows | json | Group/team/schedule-number rows |
+| validationIssues | json | Current blocking issues |
+| createdById | string | |
+| createdAt | datetime | |
+| updatedAt | datetime | |
+
+Validation:
+- Every required team must have one legal schedule number unless its group is explicitly excluded.
+- Schedule numbers must be unique within a group.
+- Unknown group/team rows stay visible for correction and block scoring.
+
+## Manual Assignment Row
+
+Logical row inside a manual draft.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| groupId | string? | Matched group |
+| groupName | string | Source/display group name |
+| teamId | string? | Matched team |
+| teamName | string | Source/display team name |
+| scheduleNumber | number? | Candidate schedule number |
+| sourceLine | string? | Raw import row for audit/correction |
+| issues | string[] | Row-level validation messages |
+
+## Scenario Comparison
+
+Transient UI selection, optionally persisted later if users ask for saved comparison sets.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| scenarioIds | string[] | Two or more compatible scenarios |
+| baselineScenarioId | string? | Used for deltas |
+
+State transitions:
+
+```text
+ManualAssignmentDraft -> validate failed -> editable draft
+ManualAssignmentDraft -> validate passed -> scored Scenario(origin=manual)
+
+Optimizer run -> queued/running -> completed/feasible Scenario(origin=optimizer)
+Optimizer run -> failed/cancelled/no_solution -> history-only Scenario
+```

--- a/specs/004-compare-raster-runs/plan.md
+++ b/specs/004-compare-raster-runs/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Raster Run Comparison
+
+**Branch**: `004-compare-raster-runs` | **Date**: 2026-07-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/004-compare-raster-runs/spec.md`
+
+## Summary
+
+Add comparable scheduling scenarios on top of the existing raster webapp. A scenario is either an optimizer run result
+(`Initial heuristic` or `CP-SAT`) or a scored manual assignment. All scenarios for the same district, season, and input
+set expose the same KPI summary, status, detail links, and staleness state so admins can compare them side by side and
+use manual plans as real baselines.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 strict for webapp/root raster code; Python 3.12 for the existing CP-SAT subprocess
+**Primary Dependencies**: Existing Next.js 16, React 19, Prisma 7, better-auth, next-intl, zod, Tailwind/shadcn; existing root `src/raster/*`; existing Python OR-Tools CP-SAT script
+**Storage**: Existing Prisma SQLite dev / PostgreSQL prod schema, extended with scenario/manual-assignment fields as needed
+**Testing**: Vitest for units/routes/services; Playwright for the smallest user-flow smoke checks
+**Target Platform**: Existing `webapp/` dashboard plus existing background worker
+**Project Type**: Web application feature layered on the raster planning pipeline
+**Performance Goals**: Compare at least three compatible scenarios within 30 seconds after they exist; manual entry/import usable for a 40-group season within 15 minutes
+**Constraints**: Reuse existing optimizer/scoring code; no fake progress percentages; failed/no-solution runs stay visible but are not valid assignment scenarios
+**Scale/Scope**: One district-season input set at a time; hundreds of teams/assignments per scenario
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution v3.0.0 permits the raster review webapp in `webapp/` and requires reuse of the planning pipeline.
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Focused click-TT Administration Suite | PASS | Extends capability 3; reuses `src/raster/*` and `scripts/solve-raster-cpsat.py`. |
+| II. Safety-First Automation | PASS | Feature remains read-only toward click-TT and compares proposals only. |
+| III. Credential Security | PASS | No new credential flow. |
+| IV. Idempotent & Resumable | PASS | Scenarios are immutable-ish records; new runs/manual scores create new comparable results. |
+| V. Observable Output | PASS | Status, KPI summary, and details are first-class scenario fields. |
+| VI. Quality Gates | PASS | Existing root/webapp validation commands remain the gate. |
+
+**Gate result**: PASSES. No constitution exception required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-compare-raster-runs/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+```text
+src/raster/
+├── optimize/                 # existing heuristic optimizer
+├── score/                    # existing KPI/conflict derivation to reuse for all scenarios
+└── types.ts
+
+scripts/
+└── solve-raster-cpsat.py     # existing CP-SAT solver invoked by worker
+
+webapp/
+├── prisma/schema.postgres.prisma
+├── src/app/(dashboard)/raster/
+├── src/app/api/raster/
+├── src/components/raster/
+├── src/lib/raster/
+├── src/services/raster/
+├── tests/unit/
+├── tests/e2e/
+└── worker/
+```
+
+**Structure Decision**: Implement 004 inside the existing 003 raster webapp. Do not fork the optimizer or create a
+separate comparison app. Add only the persistence/API/UI needed to treat existing run outputs and manual assignments as
+comparable scenarios.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/004-compare-raster-runs/quickstart.md
+++ b/specs/004-compare-raster-runs/quickstart.md
@@ -1,0 +1,46 @@
+# Quickstart: Raster Run Comparison
+
+## Prerequisites
+
+1. Start the webapp with `APP_DATABASE_URL` or `DATABASE_URL` configured.
+2. Use an existing validated raster input set for one district and season.
+3. Ensure the worker is running for background optimizer jobs.
+
+## Scenario 1: Compare Existing Runs
+
+1. Open `/raster` for the district and season.
+2. Open the scenarios/comparison area for a validated input set.
+3. Confirm existing completed runs appear as scenarios.
+4. Select two or more compatible scenarios.
+5. Confirm the comparison shows objective, hall excess, affected clubs, wish misses, derby issues, status, and detail links.
+6. Choose one scenario as baseline and confirm KPI deltas appear as better, worse, or unchanged.
+
+Expected: incompatible scenarios from another district, season, or input set are not silently compared.
+
+## Scenario 2: Run Alternative Optimizers
+
+1. On a validated input set, start an `Initial heuristic` run.
+2. Start a `CP-SAT` run with a visible time budget.
+3. Watch status move through honest states such as queued/running/completed/feasible/failed.
+4. After completion, confirm both runs appear in the same scenario list.
+
+Expected: a feasible-but-not-proven CP-SAT result is still comparable; failed/no-solution runs stay visible as history.
+
+## Scenario 3: Manual Assignment
+
+1. Open manual assignment entry for the same input set.
+2. Enter schedule numbers for teams by group, or paste/upload a simple group/team/schedule-number table.
+3. Validate the draft.
+4. Fix any duplicate, illegal, unknown, or missing assignment issues.
+5. Score the valid draft.
+6. Compare the resulting manual scenario against optimizer scenarios.
+
+Expected: manual KPIs are computed by the same scoring definitions as optimizer scenarios.
+
+## Minimal Validation Commands
+
+```powershell
+pnpm --dir webapp run typecheck
+pnpm --dir webapp exec vitest run tests/unit
+pnpm test -- tests/unit/evaluate.test.ts
+```

--- a/specs/004-compare-raster-runs/research.md
+++ b/specs/004-compare-raster-runs/research.md
@@ -1,0 +1,55 @@
+# Research: Raster Run Comparison
+
+## Decision: Model comparison around scenarios, not separate run/import tables
+
+**Decision**: Expose optimizer results and manual assignments through one `Scenario` read model with origin, strategy,
+status, settings, KPI summary, details link, and staleness.
+
+**Rationale**: The admin compares results, not storage internals. One read model keeps the UI and KPI logic small.
+
+**Alternatives considered**:
+- Separate compare paths for runs vs manual plans - rejected because it duplicates KPI and table rendering.
+- A generic snapshot import feature - too broad for 004; manual schedule-number assignment is the actual need.
+
+## Decision: Reuse existing scoring for manual assignments
+
+**Decision**: Convert valid manual schedule-number choices into the same assignment shape used by optimizer output, then
+run the existing score/conflict derivation.
+
+**Rationale**: Shared KPIs only stay honest if they are computed by the same code.
+
+**Alternatives considered**:
+- Manual-only scoring code - rejected because it would drift.
+- Storing manual KPIs typed by users - rejected because it cannot be trusted.
+
+## Decision: Honest phase/status instead of progress percentages
+
+**Decision**: Track queued, running, completed, feasible, failed, cancelled, and no-solution states. Do not show a
+percentage unless a future solver exposes real progress.
+
+**Rationale**: CP-SAT can run for minutes without linear progress. Fake precision is worse than a clear status.
+
+**Alternatives considered**:
+- Progress bar with guessed percentages - rejected as misleading.
+- Blocking request/response runs - rejected because existing runs are background jobs.
+
+## Decision: Visual manual entry plus simple paste/upload import
+
+**Decision**: Manual v1 supports a group/team/schedule-number form and a simple table import that pre-fills that form.
+Unmatched rows are corrected in the same visual flow.
+
+**Rationale**: This covers the colleague workflow without building a spreadsheet clone.
+
+**Alternatives considered**:
+- Arbitrary PDF/OCR manual import - rejected for v1 as high effort and low reliability.
+- Upload only - rejected because the user explicitly needs visual entry.
+
+## Decision: Keep Claude branch changes out of 004
+
+**Decision**: Do not copy the `speckit-clarify-041a87` branch into 004. Its changes clarify 003 topics, not scenario
+comparison.
+
+**Rationale**: Importing it would pollute 004 with club identity, click-TT ingestion, retention, and i18n work.
+
+**Alternatives considered**:
+- Merge Claude branch as-is - rejected because it edits `specs/003-raster-review-webapp` and creates no 004 artifacts.

--- a/specs/004-compare-raster-runs/spec.md
+++ b/specs/004-compare-raster-runs/spec.md
@@ -1,0 +1,138 @@
+# Feature Specification: Raster Run Comparison
+
+**Feature Branch**: `004-compare-raster-runs`  
+**Created**: 2026-07-12  
+**Status**: Draft  
+**Input**: User description: "Compare optimizer runs, CP-SAT runs, and manual schedule assignments with shared KPIs and visual entry. CP-SAT can run for several minutes; it either finishes with a solution/status or does not. Manual assignments from colleagues should be loadable, visually editable, and scored with the same KPIs as optimizer output."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Compare Scheduling Scenarios (Priority: P1)
+
+As a district admin, I want to compare multiple scheduling scenarios for the same district and season so that I can decide whether the automated optimizer improves on a baseline or a colleague's manual work.
+
+**Why this priority**: Comparison is the central value of the feature. Without it, separate runs and manual imports remain isolated artifacts and cannot support a planning decision.
+
+**Independent Test**: Can be tested by opening a district-season with at least two completed scenarios and verifying that a side-by-side comparison shows their KPIs, result links, and relative differences.
+
+**Acceptance Scenarios**:
+
+1. **Given** two completed scenarios for the same district and season, **When** the admin opens the comparison view, **Then** both scenarios appear side by side with objective value, hall excess KPIs, wish misses, same-club derby issues, solver/manual status, creation time, and a link to details.
+2. **Given** more than two scenarios, **When** the admin selects scenarios for comparison, **Then** the view updates to only compare the selected scenarios without losing access to the full scenario list.
+3. **Given** one scenario is selected as baseline, **When** other scenarios are compared, **Then** KPI differences are shown as better, worse, or unchanged compared with the baseline.
+
+---
+
+### User Story 2 - Run Alternative Optimizers (Priority: P2)
+
+As a district admin, I want to run the initial heuristic and the CP-SAT optimizer as named strategies for the same input set so that their outputs can be compared with the same scoring rules.
+
+**Why this priority**: The admin needs confidence that CP-SAT is actually better than the initial heuristic or at least understands where each strategy differs.
+
+**Independent Test**: Can be tested by choosing a strategy, queueing a run, waiting for completion, and confirming the resulting scenario records the chosen strategy, status, KPIs, and result details.
+
+**Acceptance Scenarios**:
+
+1. **Given** a validated input set, **When** the admin queues a heuristic run, **Then** a scenario is created with strategy "Initial heuristic" and progresses from queued/running to a terminal status.
+2. **Given** a validated input set, **When** the admin queues a CP-SAT run, **Then** a scenario is created with strategy "CP-SAT", a configurable time budget, solver status, KPIs, and result details.
+3. **Given** a CP-SAT run reaches its configured time budget, **When** the run ends with a feasible solution, **Then** the scenario is marked feasible rather than failed and remains comparable.
+4. **Given** a CP-SAT run cannot produce a solution, **When** the run ends, **Then** the scenario is marked with a clear terminal status and does not appear as a valid assignment in comparisons unless explicitly included.
+
+---
+
+### User Story 3 - Import and Score Manual Assignments (Priority: P2)
+
+As a district admin, I want to enter, paste, or upload a colleague's manually chosen schedule numbers so that the system can compute the same KPIs and compare the manual plan against optimizer output.
+
+**Why this priority**: Manual plans are an important real-world baseline. The feature is less useful if comparisons only cover automated runs.
+
+**Independent Test**: Can be tested by entering a complete manual assignment for one input set and verifying that it becomes a comparable scenario with KPIs and detail views.
+
+**Acceptance Scenarios**:
+
+1. **Given** a validated input set, **When** the admin opens manual assignment entry, **Then** all groups and teams are shown in a visual form with legal schedule-number choices for each group.
+2. **Given** a manual assignment is incomplete, duplicated within a group, or uses an illegal schedule number, **When** the admin tries to score it, **Then** the system reports the specific group/team issues and does not create a scored scenario.
+3. **Given** a complete valid manual assignment, **When** the admin scores it, **Then** the system creates a manual scenario with the same KPIs, conflicts, and detail views as optimizer scenarios.
+4. **Given** a colleague provides assignment data in a pasteable table or file, **When** the admin imports it, **Then** the system maps recognizable groups/teams/schedule numbers into the visual entry form and highlights unmatched rows for correction.
+
+---
+
+### User Story 4 - Review Scenario Details (Priority: P3)
+
+As a district admin, I want to inspect why one scenario is better or worse than another so that I can make adjustments or explain the decision to colleagues.
+
+**Why this priority**: KPI totals are useful, but admins need traceability into conflicts, excesses, wish misses, and assignments before trusting a final schedule.
+
+**Independent Test**: Can be tested by opening a scenario from the comparison view and verifying that detailed assignments, hall excesses, wish outcomes, and conflicts are visible and filterable enough to investigate the result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scenario with hall excesses, **When** the admin opens details, **Then** the affected club, hall, weekday, week, teams, capacity, and excess count are visible.
+2. **Given** a scenario with wish misses or derby issues, **When** the admin opens details, **Then** each issue identifies the involved teams and expected versus actual outcome.
+3. **Given** a manual scenario and an optimizer scenario, **When** the admin compares details, **Then** both use the same terminology and KPI definitions.
+
+### Edge Cases
+
+- A CP-SAT run may return a feasible but not proven-optimal assignment; the scenario must remain comparable and clearly show that status.
+- A CP-SAT run may exhaust its time budget or fail without a feasible assignment; the scenario must show the failure state and avoid presenting nonexistent KPIs as valid.
+- Odd-size groups use the next even schedule template with one unused schedule number chosen by the assignment; validation must accept any legal unused number.
+- Manual imports may contain group names, team names, or schedule-number formats that differ from the current input set; unmatched rows must be visible for correction.
+- Manual assignments may intentionally omit youth or special groups; the system must treat omitted required teams as incomplete unless the admin explicitly excludes those groups from the scenario.
+- Scenarios from different districts, seasons, or input-set versions must not be compared as if they share the same baseline.
+- If scoring rules or input sources change after a scenario is created, the system must make stale comparisons visible rather than silently mixing old and new assumptions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST present optimizer and manual results as comparable scenarios tied to one district, season, and input set.
+- **FR-002**: Users MUST be able to queue an "Initial heuristic" optimizer run for a validated input set.
+- **FR-003**: Users MUST be able to queue a "CP-SAT" optimizer run for a validated input set with a visible time budget appropriate for multi-minute runs.
+- **FR-004**: System MUST show each run's current phase using honest states such as queued, optimization started, completed, feasible, failed, or cancelled.
+- **FR-005**: System MUST store each scenario's strategy or origin, terminal status, settings, creation time, completion time, KPI summary, and link to detailed assignments/conflicts.
+- **FR-006**: System MUST compute the same KPI definitions for heuristic, CP-SAT, and manual scenarios.
+- **FR-007**: KPI summary MUST include at minimum objective score, total hall excess, maximum hall excess, affected clubs, wish misses, same-club derby issues, and solver/manual status.
+- **FR-008**: Users MUST be able to select two or more comparable scenarios and view their KPI summaries side by side.
+- **FR-009**: Users MUST be able to choose a baseline scenario and see whether each compared KPI is better, worse, or unchanged relative to that baseline.
+- **FR-010**: Users MUST be able to open scenario details from the comparison view.
+- **FR-011**: Users MUST be able to create a manual scenario through a visual assignment form organized by group and team.
+- **FR-012**: The visual manual form MUST limit or flag schedule-number choices to the legal schedule numbers for each group's size and mode.
+- **FR-013**: Users MUST be able to paste or upload manual assignment data and review the parsed rows before scoring.
+- **FR-014**: System MUST validate manual assignments for completeness, duplicate schedule numbers within a group, illegal schedule numbers, unknown groups, and unknown teams before scoring.
+- **FR-015**: System MUST let users correct imported manual assignments in the visual form before computing KPIs.
+- **FR-016**: System MUST create a scored manual scenario only after validation succeeds.
+- **FR-017**: System MUST prevent or clearly warn when users attempt to compare scenarios from different districts, seasons, input sets, or incompatible input versions.
+- **FR-018**: System MUST mark scenarios as stale when the underlying input set or scoring assumptions change after the scenario was created.
+- **FR-019**: System MUST allow failed, cancelled, or no-solution runs to remain visible in history without treating them as valid assignment scenarios.
+- **FR-020**: Users MUST be able to identify which scenario was produced by a colleague/manual import versus an optimizer strategy.
+
+### Key Entities *(include if feature involves data)*
+
+- **Scenario**: A comparable scheduling result or attempted result for one input set. Key attributes include origin/strategy, status, settings, created time, finished time, KPI summary, detail link, and staleness state.
+- **Optimizer Strategy**: A selectable automated scheduling approach such as Initial heuristic or CP-SAT, including user-visible settings such as time budget where relevant.
+- **Manual Assignment**: A user-provided set of schedule numbers for teams in the input set, including source label, parsed/imported rows, validation issues, and corrected values.
+- **KPI Summary**: Shared scoring outputs used for comparison, including objective, hall excesses, affected clubs, wish misses, derby issues, and status.
+- **Scenario Comparison**: A selected set of compatible scenarios plus an optional baseline used to show side-by-side KPIs and differences.
+- **Validation Issue**: A problem preventing a manual assignment or run result from being scored or compared, such as duplicate numbers, missing teams, unknown rows, or illegal schedule numbers.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A district admin can compare at least three compatible scenarios side by side in under 30 seconds after the scenarios exist.
+- **SC-002**: A district admin can create and score a complete manual assignment for a 40-group season in under 15 minutes using the visual form or import-and-correct flow.
+- **SC-003**: 100% of valid optimizer and manual scenarios display the same KPI categories and definitions.
+- **SC-004**: 100% of invalid manual assignments identify at least one actionable issue before scoring is allowed.
+- **SC-005**: Scenario status is visible for every queued or completed run, and users can distinguish waiting, running, completed, feasible, failed, and cancelled states without reading logs.
+- **SC-006**: At least 90% of manually imported rows from a simple group/team/schedule-number table are either matched automatically or shown as unmatched for correction.
+- **SC-007**: Users can open detailed conflict or assignment information from a compared scenario in no more than two interactions from the comparison view.
+
+## Assumptions
+
+- District admins are the primary users; read-only viewers may later receive comparison access but cannot create runs or manual scenarios.
+- Existing validated input sets remain the prerequisite for optimizer runs and manual scenario scoring.
+- CP-SAT runs may take several minutes and are acceptable as background jobs; the feature should show honest status rather than a fake percentage.
+- CP-SAT with a time budget can produce optimal, feasible, infeasible, failed, or no-solution outcomes; feasible outcomes are still useful for comparison.
+- Manual assignment import v1 supports common table formats with group, team, and schedule-number columns; complex OCR or arbitrary PDF parsing is out of scope for this feature.
+- Visual manual entry is required for v1, but advanced spreadsheet-like editing can be incremental as long as users can complete and correct an assignment.
+- Scenario comparison is limited to compatible scenarios from the same district, season, and input set version unless explicitly marked otherwise.

--- a/specs/004-compare-raster-runs/tasks.md
+++ b/specs/004-compare-raster-runs/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Raster Run Comparison
+
+**Input**: Design documents from `specs/004-compare-raster-runs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api.md, quickstart.md
+
+**Tests**: Include focused unit/route tests because the feature changes validation, scoring, and persisted comparison state.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on incomplete tasks)
+- **[Story]**: User story label from spec.md
+- Every task names exact files to touch
+
+## Phase 1: Setup
+
+**Purpose**: Reuse the existing raster webapp shape and create shared comparison vocabulary.
+
+- [ ] T001 Add scenario strategy/status TypeScript types in `webapp/src/lib/raster/scenarios.ts`
+- [ ] T002 [P] Add KPI summary TypeScript type and mapper skeleton in `webapp/src/lib/raster/kpis.ts`
+- [ ] T003 [P] Add scenario route test fixtures in `webapp/tests/unit/fixtures/raster-scenarios.ts`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Blocking scenario persistence/read model shared by all stories.
+
+- [ ] T004 Extend `webapp/prisma/schema.postgres.prisma` with the minimal fields/models needed for manual scenarios and scenario metadata
+- [ ] T005 Add matching Prisma migration under `webapp/prisma/migrations-postgres/`
+- [ ] T006 Add scenario service list/read helpers in `webapp/src/services/raster/scenarios.ts`
+- [ ] T007 Wire optimizer run/snapshot rows into the scenario read model in `webapp/src/services/raster/scenarios.ts`
+- [ ] T008 Implement shared KPI mapper from existing score/output fields in `webapp/src/lib/raster/kpis.ts`
+- [ ] T009 [P] Unit test KPI mapping in `webapp/tests/unit/raster-kpis.test.ts`
+- [ ] T010 [P] Unit test scenario compatibility filtering in `webapp/tests/unit/raster-scenarios-service.test.ts`
+
+**Checkpoint**: Scenario list can represent existing optimizer runs with shared KPI fields.
+
+---
+
+## Phase 3: User Story 1 - Compare Scheduling Scenarios (Priority: P1) MVP
+
+**Goal**: Admins can compare compatible scenarios side by side with KPI deltas.
+
+**Independent Test**: Open an input set with at least two completed scenarios and verify KPI summaries, baseline deltas, statuses, and detail links.
+
+- [ ] T011 [P] Add route tests for `GET /api/raster/scenarios` and `POST /api/raster/scenarios/compare` in `webapp/tests/unit/raster-scenarios-route.test.ts`
+- [ ] T012 Implement `GET /api/raster/scenarios` in `webapp/src/app/api/raster/scenarios/route.ts`
+- [ ] T013 Implement `POST /api/raster/scenarios/compare` compatibility checks and deltas in `webapp/src/app/api/raster/scenarios/compare/route.ts`
+- [ ] T014 Add scenario comparison service function in `webapp/src/services/raster/scenarioComparison.ts`
+- [ ] T015 Add scenario list/comparison UI in `webapp/src/components/raster/scenario-comparison.tsx`
+- [ ] T016 Wire comparison UI into `webapp/src/app/(dashboard)/raster/page.tsx`
+- [ ] T017 [P] Add UI/unit test for baseline delta rendering in `webapp/tests/unit/scenario-comparison.test.tsx`
+
+**Checkpoint**: P1 comparison works without manual assignment creation.
+
+---
+
+## Phase 4: User Story 2 - Run Alternative Optimizers (Priority: P2)
+
+**Goal**: Admins can explicitly run `Initial heuristic` or `CP-SAT` and see honest status/history.
+
+**Independent Test**: Queue both strategies for the same input set and confirm each creates a scenario with strategy, status, settings, KPIs/details after completion.
+
+- [ ] T018 Extend run-start request validation with `strategy` and optional `timeLimitSeconds` in `webapp/src/app/api/raster/input-sets/[id]/runs/route.ts`
+- [ ] T019 Pass selected strategy/settings through run creation in `webapp/src/services/raster/runs.ts`
+- [ ] T020 Add heuristic strategy execution path using existing `src/raster/optimize` code in `webapp/worker/src/starter_worker/raster_run.py`
+- [ ] T021 Preserve CP-SAT feasible/failed/no-solution status in scenario metadata in `webapp/src/services/raster/scenarios.ts`
+- [ ] T022 Add strategy selector and visible time-budget control in `webapp/src/components/raster/run-controls.tsx`
+- [ ] T023 [P] Unit test run-start strategy validation in `webapp/tests/unit/raster-runs-route.test.ts`
+- [ ] T024 [P] Unit test worker outcome-to-scenario status mapping in `webapp/tests/unit/raster-run-status.test.ts`
+
+**Checkpoint**: Both automated strategies create comparable scenarios.
+
+---
+
+## Phase 5: User Story 3 - Import and Score Manual Assignments (Priority: P2)
+
+**Goal**: Admins can visually enter or import a manual schedule-number plan, validate it, score it, and compare it.
+
+**Independent Test**: Enter a complete manual assignment for one input set and verify it becomes a comparable scenario with shared KPIs and details.
+
+- [ ] T025 Add manual assignment validation helpers in `webapp/src/lib/raster/manualAssignments.ts`
+- [ ] T026 [P] Unit test duplicate/illegal/missing/unknown manual assignment validation in `webapp/tests/unit/manual-assignments.test.ts`
+- [ ] T027 Implement manual draft persistence service in `webapp/src/services/raster/manualAssignments.ts`
+- [ ] T028 Implement `POST /api/raster/input-sets/[id]/manual-assignments` in `webapp/src/app/api/raster/input-sets/[id]/manual-assignments/route.ts`
+- [ ] T029 Implement `POST /api/raster/manual-assignments/[id]/validate` in `webapp/src/app/api/raster/manual-assignments/[id]/validate/route.ts`
+- [ ] T030 Implement `POST /api/raster/manual-assignments/[id]/score` using shared scoring in `webapp/src/app/api/raster/manual-assignments/[id]/score/route.ts`
+- [ ] T031 Add simple paste/table parser in `webapp/src/lib/raster/manualAssignmentImport.ts`
+- [ ] T032 [P] Unit test paste/table import matching in `webapp/tests/unit/manual-assignment-import.test.ts`
+- [ ] T033 Add visual manual assignment form in `webapp/src/components/raster/manual-assignment-form.tsx`
+- [ ] T034 Wire manual assignment entry into `webapp/src/app/(dashboard)/raster/page.tsx`
+
+**Checkpoint**: Manual plans can be scored and compared with optimizer scenarios.
+
+---
+
+## Phase 6: User Story 4 - Review Scenario Details (Priority: P3)
+
+**Goal**: Admins can drill from comparison into assignments, conflicts, and KPI explanations.
+
+**Independent Test**: Open scenario details from comparison in no more than two interactions.
+
+- [ ] T035 Add scenario details service in `webapp/src/services/raster/scenarioDetails.ts`
+- [ ] T036 Implement `GET /api/raster/scenarios/[id]` in `webapp/src/app/api/raster/scenarios/[id]/route.ts`
+- [ ] T037 Add scenario detail view component in `webapp/src/components/raster/scenario-details.tsx`
+- [ ] T038 Wire scenario detail route or panel in `webapp/src/app/(dashboard)/raster/page.tsx`
+- [ ] T039 [P] Unit test scenario detail route in `webapp/tests/unit/raster-scenario-details-route.test.ts`
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T040 Add stale marker propagation when input set/scoring assumptions change in `webapp/src/services/raster/scenarios.ts`
+- [ ] T041 [P] Add Playwright smoke test for compare + manual score flow in `webapp/tests/e2e/raster-scenarios.spec.ts`
+- [ ] T042 Update `specs/004-compare-raster-runs/quickstart.md` with any implementation-specific route names
+- [ ] T043 Run `pnpm --dir webapp run typecheck` and fix 004 regressions
+- [ ] T044 Run focused unit tests for 004 and root scoring tests
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup and blocks all user stories.
+- **US1 (P1)**: starts after Foundation and is the MVP.
+- **US2 (P2)**: starts after Foundation; integrates with US1 scenario list.
+- **US3 (P2)**: starts after Foundation; integrates with US1 comparison and shared scoring.
+- **US4 (P3)**: starts after US1, then reads details for any scenario origin.
+- **Polish**: after desired stories are complete.
+
+## Parallel Opportunities
+
+- T002 and T003 can run after T001.
+- T009 and T010 can run after T006-T008.
+- T011 and T017 can run while T012-T016 are implemented.
+- T023 and T024 can run while T018-T022 are implemented.
+- T026 and T032 can run while manual assignment routes/UI are implemented.
+
+## Implementation Strategy
+
+1. Ship Foundation + US1 first so existing optimizer runs become comparable.
+2. Add US2 to make strategy choice explicit.
+3. Add US3 to bring colleague/manual plans into the same scoring path.
+4. Add US4 detail drilldown after the comparison table is useful.

--- a/specs/OVERVIEW.md
+++ b/specs/OVERVIEW.md
@@ -1,6 +1,6 @@
 # click-TT Automation Specs Overview
 
-Last Updated: 2026-07-10
+Last Updated: 2026-07-11
 
 Purpose: Track the status of all planned features, their implementation progress, and next steps.
 

--- a/src/raster/ingest/clicktt-assignments.ts
+++ b/src/raster/ingest/clicktt-assignments.ts
@@ -10,6 +10,10 @@ export interface TeamRasterAssignmentRow {
   wishUrl?: string;
 }
 
+export interface TeamRasterAssignmentScrapeOptions {
+  groupNamePattern?: string;
+}
+
 function publicGroupUrl(leaguePageUrl: string, groupId: string): string {
   const url = new URL(leaguePageUrl);
   return `${url.origin}/cgi-bin/WebObjects/nuLigaTTDE.woa/wa/groupPage?${url.searchParams.toString()}&group=${groupId}`;
@@ -73,20 +77,26 @@ export async function scrapePublicLeagueAssignments(
 }
 
 export async function scrapeTeamRasterAssignments(
-  page: Page
+  page: Page,
+  options: TeamRasterAssignmentScrapeOptions = {}
 ): Promise<TeamRasterAssignmentRow[]> {
   await page.getByText("Verstanden", { exact: true }).click().catch(() => undefined);
   await page.getByText("SpielbetriebOrganisation", { exact: false }).click();
   await page.waitForLoadState("domcontentloaded");
 
-  const groups = await page.locator("a").evaluateAll((anchors) =>
-    anchors
-      .map((anchor) => ({
+  const groupPattern = new RegExp(
+    options.groupNamePattern ??
+      "^(?:Bezirksoberliga|\\d+\\.\\s*Bezirksliga|Bezirksklasse|Kreisliga|Kreisklasse|NRW-Liga|Verbandsliga|Landesliga)",
+    "i"
+  );
+  const groups = (
+    await page.locator("a").evaluateAll((anchors) =>
+      anchors.map((anchor) => ({
         group: (anchor.textContent ?? "").replace(/\s+/g, " ").trim(),
         href: anchor.getAttribute("href") ?? ""
       }))
-      .filter((link) => /^(Bezirksoberliga|1\. Bezirksliga)/.test(link.group) && link.href)
-  );
+    )
+  ).filter((link) => groupPattern.test(link.group) && link.href);
 
   const rows: TeamRasterAssignmentRow[] = [];
   for (const group of groups) {

--- a/src/raster/ingest/scrape.ts
+++ b/src/raster/ingest/scrape.ts
@@ -7,6 +7,7 @@ import { assignmentRowsToCsv } from "./assignment-table.js";
 import {
   scrapePublicLeagueAssignments,
   scrapeTeamRasterAssignments,
+  type TeamRasterAssignmentScrapeOptions,
   type TeamRasterAssignmentRow
 } from "./clicktt-assignments.js";
 import { buildSeasonModel, buildSeasonModelFromAssignments } from "./model.js";
@@ -246,7 +247,13 @@ export async function scrapeSeasonModel(
 
 export async function scrapeCurrentTeamRasterAssignments(): Promise<
   TeamRasterAssignmentRow[]
-> {
+>;
+export async function scrapeCurrentTeamRasterAssignments(
+  options: TeamRasterAssignmentScrapeOptions
+): Promise<TeamRasterAssignmentRow[]>;
+export async function scrapeCurrentTeamRasterAssignments(
+  options: TeamRasterAssignmentScrapeOptions = {}
+): Promise<TeamRasterAssignmentRow[]> {
   const config = loadConfig();
   const browser = await chromium.launch({
     headless: !config.headed,
@@ -257,7 +264,26 @@ export async function scrapeCurrentTeamRasterAssignments(): Promise<
 
   try {
     await login(page, config.baseUrl, config.username, config.password);
-    return await scrapeTeamRasterAssignments(page);
+    return await scrapeTeamRasterAssignments(page, options);
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+export async function scrapePublicLeagueAssignmentsFromUrl(
+  leaguePageUrl: string
+): Promise<TeamRasterAssignmentRow[]> {
+  const config = loadConfig();
+  const browser = await chromium.launch({
+    headless: !config.headed,
+    slowMo: config.slowMoMs
+  });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    return await scrapePublicLeagueAssignments(page, leaguePageUrl);
   } finally {
     await context.close();
     await browser.close();

--- a/src/raster/optimize/search.ts
+++ b/src/raster/optimize/search.ts
@@ -1,4 +1,8 @@
 import { evaluate } from "../score/evaluate.js";
+import {
+  numericRasterSize,
+  rasterSizeForGroupSize
+} from "../rulebook/rulebook.js";
 import type {
   Assignment,
   EvaluationResult,
@@ -80,7 +84,11 @@ export function optimize(
         .map((teamId) => best.assignment[teamId])
     );
     const available = Array.from(
-      { length: group.size },
+      {
+        length: numericRasterSize(
+          rasterSizeForGroupSize(group.size, group.rasterMode)
+        )
+      },
       (_, index) => index + 1
     ).filter((value) => !used.has(value));
 

--- a/src/raster/rulebook/rulebook.ts
+++ b/src/raster/rulebook/rulebook.ts
@@ -14,27 +14,28 @@ import type {
 
 const supportedSizes = [6, "6d", 8, 10, 12, 14] as const;
 
+export function numericRasterSize(size: RasterSize): number {
+  return size === "6d" ? 6 : size;
+}
+
 export function rasterSizeForGroupSize(
   size: number,
   mode: RasterMode = "single"
 ): RasterSize {
+  if (size === 5) return 6;
   if (size === 6) return mode === "double" ? "6d" : 6;
   if (size === 7 || size === 8) return 8;
   if (size === 9 || size === 10) return 10;
   if (size === 11 || size === 12) return 12;
   if (size === 13 || size === 14) return 14;
   throw new Error(
-    `Unsupported group size ${size}; supported district sizes are 6..14.`
+    `Unsupported group size ${size}; supported district sizes are 5..14.`
   );
 }
 
 export function pairKey(a: number, b: number): PairKey {
   const [left, right] = a < b ? [a, b] : [b, a];
   return `${left}-${right}`;
-}
-
-function numericRasterSize(size: RasterSize): number {
-  return size === "6d" ? 6 : size;
 }
 
 function circlePairs(size: RasterSize): Pairing[][] {
@@ -114,9 +115,9 @@ export function deriveRaster(size: RasterSize): DerivedRaster {
 export function homeWeeks(
   size: RasterSize,
   rasterzahl: number,
-  groupSize: number = numericRasterSize(size)
+  groupSize: number = numericRasterSize(size),
+  bye: number | null = groupSize % 2 === 1 ? numericRasterSize(size) : null
 ): number[] {
-  const bye = groupSize % 2 === 1 ? numericRasterSize(size) : null;
   if (rasterzahl === bye) return [];
 
   const weeks: number[] = [];

--- a/src/raster/score/derive.ts
+++ b/src/raster/score/derive.ts
@@ -1,17 +1,48 @@
-import { homeWeeks, rasterSizeForGroupSize } from "../rulebook/rulebook.js";
-import type { RasterMode, RasterSize, WeekSlot } from "../types.js";
+import {
+  homeWeeks,
+  numericRasterSize,
+  rasterSizeForGroupSize
+} from "../rulebook/rulebook.js";
+import type {
+  Assignment,
+  RasterMode,
+  RasterSize,
+  SeasonModel,
+  WeekSlot
+} from "../types.js";
 
 export function deriveHomeWeeks(
   groupSize: number,
   rasterzahl: number,
-  mode: RasterMode = "single"
+  mode: RasterMode = "single",
+  bye?: number | null
 ): { rasterSize: RasterSize; weeks: number[]; slot: WeekSlot } {
   const rasterSize = rasterSizeForGroupSize(groupSize, mode);
-  const weeks = homeWeeks(rasterSize, rasterzahl, groupSize);
+  const weeks = homeWeeks(rasterSize, rasterzahl, groupSize, bye);
   const oddWeeks = weeks.filter((week) => week % 2 === 1).length;
   return {
     rasterSize,
     weeks,
     slot: oddWeeks >= weeks.length - oddWeeks ? "A" : "B"
   };
+}
+
+export function unusedRasterzahl(
+  group: SeasonModel["groups"][number],
+  assignment: Assignment
+): number | null {
+  if (group.size % 2 === 0) return null;
+  const maxRasterzahl = numericRasterSize(
+    rasterSizeForGroupSize(group.size, group.rasterMode)
+  );
+  const used = new Set(
+    group.teamIds
+      .map((teamId) => assignment[teamId])
+      .filter((value): value is number => value !== undefined)
+  );
+  return (
+    Array.from({ length: maxRasterzahl }, (_, index) => index + 1).find(
+      (value) => !used.has(value)
+    ) ?? null
+  );
 }

--- a/src/raster/score/evaluate.ts
+++ b/src/raster/score/evaluate.ts
@@ -1,5 +1,9 @@
-import { derbySpieltag, rasterSizeForGroupSize } from "../rulebook/rulebook.js";
-import { deriveHomeWeeks } from "./derive.js";
+import {
+  derbySpieltag,
+  numericRasterSize,
+  rasterSizeForGroupSize
+} from "../rulebook/rulebook.js";
+import { deriveHomeWeeks, unusedRasterzahl } from "./derive.js";
 import { evaluateWishes, findOverUsages } from "./penalties.js";
 import type {
   Assignment,
@@ -47,18 +51,25 @@ export function evaluate(
 
   for (const group of model.groups) {
     const rasterSize = rasterSizeForGroupSize(group.size, group.rasterMode);
+    const maxRasterzahl = numericRasterSize(rasterSize);
     const values = group.teamIds.map((teamId) => assignment[teamId]);
     const assignedValues = values.filter(
       (value): value is number => value !== undefined
     );
+    const bye =
+      group.size % 2 === 1
+        ? Array.from({ length: maxRasterzahl }, (_, index) => index + 1).find(
+            (value) => !assignedValues.includes(value)
+          )
+        : null;
     const valid =
       assignedValues.length === values.length &&
       new Set(assignedValues).size === assignedValues.length &&
-      assignedValues.every((value) => value >= 1 && value <= group.size);
+      assignedValues.every((value) => value >= 1 && value <= maxRasterzahl);
     if (!valid)
       hardViolations.push({
         kind: "permutation",
-        detail: `${group.ref.league} ${group.ref.name} is not a valid 1..${group.size} permutation`
+        detail: `${group.ref.league} ${group.ref.name} is not a valid 1..${maxRasterzahl} permutation`
       });
     perGroup.push({
       group: group.ref,
@@ -77,6 +88,7 @@ export function evaluate(
         const rightRz = assignment[rightId];
         if (!right || rightRz === undefined || left.clubId !== right.clubId)
           continue;
+        if (leftRz === bye || rightRz === bye) continue;
         const spieltag = derbySpieltag(rasterSize, leftRz, rightRz);
         if (spieltag !== undefined && spieltag > 4)
           hardViolations.push({
@@ -115,7 +127,8 @@ export function evaluate(
     );
     const rz = assignment[team.id];
     if (!group || rz === undefined) return [];
-    const got = deriveHomeWeeks(group.size, rz, group.rasterMode).slot;
+    const bye = unusedRasterzahl(group, assignment);
+    const got = deriveHomeWeeks(group.size, rz, group.rasterMode, bye).slot;
     return got === team.spielwochePref
       ? []
       : [{ teamId: team.id, want: team.spielwochePref, got }];

--- a/src/raster/score/penalties.ts
+++ b/src/raster/score/penalties.ts
@@ -1,5 +1,5 @@
 import { relation } from "../rulebook/rulebook.js";
-import { deriveHomeWeeks } from "./derive.js";
+import { deriveHomeWeeks, unusedRasterzahl } from "./derive.js";
 import type {
   Assignment,
   OverUsage,
@@ -44,7 +44,8 @@ export function findOverUsages(
     );
     const capacity = venue?.capacityByWeekday?.[team.homeWeekday] ?? venue?.capacity ?? (inferredCapacity || undefined);
     if (capacity === undefined) continue;
-    for (const week of new Set(deriveHomeWeeks(group.size, rz, group.rasterMode).weeks)) {
+    const bye = unusedRasterzahl(group, assignment);
+    for (const week of new Set(deriveHomeWeeks(group.size, rz, group.rasterMode, bye).weeks)) {
       const key = `${team.clubId}|${team.hall}|${team.homeWeekday}|${week}`;
       const bucket = slots.get(key) ?? { teams: [], capacity };
       bucket.teams.push(team.id);
@@ -90,12 +91,14 @@ export function evaluateWishes(
     const rzB = assigned(teamB.id, assignment, model);
     if (!groupA || !groupB || rzA === undefined || rzB === undefined)
       return { wish, status: "unknown", reason: "missing group or assignment" };
-    const actual = relation(
-      deriveHomeWeeks(groupA.size, rzA, groupA.rasterMode).rasterSize,
-      rzA,
-      deriveHomeWeeks(groupB.size, rzB, groupB.rasterMode).rasterSize,
-      rzB
-    );
+    const byeA = unusedRasterzahl(groupA, assignment);
+    const byeB = unusedRasterzahl(groupB, assignment);
+    const derivedA = deriveHomeWeeks(groupA.size, rzA, groupA.rasterMode, byeA);
+    const derivedB = deriveHomeWeeks(groupB.size, rzB, groupB.rasterMode, byeB);
+    const actual =
+      byeA !== null || byeB !== null
+        ? relationFromWeeks(derivedA.weeks, derivedB.weeks)
+        : relation(derivedA.rasterSize, rzA, derivedB.rasterSize, rzB);
     if (actual === wish.relation) return { wish, status: "fulfilled" };
     return {
       wish,
@@ -103,4 +106,16 @@ export function evaluateWishes(
       reason: `expected ${wish.relation}, got ${actual}`
     };
   });
+}
+
+function relationFromWeeks(
+  weeksA: number[],
+  weeksB: number[]
+): "wechsel" | "zeitgleich" | "neither" {
+  const a = new Set(weeksA);
+  const b = new Set(weeksB);
+  const overlap = [...a].filter((week) => b.has(week)).length;
+  if (overlap === 0) return "wechsel";
+  if (overlap === Math.min(a.size, b.size)) return "zeitgleich";
+  return "neither";
 }

--- a/tests/unit/cpsat-solver.test.ts
+++ b/tests/unit/cpsat-solver.test.ts
@@ -162,6 +162,40 @@ function fixedSt4DerbyModel(): SeasonModel {
   };
 }
 
+function fiveTeamModelWithFixedSix(): SeasonModel {
+  const teams = Array.from({ length: 5 }, (_, index) => ({
+    id: `team-${index + 1}`,
+    clubId: `club-${index + 1}`,
+    label: `Team ${index + 1}`,
+    homeWeekday: "friday" as const,
+    hall: "1",
+    rasterzahl:
+      index === 0
+        ? ({ kind: "fixed", value: 6 } as const)
+        : ({ kind: "assignable" } as const),
+    confidence: "ok" as const
+  }));
+  return {
+    clubs: teams.map((team) => ({
+      id: team.clubId,
+      name: team.clubId,
+      venues: [],
+      notes: ""
+    })),
+    teams,
+    groups: [
+      {
+        ref: { league: "L", name: "G5" },
+        size: 5,
+        teamIds: teams.map((team) => team.id)
+      }
+    ],
+    wishes: [],
+    absoluteConstraints: [],
+    warnings: []
+  };
+}
+
 describe("CP-SAT raster solver", () => {
   it("finds a known optimum across multiple groups and hall constraints", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "raster-cpsat-"));
@@ -197,6 +231,43 @@ describe("CP-SAT raster solver", () => {
       expect(metadata.status).toBe("OPTIMAL");
       expect(assignment).toEqual(knownAssignment);
       expect(evaluate(model, assignment).objective).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 120_000);
+
+  it("allows a 5-team group to use schedule number 6", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "raster-cpsat-"));
+    try {
+      const model = fiveTeamModelWithFixedSix();
+      const modelPath = path.join(dir, "model.json");
+      const outPath = path.join(dir, "assignment.json");
+      const metadataPath = path.join(dir, "metadata.json");
+      await writeFile(modelPath, JSON.stringify(model), "utf8");
+
+      await execFileAsync(
+        "uv",
+        [
+          "run",
+          "--python",
+          "3.12",
+          "scripts/solve-raster-cpsat.py",
+          "--model",
+          modelPath,
+          "--out",
+          outPath,
+          "--metadata",
+          metadataPath,
+          "--time-limit",
+          "30"
+        ],
+        { cwd: process.cwd(), timeout: 120_000 }
+      );
+
+      const assignment = JSON.parse(await readFile(outPath, "utf8")) as Assignment;
+
+      expect(assignment["team-1"]).toBe(6);
+      expect(evaluate(model, assignment).hardViolations).toHaveLength(0);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/unit/evaluate.test.ts
+++ b/tests/unit/evaluate.test.ts
@@ -19,9 +19,19 @@ describe("raster evaluation", () => {
     const baseModel = fixture.model as unknown as SeasonModel;
     const model = {
       ...baseModel,
-      groups: [{ ref: { league: "L", name: "Bad" }, size: 5, teamIds: ["a", "b"] }]
+      groups: [{ ref: { league: "L", name: "Bad" }, size: 4, teamIds: ["a", "b"] }]
     };
     expect(() => evaluate(model, fixture.assignment)).toThrow(/Unsupported group size/);
+  });
+
+  it("accepts a 5-team group as a 6er raster with any unused slot", () => {
+    const baseModel = fixture.model as unknown as SeasonModel;
+    const model = {
+      ...baseModel,
+      groups: [{ ref: { league: "L", name: "G5" }, size: 5, teamIds: ["a", "b"] }]
+    };
+    expect(() => evaluate(model, { a: 1, b: 2 })).not.toThrow();
+    expect(evaluate(model, { a: 5, b: 6 }).hardViolations).toHaveLength(0);
   });
 
   it("reports Spielwoche misses without default penalty", () => {

--- a/webapp/next-env.d.ts
+++ b/webapp/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,6 +23,7 @@
     "quality:ts": "pnpm run lint && pnpm run architecture && pnpm run duplication",
     "quality:python": "node scripts/check-python-quality.mjs",
     "quality:cli": "node scripts/check-cli-quality.mjs",
+    "worker:dev": "cd worker && uv run starter-worker",
     "check:text": "node scripts/check-text-conventions.mjs",
     "logging:guard": "node scripts/check-logging-guard.mjs",
     "smoke:azure": "node scripts/run-azure-deploy-smoke.mjs",

--- a/webapp/prisma/migrations-postgres/20260711160000_add_raster_season/migration.sql
+++ b/webapp/prisma/migrations-postgres/20260711160000_add_raster_season/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "RasterSource" ADD COLUMN "season" TEXT NOT NULL DEFAULT '2026/27';
+ALTER TABLE "RasterInputSet" ADD COLUMN "season" TEXT NOT NULL DEFAULT '2026/27';
+
+DROP INDEX "RasterSource_scopeId_sourceType_idx";
+DROP INDEX "RasterSource_scopeId_sourceType_sourceRef_key";
+DROP INDEX "RasterInputSet_district_createdAt_idx";
+
+CREATE UNIQUE INDEX "RasterSource_scopeId_season_sourceType_sourceRef_key" ON "RasterSource"("scopeId", "season", "sourceType", "sourceRef");
+CREATE INDEX "RasterSource_scopeId_season_sourceType_idx" ON "RasterSource"("scopeId", "season", "sourceType");
+CREATE INDEX "RasterInputSet_district_season_createdAt_idx" ON "RasterInputSet"("district", "season", "createdAt");

--- a/webapp/prisma/schema.postgres.prisma
+++ b/webapp/prisma/schema.postgres.prisma
@@ -284,6 +284,7 @@ model Scope {
 model RasterSource {
   id          String   @id @default(cuid())
   scopeId     String
+  season      String   @default("2026/27")
   sourceType  String
   sourceRef   String
   displayName String
@@ -293,8 +294,8 @@ model RasterSource {
   updatedAt   DateTime @updatedAt
   scope       Scope    @relation(fields: [scopeId], references: [id], onDelete: Cascade)
 
-  @@unique([scopeId, sourceType, sourceRef])
-  @@index([scopeId, sourceType])
+  @@unique([scopeId, season, sourceType, sourceRef])
+  @@index([scopeId, season, sourceType])
 }
 
 model UserScopeAssignment {
@@ -575,6 +576,7 @@ model RasterInputSet {
   id                  String                  @id @default(cuid())
   name                String
   district            String
+  season              String                  @default("2026/27")
   createdById         String
   createdAt           DateTime                @default(now())
   status              InputSetStatus          @default(DRAFT)
@@ -586,7 +588,7 @@ model RasterInputSet {
   fixedRasterzahlen   RasterFixedRasterzahl[]
   runs                RasterOptimizationRun[]
 
-  @@index([district, createdAt])
+  @@index([district, season, createdAt])
   @@index([createdById])
 }
 

--- a/webapp/prisma/seed.ts
+++ b/webapp/prisma/seed.ts
@@ -50,6 +50,58 @@ const demoRasterUsers = [
   },
 ] as const;
 
+const wttvDistricts = [
+  ["NIEDERRHEIN", "Niederrhein"],
+  ["RHEIN_RUHR", "Rhein-Ruhr"],
+  ["RHEIN_WUPPER", "Rhein-Wupper"],
+  ["KOELN", "Köln"],
+  ["RHEIN_ERFT_SIEG", "Rhein-Erft-Sieg"],
+  ["AACHEN_EUREGIO", "Aachen/Euregio"],
+  ["MUENSTERLAND", "Münsterland"],
+  ["MUENSTERLAND_HOHE_MARK", "Münsterland/Hohe Mark"],
+  ["OSTWESTFALEN_NORD", "Ostwestfalen-Nord"],
+  ["OWL", "Ostwestfalen/Lippe"],
+  ["MITTLERES_RUHRGEBIET", "Mittleres Ruhrgebiet"],
+  ["WESTFALEN_MITTE", "Westfalen-Mitte"],
+  ["SUEDWESTFALEN", "Südwestfalen"],
+] as const;
+
+async function seedRasterScopes() {
+  const germanyScope = await prisma.scope.upsert({
+    where: { code: "DE" },
+    update: { name: "Germany", parentId: null },
+    create: { code: "DE", name: "Germany" },
+  });
+  const wttvScope = await prisma.scope.upsert({
+    where: { code: "WTTV" },
+    update: {
+      name: "Westdeutscher Tischtennis-Verband",
+      parentId: germanyScope.id,
+    },
+    create: {
+      code: "WTTV",
+      name: "Westdeutscher Tischtennis-Verband",
+      parentId: germanyScope.id,
+    },
+  });
+
+  const districts = await Promise.all(
+    wttvDistricts.map(([code, name]) =>
+      prisma.scope.upsert({
+        where: { code },
+        update: { name, parentId: wttvScope.id },
+        create: { code, name, parentId: wttvScope.id },
+      }),
+    ),
+  );
+
+  return {
+    germanyScope,
+    wttvScope,
+    demoScope: districts.find((scope) => scope.code === "OWL") ?? districts[0],
+  };
+}
+
 async function main() {
   const rawEmail = process.env.INITIAL_ADMIN_EMAIL;
   const password = process.env.INITIAL_ADMIN_PASSWORD;
@@ -73,6 +125,7 @@ async function main() {
     );
   }
 
+  const { demoScope } = await seedRasterScopes();
   const existingCount = await prisma.user.count();
 
   if (existingCount > 0) {
@@ -113,27 +166,6 @@ async function main() {
     },
   });
 
-  const germanyScope = await prisma.scope.create({
-    data: {
-      code: "DE",
-      name: "Germany",
-    },
-  });
-  const wttvScope = await prisma.scope.create({
-    data: {
-      code: "WTTV",
-      name: "Westdeutscher Tischtennis-Verband",
-      parentId: germanyScope.id,
-    },
-  });
-  const demoScope = await prisma.scope.create({
-    data: {
-      code: "OWL",
-      name: "Ostwestfalen-Lippe",
-      parentId: wttvScope.id,
-    },
-  });
-
   for (const demoUser of demoRasterUsers) {
     await prisma.user.create({
       data: {
@@ -163,7 +195,7 @@ async function main() {
   }
 
   console.log(`Seeded initial admin user ${email}.`);
-  console.log("Seeded demo Raster hierarchy DE > WTTV > OWL and review users.");
+  console.log("Seeded WTTV Raster districts and review users.");
 }
 
 main()

--- a/webapp/src/app/(dashboard)/raster/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/page.tsx
@@ -1,9 +1,22 @@
 import { requireSession } from "@/lib/auth";
-import { assertRasterAccess } from "@/lib/raster/access";
+import {
+  assertRasterAccess,
+  listAccessibleRasterScopes,
+  rasterScopePath,
+} from "@/lib/raster/access";
+import {
+  normalizeRasterSeason,
+  rasterSeasonOptions,
+} from "@/lib/raster/season";
 import {
   GroupModeReview,
   type GroupModeReviewRow,
 } from "@/components/raster/group-mode-review";
+import {
+  CreateInputSetForm,
+  FixedScheduleNumbersForm,
+  InputSetRunActions,
+} from "@/components/raster/input-set-actions";
 import { RasterSourcesPanel } from "@/components/raster/sources/raster-sources-panel";
 import { Role } from "../../../../generated/prisma/enums";
 import { listInputSets, listRasterSourcesForDistrict } from "@/services/raster";
@@ -18,10 +31,22 @@ type SeasonGroup = {
 export default async function RasterPage({
   searchParams,
 }: {
-  searchParams: Promise<{ district?: string }>;
+  searchParams: Promise<{ district?: string; season?: string }>;
 }) {
   const user = await requireSession();
-  const district = (await searchParams).district?.trim() || "OWL";
+  const scopes = await listAccessibleRasterScopes(user);
+  const params = await searchParams;
+  const district = params.district?.trim() || scopes[0]?.code;
+  const season = normalizeRasterSeason(params.season);
+
+  if (!district) {
+    return (
+      <div className="rounded-lg border border-[var(--border)] px-4 py-6 text-sm text-[var(--muted-foreground)]">
+        No Raster districts are configured for your account.
+      </div>
+    );
+  }
+
   const access = await assertRasterAccess(user, district, "viewer");
 
   if (access !== true) {
@@ -33,8 +58,8 @@ export default async function RasterPage({
   }
 
   const [inputSets, sources] = await Promise.all([
-    listInputSets(district),
-    listRasterSourcesForDistrict(district),
+    listInputSets(district, season),
+    listRasterSourcesForDistrict(district, season),
   ]);
 
   return (
@@ -46,15 +71,66 @@ export default async function RasterPage({
         <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-tight sm:text-5xl">
           Raster
         </h1>
+        <form className="mt-5 flex max-w-xl gap-2" action="/raster">
+          <label className="grid flex-1 gap-1 text-sm font-medium">
+            District
+            <select
+              className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+              defaultValue={district}
+              name="district"
+            >
+              {scopes.map((scope) => (
+                <option key={scope.code} value={scope.code}>
+                  {rasterScopePath(scope)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid w-36 gap-1 text-sm font-medium">
+            Season
+            <select
+              className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+              defaultValue={season}
+              name="season"
+            >
+              {rasterSeasonOptions().map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            className="mt-6 h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
+            type="submit"
+          >
+            Open
+          </button>
+        </form>
       </section>
 
       <RasterSourcesPanel
         canEdit={user.role === Role.PLATFORM_ADMIN}
         district={district}
+        season={season}
+        scopes={scopes}
         sources={sources}
       />
 
       <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
+        <div className="border-b border-[var(--border)] px-4 py-3">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+            Input sets
+          </h2>
+          <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+            Fixed Rasterzahlen are optional. You can run a full {district}{" "}
+            {season} plan without fixing any team; the optimizer will assign
+            Rasterzahlen.
+          </p>
+        </div>
+        {user.role === Role.PLATFORM_ADMIN ? (
+          <CreateInputSetForm district={district} season={season} />
+        ) : null}
         <div className="grid grid-cols-[minmax(12rem,1fr)_8rem_8rem_8rem] gap-3 border-b border-[var(--border)] px-4 py-3 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
           <span>Name</span>
           <span>Status</span>
@@ -67,6 +143,7 @@ export default async function RasterPage({
               inputSet.id,
               inputSet.seasonModelJson,
             );
+            const warnings = extractModelWarnings(inputSet.seasonModelJson);
             return (
               <div
                 key={inputSet.id}
@@ -78,7 +155,21 @@ export default async function RasterPage({
                   <span>{inputSet._count.wishes}</span>
                   <span>{inputSet._count.runs}</span>
                 </div>
+                {user.role === Role.PLATFORM_ADMIN ? (
+                  <FixedScheduleNumbersForm
+                    inputSetId={inputSet.id}
+                    rows={inputSet.fixedRasterzahlen}
+                  />
+                ) : null}
+                <ModelWarnings warnings={warnings} />
                 <GroupModeReview groups={sixTeamGroups} />
+                {user.role === Role.PLATFORM_ADMIN ? (
+                  <InputSetRunActions
+                    inputSetId={inputSet.id}
+                    runs={inputSet.runs}
+                    status={inputSet.status}
+                  />
+                ) : null}
               </div>
             );
           })
@@ -90,6 +181,34 @@ export default async function RasterPage({
       </section>
     </div>
   );
+}
+
+function ModelWarnings({ warnings }: { warnings: string[] }) {
+  if (!warnings.length) return null;
+  return (
+    <details className="mt-3 border-t border-[var(--border)] pt-3 text-sm">
+      <summary className="cursor-pointer font-medium">
+        Model warnings ({warnings.length})
+      </summary>
+      <ul className="mt-2 list-disc space-y-1 pl-5 text-[var(--muted-foreground)]">
+        {warnings.map((warning) => (
+          <li key={warning}>{warning}</li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+function extractModelWarnings(seasonModelJson: string | null): string[] {
+  if (!seasonModelJson) return [];
+  try {
+    const parsed = JSON.parse(seasonModelJson) as { warnings?: unknown[] };
+    return (parsed.warnings ?? []).filter(
+      (warning): warning is string => typeof warning === "string",
+    );
+  } catch {
+    return [];
+  }
 }
 
 function extractSixTeamGroups(

--- a/webapp/src/app/(dashboard)/raster/snapshots/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/snapshots/[id]/page.tsx
@@ -1,0 +1,137 @@
+import { notFound } from "next/navigation";
+import { requireSession } from "@/lib/auth";
+import { assertRasterAccess } from "@/lib/raster/access";
+import {
+  getSnapshot,
+  listSnapshotAssignments,
+  listSnapshotConflicts,
+  summarizeSnapshotConflicts,
+} from "@/services/raster";
+import { AssignmentTable } from "@/components/raster/assignments/assignment-table";
+
+export default async function RasterSnapshotPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const user = await requireSession();
+  const snapshot = await getSnapshot((await params).id);
+  if (!snapshot) notFound();
+
+  const access = await assertRasterAccess(user, snapshot.district, "viewer");
+  if (access !== true) {
+    return (
+      <div className="rounded-lg border border-[var(--border)] px-4 py-6 text-sm text-[var(--muted-foreground)]">
+        You are not authorized to view this snapshot.
+      </div>
+    );
+  }
+
+  const [assignments, conflicts, topClubs] = await Promise.all([
+    listSnapshotAssignments(snapshot.id),
+    listSnapshotConflicts(snapshot.id),
+    summarizeSnapshotConflicts(snapshot.id),
+  ]);
+
+  return (
+    <div className="space-y-7">
+      <section>
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-[var(--muted-foreground)]">
+          {snapshot.district}
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-tight sm:text-5xl">
+          Raster results
+        </h1>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        <Metric label="Optimality" value={snapshot.optimality} />
+        <Metric label="Conflicts" value={snapshot.totalConflicts} />
+        <Metric label="Total excess" value={snapshot.totalExcess} />
+        <Metric label="Max excess" value={snapshot.maxExcess} />
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
+        <div className="border-b border-[var(--border)] px-4 py-3">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+            Top clubs
+          </h2>
+        </div>
+        {topClubs.length ? (
+          topClubs.slice(0, 10).map((club) => (
+            <div
+              className="grid grid-cols-[minmax(12rem,1fr)_6rem_6rem] gap-3 border-b border-[var(--border)] px-4 py-3 text-sm last:border-b-0"
+              key={club.clubId}
+            >
+              <span className="font-medium">{club.clubName}</span>
+              <span>{club.rows} rows</span>
+              <span>{club.excess} excess</span>
+            </div>
+          ))
+        ) : (
+          <p className="px-4 py-6 text-sm text-[var(--muted-foreground)]">
+            No conflict summary.
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+          Assignments
+        </h2>
+        <AssignmentTable
+          assignments={assignments.map((assignment) => ({
+            id: assignment.id,
+            league: assignment.league,
+            group: assignment.group,
+            clubName: assignment.clubName,
+            team: assignment.team,
+            rasterzahl: assignment.rasterzahl,
+            status: assignment.status,
+            weekday: assignment.weekday,
+            hall: assignment.hall,
+            startTime: assignment.startTime,
+            weekSlot: assignment.weekSlot,
+          }))}
+        />
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
+        <div className="border-b border-[var(--border)] px-4 py-3">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+            Conflicts
+          </h2>
+        </div>
+        {conflicts.length ? (
+          conflicts.map((conflict) => (
+            <div
+              className="grid gap-2 border-b border-[var(--border)] px-4 py-3 text-sm last:border-b-0 md:grid-cols-[minmax(10rem,1fr)_5rem_7rem_5rem_minmax(10rem,1fr)]"
+              key={conflict.id}
+            >
+              <span className="font-medium">{conflict.clubName}</span>
+              <span>W{conflict.matchWeek}</span>
+              <span>{conflict.weekday}</span>
+              <span>+{conflict.excess}</span>
+              <span>{conflict.teams}</span>
+            </div>
+          ))
+        ) : (
+          <p className="px-4 py-6 text-sm text-[var(--muted-foreground)]">
+            No conflicts.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--panel)] px-4 py-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+        {label}
+      </p>
+      <p className="mt-2 text-xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/webapp/src/app/api/raster/input-sets/route.ts
+++ b/webapp/src/app/api/raster/input-sets/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { requireApiUser } from "@/lib/route-auth";
 import { assertRasterAccess } from "@/lib/raster/access";
+import { normalizeRasterSeason } from "@/lib/raster/season";
 import { createInputSet, listInputSets } from "@/services/raster";
 import { z } from "zod";
 
 const createInputSetBodySchema = z.object({
   district: z.string().trim().min(1),
+  season: z.string().trim().optional(),
   name: z.string().trim().min(1),
 });
 
@@ -14,6 +16,9 @@ export async function GET(request: Request) {
   if ("error" in auth) return auth.error;
 
   const district = new URL(request.url).searchParams.get("district")?.trim();
+  const season = normalizeRasterSeason(
+    new URL(request.url).searchParams.get("season"),
+  );
   if (!district) {
     return NextResponse.json(
       { error: "district is required" },
@@ -24,7 +29,9 @@ export async function GET(request: Request) {
   const access = await assertRasterAccess(auth.user, district, "viewer");
   if (access !== true) return access.error;
 
-  return NextResponse.json({ inputSets: await listInputSets(district) });
+  return NextResponse.json({
+    inputSets: await listInputSets(district, season),
+  });
 }
 
 export async function POST(request: Request) {
@@ -50,6 +57,7 @@ export async function POST(request: Request) {
 
   const inputSet = await createInputSet({
     ...parsed.data,
+    season: normalizeRasterSeason(parsed.data.season),
     createdById: auth.user.id,
   });
 

--- a/webapp/src/app/api/raster/sources/[id]/refresh/route.ts
+++ b/webapp/src/app/api/raster/sources/[id]/refresh/route.ts
@@ -23,8 +23,10 @@ export async function POST(
   if (access !== true) return access.error;
 
   try {
+    const refreshed = await refreshRasterSource(source.id);
     return NextResponse.json({
-      source: await refreshRasterSource(source.id),
+      source: refreshed,
+      summary: summarizeParsedSource(refreshed?.parsedJson),
     });
   } catch (error) {
     return NextResponse.json(
@@ -35,4 +37,31 @@ export async function POST(
       { status: 422 },
     );
   }
+}
+
+function summarizeParsedSource(parsedJson?: string | null) {
+  if (!parsedJson) return "No parsed data";
+  let parsed: {
+    assignments?: unknown[];
+    clubs?: unknown[];
+    teams?: unknown[];
+    wishes?: unknown[];
+  };
+  try {
+    parsed = JSON.parse(parsedJson) as typeof parsed;
+  } catch {
+    return "Parsed data saved";
+  }
+  const parts = [
+    countLabel(parsed.assignments, "assignment"),
+    countLabel(parsed.clubs, "club"),
+    countLabel(parsed.teams, "team"),
+    countLabel(parsed.wishes, "wish"),
+  ].filter(Boolean);
+  return parts.length ? `Parsed ${parts.join(", ")}` : "Parsed data saved";
+}
+
+function countLabel(rows: unknown[] | undefined, label: string) {
+  if (!rows?.length) return null;
+  return `${rows.length} ${label}${rows.length === 1 ? "" : "s"}`;
 }

--- a/webapp/src/app/api/raster/sources/[id]/route.ts
+++ b/webapp/src/app/api/raster/sources/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { requireApiUser } from "@/lib/route-auth";
+import { assertRasterAccess } from "@/lib/raster/access";
+import { prisma } from "@/lib/db";
+import { deleteRasterSource } from "@/services/raster";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireApiUser(request);
+  if ("error" in auth) return auth.error;
+
+  const source = await prisma.rasterSource.findUnique({
+    where: { id: (await params).id },
+    include: { scope: true },
+  });
+  if (!source) {
+    return NextResponse.json({ error: "Source not found" }, { status: 404 });
+  }
+
+  const access = await assertRasterAccess(auth.user, source.scope.code, "admin");
+  if (access !== true) return access.error;
+
+  await deleteRasterSource(source.id);
+  return NextResponse.json({ ok: true });
+}

--- a/webapp/src/app/api/raster/sources/route.ts
+++ b/webapp/src/app/api/raster/sources/route.ts
@@ -2,11 +2,13 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireApiUser } from "@/lib/route-auth";
 import { assertRasterAccess } from "@/lib/raster/access";
+import { normalizeRasterSeason } from "@/lib/raster/season";
 import { prisma } from "@/lib/db";
 import { listRasterSourcesForDistrict, upsertRasterSource } from "@/services/raster";
 
 const sourceBodySchema = z.object({
   scopeCode: z.string().trim().min(1),
+  season: z.string().trim().optional(),
   sourceType: z.string().trim().min(1),
   sourceRef: z.string().trim().min(1),
   displayName: z.string().trim().min(1),
@@ -20,6 +22,7 @@ export async function GET(request: Request) {
 
   const search = new URL(request.url).searchParams;
   const district = search.get("district")?.trim();
+  const season = normalizeRasterSeason(search.get("season"));
   if (!district) {
     return NextResponse.json(
       { error: "district is required" },
@@ -33,6 +36,7 @@ export async function GET(request: Request) {
   return NextResponse.json({
     sources: await listRasterSourcesForDistrict(
       district,
+      season,
       search.get("sourceType")?.trim() || undefined,
     ),
   });
@@ -66,6 +70,7 @@ export async function POST(request: Request) {
     {
       source: await upsertRasterSource({
         scopeId: scope.id,
+        season: normalizeRasterSeason(parsed.data.season),
         sourceType: parsed.data.sourceType,
         sourceRef: parsed.data.sourceRef,
         displayName: parsed.data.displayName,

--- a/webapp/src/app/api/raster/sources/upload/route.ts
+++ b/webapp/src/app/api/raster/sources/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireApiUser } from "@/lib/route-auth";
 import { assertRasterAccess } from "@/lib/raster/access";
+import { normalizeRasterSeason } from "@/lib/raster/season";
 import { prisma } from "@/lib/db";
 import { saveFile } from "@/lib/file-storage";
 import { upsertRasterSource } from "@/services/raster";
@@ -11,10 +12,13 @@ export async function POST(request: Request) {
 
   const formData = await request.formData();
   const scopeCode = String(formData.get("scopeCode") ?? "").trim();
+  const season = normalizeRasterSeason(String(formData.get("season") ?? ""));
   const sourceType = String(formData.get("sourceType") ?? "").trim();
   const displayName = String(formData.get("displayName") ?? "").trim();
-  const file = formData.get("file");
-  if (!scopeCode || !sourceType || !displayName || !(file instanceof File)) {
+  const files = formData
+    .getAll("file")
+    .filter((file): file is File => file instanceof File && file.size > 0);
+  if (!scopeCode || !sourceType || files.length === 0) {
     return NextResponse.json({ error: "Invalid source upload" }, { status: 422 });
   }
 
@@ -29,19 +33,43 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Scope not found" }, { status: 404 });
   }
 
-  const sourceRef = await saveFile(
-    Buffer.from(await file.arrayBuffer()),
-    file.name || "source.bin",
-  );
-  return NextResponse.json(
-    {
-      source: await upsertRasterSource({
+  const sources = [];
+  for (const file of files) {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const expectedPdf = sourceType.toUpperCase().endsWith("_PDF");
+    if (expectedPdf && !isPdf(buffer)) {
+      return NextResponse.json(
+        { error: `${file.name || "Uploaded file"} is not a PDF.` },
+        { status: 422 },
+      );
+    }
+    const sourceRef = await saveFile(buffer, file.name || "source.bin");
+    sources.push(
+      await upsertRasterSource({
         scopeId: scope.id,
+        season,
         sourceType,
         sourceRef,
-        displayName,
+        displayName: sourceDisplayName(displayName, file, files.length),
       }),
+    );
+  }
+
+  return NextResponse.json(
+    {
+      source: sources[0],
+      sources,
     },
     { status: 201 },
   );
+}
+
+function sourceDisplayName(displayName: string, file: File, fileCount: number) {
+  if (displayName && fileCount === 1) return displayName;
+  if (displayName) return `${displayName} - ${file.name || "source"}`;
+  return file.name || "Uploaded source";
+}
+
+function isPdf(buffer: Buffer) {
+  return buffer.subarray(0, 5).toString("ascii") === "%PDF-";
 }

--- a/webapp/src/components/raster/group-mode-review.tsx
+++ b/webapp/src/components/raster/group-mode-review.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { withBasePath } from "@/lib/base-path";
 
 export type GroupModeReviewRow = {
@@ -14,12 +14,30 @@ export type GroupModeReviewRow = {
 export function GroupModeReview({ groups }: { groups: GroupModeReviewRow[] }) {
   const router = useRouter();
   const [savingId, setSavingId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<Record<string, string>>({});
+  const [values, setValues] = useState<Record<string, "single" | "double" | "">>(
+    {},
+  );
 
-  async function save(
-    group: GroupModeReviewRow,
-    rasterMode: "single" | "double",
-  ) {
+  useEffect(() => {
+    setValues(
+      Object.fromEntries(
+        groups.map((group) => [group.groupId, group.rasterMode ?? ""]),
+      ),
+    );
+  }, [groups]);
+
+  async function save(group: GroupModeReviewRow) {
+    const rasterMode = values[group.groupId];
+    if (rasterMode !== "single" && rasterMode !== "double") {
+      setMessages((current) => ({
+        ...current,
+        [group.groupId]: "Choose a mode",
+      }));
+      return;
+    }
     setSavingId(group.groupId);
+    setMessages((current) => ({ ...current, [group.groupId]: "Saving..." }));
     try {
       const response = await fetch(
         withBasePath(
@@ -31,8 +49,41 @@ export function GroupModeReview({ groups }: { groups: GroupModeReviewRow[] }) {
           body: JSON.stringify({ rasterMode }),
         },
       );
-      if (!response.ok) throw new Error("Group mode update failed");
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(body.error ?? "Group mode update failed");
+      }
+      setMessages((current) => ({ ...current, [group.groupId]: "Saved" }));
       router.refresh();
+    } catch (error) {
+      setMessages((current) => ({
+        ...current,
+        [group.groupId]: error instanceof Error ? error.message : "Save failed",
+      }));
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  async function saveAll() {
+    setSavingId("__all__");
+    for (const group of groups) {
+      const rasterMode = values[group.groupId];
+      if (rasterMode !== "single" && rasterMode !== "double") {
+        setMessages((current) => ({
+          ...current,
+          [group.groupId]: "Choose a mode",
+        }));
+        setSavingId(null);
+        return;
+      }
+    }
+    try {
+      for (const group of groups) {
+        await save(group);
+      }
     } finally {
       setSavingId(null);
     }
@@ -42,20 +93,44 @@ export function GroupModeReview({ groups }: { groups: GroupModeReviewRow[] }) {
 
   return (
     <div className="mt-3 space-y-2 border-t border-[var(--border)] pt-3">
+      <div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold">Six-team group mode</h3>
+          <button
+            className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+            disabled={savingId !== null}
+            onClick={() => void saveAll()}
+            type="button"
+          >
+            Save all
+          </button>
+        </div>
+        <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+          Choose whether each 6-team group uses the normal 6er schedule or a
+          6er Doppelrunde, then validate again.
+        </p>
+      </div>
       {groups.map((group) => (
-        <label
+        <div
           key={`${group.inputSetId}:${group.groupId}`}
-          className="grid grid-cols-[minmax(10rem,1fr)_12rem] items-center gap-3 text-sm"
+          className="grid grid-cols-[minmax(10rem,1fr)_12rem_5rem_7rem] items-center gap-3 text-sm"
         >
           <span>{group.label}</span>
           <select
+            data-group-id={group.groupId}
+            data-input-set-id={group.inputSetId}
+            data-raster-group-mode=""
             className="h-9 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
-            defaultValue={group.rasterMode ?? ""}
-            disabled={savingId === group.groupId}
+            value={values[group.groupId] ?? group.rasterMode ?? ""}
+            disabled={savingId === group.groupId || savingId === "__all__"}
             onChange={(event) => {
               const value = event.currentTarget.value;
-              if (value === "single" || value === "double")
-                void save(group, value);
+              if (value === "single" || value === "double" || value === "") {
+                setValues((current) => ({
+                  ...current,
+                  [group.groupId]: value,
+                }));
+              }
             }}
           >
             <option value="" disabled>
@@ -64,7 +139,18 @@ export function GroupModeReview({ groups }: { groups: GroupModeReviewRow[] }) {
             <option value="single">Normal 6er</option>
             <option value="double">6er Doppelrunde</option>
           </select>
-        </label>
+          <button
+            className="h-9 rounded-md border border-[var(--border)] px-2 text-xs font-medium"
+            disabled={savingId === group.groupId || savingId === "__all__"}
+            onClick={() => void save(group)}
+            type="button"
+          >
+            Save
+          </button>
+          <span className="text-xs text-[var(--muted-foreground)]">
+            {messages[group.groupId] ?? ""}
+          </span>
+        </div>
       ))}
     </div>
   );

--- a/webapp/src/components/raster/input-set-actions.tsx
+++ b/webapp/src/components/raster/input-set-actions.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { withBasePath } from "@/lib/base-path";
+
+type FixedScheduleNumber = {
+  clubId: string;
+  teamLabel: string;
+  rasterzahl: number;
+  source: string;
+};
+
+type RasterRunRow = {
+  id: string;
+  status: string;
+  outcome: string | null;
+  objectiveValue: number | null;
+  createdAt: Date | string;
+  finishedAt: Date | string | null;
+  snapshot: { id: string } | null;
+};
+
+export function CreateInputSetForm({
+  district,
+  season,
+}: {
+  district: string;
+  season: string;
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function createInputSet(formData: FormData) {
+    setMessage(null);
+    const response = await fetch(withBasePath("/api/raster/input-sets"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        district,
+        season,
+        name: String(formData.get("name") ?? ""),
+      }),
+    });
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      setMessage(body.error ?? `Failed (${response.status})`);
+      return;
+    }
+    setMessage("Created");
+    router.refresh();
+  }
+
+  return (
+    <form
+      action={createInputSet}
+      className="flex flex-wrap items-end gap-3 border-b border-[var(--border)] px-4 py-3"
+    >
+      <label className="grid min-w-64 flex-1 gap-1 text-sm font-medium">
+        Input set name
+        <input
+          className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+          defaultValue={`${district} ${season}`}
+          name="name"
+          required
+        />
+      </label>
+      <button
+        className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
+        type="submit"
+      >
+        Create input set
+      </button>
+      {message ? (
+        <p className="text-sm text-[var(--muted-foreground)]">{message}</p>
+      ) : null}
+    </form>
+  );
+}
+
+export function FixedScheduleNumbersForm({
+  inputSetId,
+  rows,
+}: {
+  inputSetId: string;
+  rows: FixedScheduleNumber[];
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function saveFixedScheduleNumbers(formData: FormData) {
+    setMessage(null);
+    let fixedRasterzahlen: unknown;
+    try {
+      fixedRasterzahlen = JSON.parse(String(formData.get("fixedRasterzahlen")));
+    } catch {
+      setMessage("Invalid JSON");
+      return;
+    }
+    const response = await fetch(
+      withBasePath(`/api/raster/input-sets/${inputSetId}/fixed-rasterzahlen`),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fixedRasterzahlen }),
+      },
+    );
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      setMessage(body.error ?? `Failed (${response.status})`);
+      return;
+    }
+    setMessage("Saved");
+    router.refresh();
+  }
+
+  return (
+    <details className="mt-3">
+      <summary className="cursor-pointer text-sm font-medium">
+        Fixed schedule numbers ({rows.length})
+      </summary>
+      <form action={saveFixedScheduleNumbers} className="mt-3 grid gap-3">
+        <textarea
+          className="min-h-32 rounded-md border border-[var(--border)] bg-transparent p-3 font-mono text-xs"
+          defaultValue={JSON.stringify(rows, null, 2)}
+          name="fixedRasterzahlen"
+        />
+        <div className="flex items-center gap-3">
+          <button
+            className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+            type="submit"
+          >
+            Save fixed numbers
+          </button>
+          {message ? (
+            <p className="text-sm text-[var(--muted-foreground)]">{message}</p>
+          ) : null}
+        </div>
+      </form>
+    </details>
+  );
+}
+
+export function InputSetRunActions({
+  inputSetId,
+  status,
+  runs,
+}: {
+  inputSetId: string;
+  status: string;
+  runs: RasterRunRow[];
+}) {
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function post(path: string, label: string) {
+    setBusy(label);
+    setMessage(null);
+    try {
+      if (label === "Validate") {
+        const selects = Array.from(
+          document.querySelectorAll<HTMLSelectElement>(
+            `[data-input-set-id="${inputSetId}"][data-raster-group-mode]`,
+          ),
+        );
+        for (const select of selects) {
+          if (select.value !== "single" && select.value !== "double") continue;
+          const groupId = select.dataset.groupId;
+          if (!groupId) continue;
+          const saveResponse = await fetch(
+            withBasePath(
+              `/api/raster/input-sets/${inputSetId}/groups/${encodeURIComponent(
+                groupId,
+              )}`,
+            ),
+            {
+              method: "PUT",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ rasterMode: select.value }),
+            },
+          );
+          if (!saveResponse.ok) {
+            const body = (await saveResponse.json().catch(() => ({}))) as {
+              error?: string;
+            };
+            setMessage(body.error ?? `Save failed (${saveResponse.status})`);
+            return;
+          }
+        }
+      }
+      const response = await fetch(withBasePath(path), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        errors?: string[];
+        run?: {
+          id?: string;
+          jobId?: string | null;
+          status?: string;
+        };
+        inputSet?: {
+          status?: string;
+          _count?: {
+            wishes?: number;
+            fixedRasterzahlen?: number;
+          };
+        };
+      };
+      if (!response.ok) {
+        setMessage(body.error ?? `Failed (${response.status})`);
+        return;
+      }
+      if (body.errors?.length) {
+        setMessage(body.errors.join(" "));
+      } else if (label === "Validate") {
+        const wishes = body.inputSet?._count?.wishes ?? 0;
+        const fixed = body.inputSet?._count?.fixedRasterzahlen ?? 0;
+        setMessage(
+          `Validation passed: ${wishes} wish rows, ${fixed} fixed schedule numbers. You can start a run.`,
+        );
+      } else if (label === "Run") {
+        setMessage(
+          `Run queued: ${body.run?.status ?? "PENDING"}${body.run?.jobId ? `, job ${body.run.jobId}` : ""}. Refresh to update progress.`,
+        );
+      } else {
+        setMessage(`${label} done`);
+      }
+      router.refresh();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function cancel(runId: string) {
+    setBusy(runId);
+    setMessage(null);
+    try {
+      const response = await fetch(withBasePath(`/api/raster/runs/${runId}`), {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setMessage(body.error ?? `Cancel failed (${response.status})`);
+        return;
+      }
+      setMessage("Cancelled");
+      router.refresh();
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="mt-3 space-y-3 border-t border-[var(--border)] pt-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+          disabled={busy !== null}
+          onClick={() =>
+            void post(`/api/raster/input-sets/${inputSetId}/validate`, "Validate")
+          }
+          type="button"
+        >
+          {busy === "Validate" ? "..." : "Validate"}
+        </button>
+        <button
+          className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium disabled:opacity-50"
+          disabled={busy !== null || status !== "READY"}
+          onClick={() =>
+            void post(`/api/raster/input-sets/${inputSetId}/runs`, "Run")
+          }
+          type="button"
+        >
+          {busy === "Run" ? "..." : "Queue run"}
+        </button>
+        {status !== "READY" ? (
+          <span className="text-sm text-[var(--muted-foreground)]">
+            Validate before starting a run.
+          </span>
+        ) : null}
+        {message ? (
+          <span className="text-sm text-[var(--muted-foreground)]">
+            {message}
+          </span>
+        ) : null}
+      </div>
+      {runs.length ? (
+        <div className="grid gap-2 text-sm">
+          {runs.some((run) => run.status === "PENDING" || run.status === "RUNNING") ? (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              A run is queued or running in the background. Refresh this page to
+              update the status; results appear here when the worker finishes.
+            </p>
+          ) : null}
+          {runs.map((run) => (
+            <div
+              className="grid gap-2 rounded-md border border-[var(--border)] px-3 py-2"
+              key={run.id}
+            >
+              <div className="grid gap-2 md:grid-cols-[9rem_12rem_minmax(8rem,1fr)_auto]">
+                <span className="font-medium">{run.status}</span>
+                <span>{run.outcome ?? runStatusLabel(run.status)}</span>
+                <span className="text-[var(--muted-foreground)]">
+                  {new Date(run.createdAt).toLocaleString()}
+                </span>
+                <span className="flex gap-2">
+                  {run.snapshot ? (
+                    <a
+                      className="text-[var(--primary)]"
+                      href={withBasePath(`/raster/snapshots/${run.snapshot.id}`)}
+                    >
+                      Results
+                    </a>
+                  ) : null}
+                  {run.status === "PENDING" || run.status === "RUNNING" ? (
+                    <button
+                      className="text-[var(--primary)]"
+                      disabled={busy === run.id}
+                      onClick={() => void cancel(run.id)}
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                  ) : null}
+                </span>
+              </div>
+              <RunPhaseBar status={run.status} snapshotId={run.snapshot?.id} />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function runStatusLabel(status: string) {
+  if (status === "PENDING") return "Waiting for worker";
+  if (status === "RUNNING") return "Worker is processing";
+  if (status === "CANCELLED") return "Cancelled";
+  return "No outcome yet";
+}
+
+function RunPhaseBar({
+  status,
+  snapshotId,
+}: {
+  status: string;
+  snapshotId?: string;
+}) {
+  const failed = status === "FAILED" || status === "CANCELLED";
+  const activeIndex =
+    status === "PENDING"
+      ? 0
+      : status === "RUNNING"
+        ? 1
+        : snapshotId
+          ? 2
+          : failed
+            ? 1
+            : 0;
+  const steps = [
+    "Waiting for worker",
+    "Optimization started",
+    "Results available",
+  ];
+  return (
+    <div className="grid gap-1">
+      <div className="grid grid-cols-3 gap-1">
+        {steps.map((step, index) => (
+          <div
+            aria-label={step}
+            className={`h-2 rounded-sm ${
+              failed && index >= activeIndex
+                ? "bg-red-500/70"
+                : index <= activeIndex
+                  ? "bg-[var(--primary)]"
+                  : "bg-[var(--border)]"
+            }`}
+            key={step}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between gap-2 text-xs text-[var(--muted-foreground)]">
+        {steps.map((step, index) => (
+          <span
+            className={index === activeIndex ? "font-medium text-[var(--foreground)]" : ""}
+            key={step}
+          >
+            {failed && index === activeIndex ? status.toLowerCase() : step}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/raster/sources/raster-sources-panel.tsx
+++ b/webapp/src/components/raster/sources/raster-sources-panel.tsx
@@ -10,28 +10,43 @@ type RasterSourceRow = {
   sourceType: string;
   sourceRef: string;
   displayName: string;
+  season: string;
   contentHash: string | null;
   parsedJson: string | null;
   updatedAt: Date | string;
 };
 
+type RasterScopeOption = {
+  code: string;
+  name: string;
+};
+
 export function RasterSourcesPanel({
   district,
+  season,
+  scopes,
   sources,
   canEdit,
 }: {
   district: string;
+  season: string;
+  scopes: RasterScopeOption[];
   sources: RasterSourceRow[];
   canEdit: boolean;
 }) {
   const router = useRouter();
   const [message, setMessage] = useState<string | null>(null);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [sourceMessages, setSourceMessages] = useState<Record<string, string>>(
+    {},
+  );
 
   async function submitLink(formData: FormData) {
     setMessage(null);
     const payload = {
       scopeCode: String(formData.get("scopeCode") ?? ""),
+      season: String(formData.get("season") ?? ""),
       sourceType: String(formData.get("sourceType") ?? ""),
       sourceRef: String(formData.get("sourceRef") ?? ""),
       displayName: String(formData.get("displayName") ?? ""),
@@ -67,29 +82,67 @@ export function RasterSourcesPanel({
       setMessage(body.error ?? `Upload failed (${response.status})`);
       return;
     }
-    setMessage("Uploaded");
+    const body = (await response.json().catch(() => ({}))) as {
+      sources?: unknown[];
+    };
+    const count = body.sources?.length ?? 1;
+    setMessage(count === 1 ? "Uploaded 1 source" : `Uploaded ${count} sources`);
     router.refresh();
   }
 
   async function refreshSource(sourceId: string) {
     setRefreshingId(sourceId);
     setMessage(null);
+    setSourceMessages((messages) => ({
+      ...messages,
+      [sourceId]: "Parsing...",
+    }));
     try {
       const response = await fetch(
         withBasePath(`/api/raster/sources/${sourceId}/refresh`),
         { method: "POST" },
       );
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        summary?: string;
+      };
+      if (!response.ok) {
+        setSourceMessages((messages) => ({
+          ...messages,
+          [sourceId]: body.error ?? `Parse failed (${response.status})`,
+        }));
+        return;
+      }
+      setSourceMessages((messages) => ({
+        ...messages,
+        [sourceId]: body.summary ?? "Parsed",
+      }));
+      router.refresh();
+    } finally {
+      setRefreshingId(null);
+    }
+  }
+
+  async function deleteSource(sourceId: string, displayName: string) {
+    if (!window.confirm(`Delete ${displayName}?`)) return;
+    setDeletingId(sourceId);
+    setMessage(null);
+    try {
+      const response = await fetch(
+        withBasePath(`/api/raster/sources/${sourceId}`),
+        { method: "DELETE" },
+      );
       if (!response.ok) {
         const body = (await response.json().catch(() => ({}))) as {
           error?: string;
         };
-        setMessage(body.error ?? `Refresh failed (${response.status})`);
+        setMessage(body.error ?? `Delete failed (${response.status})`);
         return;
       }
-      setMessage("Refreshed");
+      setMessage("Deleted");
       router.refresh();
     } finally {
-      setRefreshingId(null);
+      setDeletingId(null);
     }
   }
 
@@ -105,31 +158,61 @@ export function RasterSourcesPanel({
           sources.map((source) => (
             <div
               key={source.id}
-              className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[10rem_minmax(12rem,1fr)_12rem_7rem]"
+              className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[10rem_minmax(12rem,1fr)_8rem_12rem_7rem_7rem]"
             >
-              <span className="font-medium">{source.sourceType}</span>
+              <span className="font-medium">
+                {source.sourceType} {source.season}
+              </span>
               <span className="break-all">{source.displayName}</span>
+              <span
+                className={
+                  source.parsedJson
+                    ? "text-[var(--primary)]"
+                    : "text-[var(--muted-foreground)]"
+                }
+              >
+                {source.parsedJson ? "Parsed" : "Needs parse"}
+              </span>
               <span className="text-[var(--muted-foreground)]">
                 {new Date(source.updatedAt).toLocaleDateString()}
               </span>
               {canEdit ? (
                 <button
+                  aria-label={`Parse ${source.displayName}`}
                   className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
                   disabled={refreshingId === source.id}
                   onClick={() => void refreshSource(source.id)}
                   type="button"
                 >
-                  {refreshingId === source.id ? "..." : "Refresh"}
+                  {refreshingId === source.id ? "..." : "Parse"}
+                </button>
+              ) : null}
+              {canEdit ? (
+                <button
+                  aria-label={`Delete ${source.displayName}`}
+                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
+                  disabled={deletingId === source.id}
+                  onClick={() =>
+                    void deleteSource(source.id, source.displayName)
+                  }
+                  type="button"
+                >
+                  {deletingId === source.id ? "..." : "Delete"}
                 </button>
               ) : null}
               <a
-                className="break-all text-[var(--primary)] md:col-span-4"
+                className="break-all text-[var(--primary)] md:col-span-6"
                 href={source.sourceRef}
                 rel="noreferrer"
                 target="_blank"
               >
                 {source.sourceRef}
               </a>
+              {sourceMessages[source.id] ? (
+                <p className="text-sm text-[var(--muted-foreground)] md:col-span-6">
+                  {sourceMessages[source.id]}
+                </p>
+              ) : null}
             </div>
           ))
         ) : (
@@ -140,83 +223,180 @@ export function RasterSourcesPanel({
       </div>
       {canEdit ? (
         <div className="space-y-4 border-t border-[var(--border)] p-4">
-        <form action={uploadSource} className="grid gap-3 md:grid-cols-2">
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
-            defaultValue="WTTV"
-            name="scopeCode"
-            placeholder="Scope"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
-            defaultValue="GROUP_ASSIGNMENT"
-            name="sourceType"
-            placeholder="Type"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
-            name="displayName"
-            placeholder="Name"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 py-2 text-sm md:col-span-2"
-            name="file"
-            type="file"
-          />
-          <button
-            className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
-            type="submit"
+          <form
+            action={uploadSource}
+            className="hidden gap-3 rounded-lg border border-[var(--border)] p-4 md:grid-cols-2"
           >
-            Upload
-          </button>
-        </form>
-        <form action={submitLink} className="grid gap-3 md:grid-cols-2">
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
-            defaultValue="WTTV"
-            name="scopeCode"
-            placeholder="Scope"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm"
-            defaultValue="GROUP_ASSIGNMENT"
-            name="sourceType"
-            placeholder="Type"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
-            name="displayName"
-            placeholder="Name"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
-            name="sourceRef"
-            placeholder="URL or document id"
-          />
-          <input
-            className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm md:col-span-2"
-            name="contentHash"
-            placeholder="Content hash"
-          />
-          <textarea
-            className="min-h-24 rounded-md border border-[var(--border)] bg-transparent p-3 text-sm md:col-span-2"
-            name="parsedJson"
-            placeholder="Parsed JSON"
-          />
-          <div className="flex items-center gap-3 md:col-span-2">
+            <div className="md:col-span-2">
+              <h3 className="text-sm font-semibold">
+                1. Upload group assignment
+              </h3>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                Upload one current group assignment file. Store it under a
+                parent district if sub-districts should inherit it.
+              </p>
+            </div>
+            <input name="season" type="hidden" value={season} />
+            <input name="sourceType" type="hidden" value="GROUP_ASSIGNMENT" />
+            <label className="grid gap-1 text-sm font-medium">
+              Store source under
+              <select
+                className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                defaultValue={district}
+                name="scopeCode"
+              >
+                {scopes.map((scope) => (
+                  <option key={scope.code} value={scope.code}>
+                    {scope.code} - {scope.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="grid gap-1 text-sm font-medium">
+              Display name
+              <input
+                className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                name="displayName"
+                placeholder="Example: WTTV group assignment 2026"
+                required
+              />
+            </label>
+            <label className="grid gap-1 text-sm font-medium md:col-span-2">
+              File
+              <input
+                className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 py-2 text-sm font-normal"
+                name="file"
+                required
+                type="file"
+              />
+            </label>
             <button
               className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
               type="submit"
             >
-              Save
+              Upload group assignment
             </button>
-            {message ? (
-              <span className="text-sm text-[var(--muted-foreground)]">
-                {message}
-              </span>
-            ) : null}
-          </div>
-        </form>
+          </form>
+          <form
+            action={uploadSource}
+            className="grid gap-3 rounded-lg border border-[var(--border)] p-4 md:grid-cols-2"
+          >
+            <div className="md:col-span-2">
+              <h3 className="text-sm font-semibold">Upload wish PDFs</h3>
+              <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                Upload one or more wish PDFs. Each selected file becomes its own
+                wish source and will be combined during validation.
+              </p>
+            </div>
+            <input name="season" type="hidden" value={season} />
+            <input name="sourceType" type="hidden" value="WISHES_PDF" />
+            <label className="grid gap-1 text-sm font-medium">
+              Store source under
+              <select
+                className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                defaultValue={district}
+                name="scopeCode"
+              >
+                {scopes.map((scope) => (
+                  <option key={scope.code} value={scope.code}>
+                    {scope.code} - {scope.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="grid gap-1 text-sm font-medium">
+              Files
+              <input
+                accept="application/pdf,.pdf"
+                className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                multiple
+                name="file"
+                required
+                type="file"
+              />
+            </label>
+            <button
+              className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
+              type="submit"
+            >
+              Upload wish PDFs
+            </button>
+          </form>
+          <details className="rounded-lg border border-[var(--border)] p-4">
+            <summary className="cursor-pointer text-sm font-semibold">
+              Advanced: register external source
+            </summary>
+            <form action={submitLink} className="mt-4 grid gap-3 md:grid-cols-2">
+              <input name="season" type="hidden" value={season} />
+              <p className="text-sm text-[var(--muted-foreground)] md:col-span-2">
+                Paste a normal click-TT league page URL instead of uploading a
+                file here.
+              </p>
+              <label className="grid gap-1 text-sm font-medium">
+                Store source under
+                <select
+                  className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                  defaultValue={district}
+                  name="scopeCode"
+                >
+                  {scopes.map((scope) => (
+                    <option key={scope.code} value={scope.code}>
+                      {scope.code} - {scope.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <input name="sourceType" type="hidden" value="GROUP_ASSIGNMENT" />
+              <label className="grid gap-1 text-sm font-medium md:col-span-2">
+                Display name
+                <input
+                  className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                  name="displayName"
+                  placeholder="Example: WTTV group assignment 2026"
+                  required
+                />
+              </label>
+              <label className="grid gap-1 text-sm font-medium md:col-span-2">
+                URL or document id
+                <input
+                  className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                  name="sourceRef"
+                  placeholder="https://wttv.click-tt.de/.../leaguePage?championship=WTTV%2026/27"
+                  required
+                />
+              </label>
+              <details className="space-y-3 md:col-span-2">
+                <summary className="cursor-pointer text-sm font-medium">
+                  Raw metadata
+                </summary>
+                <label className="mt-3 grid gap-1 text-sm font-medium">
+                  Content hash
+                  <input
+                    className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
+                    name="contentHash"
+                    placeholder="Optional checksum"
+                  />
+                </label>
+                <label className="grid gap-1 text-sm font-medium">
+                  Parsed JSON
+                  <textarea
+                    className="min-h-24 rounded-md border border-[var(--border)] bg-transparent p-3 text-sm font-normal"
+                    name="parsedJson"
+                    placeholder="Optional pre-parsed source payload"
+                  />
+                </label>
+              </details>
+              <button
+                className="h-10 rounded-md border border-[var(--border)] px-4 text-sm font-medium"
+                type="submit"
+              >
+                Save external source
+              </button>
+            </form>
+          </details>
+          {message ? (
+            <p className="text-sm text-[var(--muted-foreground)]">{message}</p>
+          ) : null}
         </div>
       ) : null}
     </section>

--- a/webapp/src/lib/file-storage.ts
+++ b/webapp/src/lib/file-storage.ts
@@ -1,4 +1,4 @@
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
@@ -40,4 +40,8 @@ export function getFilePath(storedPath: string) {
 
 export async function assertStoredFileExists(storedPath: string) {
   await stat(getFilePath(storedPath));
+}
+
+export async function deleteStoredFile(storedPath: string) {
+  await rm(getFilePath(storedPath), { force: true });
 }

--- a/webapp/src/lib/raster/access.ts
+++ b/webapp/src/lib/raster/access.ts
@@ -5,6 +5,15 @@ import { Role } from "../../../generated/prisma/enums";
 import type { RouteErrorResult } from "@/services/api/types";
 
 export type RasterAccessLevel = "viewer" | "scheduler" | "admin";
+export type RasterScopeOption = {
+  code: string;
+  name: string;
+  parent: {
+    code: string;
+    name: string;
+    parent: { code: string; name: string } | null;
+  } | null;
+};
 
 const levelRoles: Record<RasterAccessLevel, Role[]> = {
   viewer: [Role.PLATFORM_ADMIN, Role.SCOPE_ADMIN, Role.SCOPE_USER],
@@ -21,6 +30,49 @@ export function canUseRasterLevel(
   level: RasterAccessLevel,
 ) {
   return levelRoles[level].includes(user.role);
+}
+
+export async function listAccessibleRasterScopes(
+  user: Pick<SessionUser, "id" | "role">,
+): Promise<RasterScopeOption[]> {
+  const scopes = await prisma.scope.findMany({
+    where:
+      user.role === Role.PLATFORM_ADMIN
+        ? undefined
+        : {
+            OR: [
+              { userAssignments: { some: { userId: user.id } } },
+              { parent: { userAssignments: { some: { userId: user.id } } } },
+              {
+                parent: {
+                  parent: { userAssignments: { some: { userId: user.id } } },
+                },
+              },
+            ],
+          },
+    select: {
+      code: true,
+      name: true,
+      parent: {
+        select: {
+          code: true,
+          name: true,
+          parent: { select: { code: true, name: true } },
+        },
+      },
+    },
+  });
+
+  return [...scopes].sort((left, right) =>
+    rasterScopePath(left).localeCompare(rasterScopePath(right), "de"),
+  );
+}
+
+export function rasterScopePath(scope: RasterScopeOption) {
+  return [scope.parent?.parent, scope.parent, scope]
+    .filter((item): item is { code: string; name: string } => Boolean(item))
+    .map((item) => item.name)
+    .join(" / ");
 }
 
 export async function canAccessRasterDistrict(

--- a/webapp/src/lib/raster/pipeline.ts
+++ b/webapp/src/lib/raster/pipeline.ts
@@ -1,16 +1,25 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import type {
   TeamRasterAssignmentRow,
   WishParseResult,
 } from "../../../../src/raster/ingest/index.js";
+import type { SeasonModel } from "../../../../src/raster/types.js";
 
-type WishesPdfModule = {
-  parseWishesPdf(filePath: string): Promise<WishParseResult>;
-  readAssignmentTable(filePath: string): Promise<TeamRasterAssignmentRow[]>;
-};
-
-type ClickTtScrapeModule = {
-  scrapeCurrentTeamRasterAssignments(): Promise<TeamRasterAssignmentRow[]>;
-};
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(process.cwd(), "..");
+const ingestIndexUrl = pathToFileURL(
+  path.join(repoRoot, "src/raster/ingest/index.ts"),
+).href;
+const ingestScrapeUrl = pathToFileURL(
+  path.join(repoRoot, "src/raster/ingest/scrape.ts"),
+).href;
+const ingestWishesPdfUrl = pathToFileURL(
+  path.join(repoRoot, "src/raster/ingest/wishes-pdf.ts"),
+).href;
 
 function parseCsvLine(line: string): string[] {
   const result: string[] = [];
@@ -35,43 +44,102 @@ function parseCsvLine(line: string): string[] {
 }
 
 async function parseWishesPdf(filePath: string): Promise<WishParseResult> {
-  const modulePath = new URL(
-    "../../../../src/raster/ingest/wishes-pdf.ts",
-    import.meta.url,
-  ).href;
-  const wishesPdf = (await import(
-    /* webpackIgnore: true */ modulePath
-  )) as WishesPdfModule;
-  return wishesPdf.parseWishesPdf(filePath);
+  return runRasterTs<WishParseResult>(`
+    const { parseWishesPdf } = await import(${JSON.stringify(ingestWishesPdfUrl)});
+    emit(await parseWishesPdf(${JSON.stringify(filePath)}));
+  `);
 }
 
 async function readAssignmentTable(
   filePath: string,
 ): Promise<TeamRasterAssignmentRow[]> {
-  const modulePath = new URL(
-    "../../../../src/raster/ingest/index.ts",
-    import.meta.url,
-  ).href;
-  const ingest = (await import(
-    /* webpackIgnore: true */ modulePath
-  )) as WishesPdfModule;
-  return ingest.readAssignmentTable(filePath);
+  return runRasterTs<TeamRasterAssignmentRow[]>(`
+    const { readAssignmentTable } = await import(${JSON.stringify(ingestIndexUrl)});
+    emit(await readAssignmentTable(${JSON.stringify(filePath)}));
+  `);
 }
 
-async function scrapeClickTtAssignments(): Promise<TeamRasterAssignmentRow[]> {
-  const modulePath = new URL(
-    "../../../../src/raster/ingest/scrape.ts",
-    import.meta.url,
-  ).href;
-  const scrape = (await import(
-    /* webpackIgnore: true */ modulePath
-  )) as ClickTtScrapeModule;
-  return scrape.scrapeCurrentTeamRasterAssignments();
+async function buildSeasonModelFromAssignments(
+  assignments: TeamRasterAssignmentRow[],
+): Promise<SeasonModel> {
+  return runRasterTs<SeasonModel>(`
+    const { buildSeasonModelFromAssignments } = await import(${JSON.stringify(ingestIndexUrl)});
+    emit(await buildSeasonModelFromAssignments(${JSON.stringify(assignments)}));
+  `);
+}
+
+async function scrapeClickTtAssignments(options?: {
+  groupNamePattern?: string;
+}): Promise<TeamRasterAssignmentRow[]> {
+  return runRasterTs<TeamRasterAssignmentRow[]>(`
+    const { scrapeCurrentTeamRasterAssignments } = await import(${JSON.stringify(ingestScrapeUrl)});
+    emit(await scrapeCurrentTeamRasterAssignments(${JSON.stringify(options)}));
+  `);
+}
+
+async function scrapeClickTtPublicLeagueAssignments(
+  leaguePageUrl: string,
+): Promise<TeamRasterAssignmentRow[]> {
+  return runRasterTs<TeamRasterAssignmentRow[]>(`
+    const { scrapePublicLeagueAssignmentsFromUrl } = await import(${JSON.stringify(ingestScrapeUrl)});
+    emit(await scrapePublicLeagueAssignmentsFromUrl(${JSON.stringify(leaguePageUrl)}));
+  `);
+}
+
+async function runRasterTs<T>(code: string): Promise<T> {
+  const command =
+    process.platform === "win32" ? process.env.ComSpec ?? "cmd.exe" : "pnpm";
+  const dir = await mkdtemp(path.join(repoRoot, ".tmp-raster-ts-"));
+  const scriptPath = path.join(dir, "run.ts");
+  await writeFile(
+    scriptPath,
+    `
+    function emit(value) {
+      console.log("__RASTER_JSON__" + JSON.stringify(value));
+    }
+    async function main() {
+      ${code}
+    }
+    main().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  `,
+  );
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      command,
+      process.platform === "win32"
+        ? ["/d", "/c", `pnpm exec tsx ${scriptPath}`]
+        : ["exec", "tsx", scriptPath],
+      {
+        cwd: repoRoot,
+        env: process.env,
+        maxBuffer: 20 * 1024 * 1024,
+      },
+    );
+    const lines = stdout.split(/\r?\n/);
+    let line: string | undefined;
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      if (lines[index]?.startsWith("__RASTER_JSON__")) {
+        line = lines[index];
+        break;
+      }
+    }
+    if (!line) {
+      throw new Error(stderr.trim() || "Raster parser returned no data");
+    }
+    return JSON.parse(line.slice("__RASTER_JSON__".length)) as T;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }
 
 export const rasterIngest = {
   parseCsvLine,
   parseWishesPdf,
   readAssignmentTable,
+  buildSeasonModelFromAssignments,
   scrapeClickTtAssignments,
+  scrapeClickTtPublicLeagueAssignments,
 };

--- a/webapp/src/lib/raster/season.ts
+++ b/webapp/src/lib/raster/season.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_RASTER_SEASON = "2026/27";
+
+export function normalizeRasterSeason(value: string | null | undefined) {
+  return value?.trim() || DEFAULT_RASTER_SEASON;
+}
+
+export function rasterSeasonOptions() {
+  return ["2026/27", "2027/28", "2028/29"];
+}

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -1,21 +1,45 @@
 import { prisma } from "@/lib/db";
 import { rasterDistrictWhere } from "@/lib/raster/access";
+import { rasterIngest } from "@/lib/raster/pipeline";
+import { normalizeRasterSeason } from "@/lib/raster/season";
 import { seasonModelSchema, type SeasonModelInput } from "@/lib/raster/schemas";
 import { InputSetStatus } from "../../../generated/prisma/enums";
+import type {
+  TeamRasterAssignmentRow,
+  WishParseResult,
+} from "../../../../src/raster/ingest/index.js";
 import { listRasterSourcesForDistrict } from "./sources";
+import { replaceParsedWishes } from "./wishes";
 
-type SeasonGroup = Record<string, unknown> & {
+type SeasonGroup = {
   id?: string;
   ref?: { league?: string; name?: string };
   size?: number;
   rasterMode?: "single" | "double";
 };
 
-export async function listInputSets(district: string) {
+export async function listInputSets(
+  district: string,
+  season = normalizeRasterSeason(undefined),
+) {
   return prisma.rasterInputSet.findMany({
-    where: rasterDistrictWhere(district),
+    where: { ...rasterDistrictWhere(district), season: normalizeRasterSeason(season) },
     orderBy: { createdAt: "desc" },
     include: {
+      fixedRasterzahlen: {
+        orderBy: [{ clubId: "asc" }, { teamLabel: "asc" }],
+        select: {
+          clubId: true,
+          teamLabel: true,
+          rasterzahl: true,
+          source: true,
+        },
+      },
+      runs: {
+        orderBy: { createdAt: "desc" },
+        take: 5,
+        include: { snapshot: { select: { id: true } } },
+      },
       _count: {
         select: { wishes: true, fixedRasterzahlen: true, runs: true },
       },
@@ -25,11 +49,12 @@ export async function listInputSets(district: string) {
 
 export async function createInputSet(params: {
   district: string;
+  season: string;
   name: string;
   createdById: string;
 }) {
   return prisma.rasterInputSet.create({
-    data: params,
+    data: { ...params, season: normalizeRasterSeason(params.season) },
   });
 }
 
@@ -90,11 +115,14 @@ export async function validateInputSet(id: string) {
 export async function syncInputSetSourceCaches(inputSetId: string) {
   const inputSet = await prisma.rasterInputSet.findUnique({
     where: { id: inputSetId },
-    select: { id: true, district: true },
+    select: { id: true, district: true, season: true, seasonModelJson: true },
   });
   if (!inputSet) return null;
 
-  const sources = await listRasterSourcesForDistrict(inputSet.district);
+  const sources = await listRasterSourcesForDistrict(
+    inputSet.district,
+    inputSet.season,
+  );
   const groupSource = sources.find(
     (source) =>
       source.sourceType.toUpperCase() === "GROUP_ASSIGNMENT" &&
@@ -105,27 +133,87 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
       source.sourceType.toUpperCase() === "WISHES_PDF" && source.parsedJson,
   );
   const data: {
+    seasonModelJson?: string;
     groupAssignmentJson?: string;
     wishesJson?: string;
   } = {};
   if (groupSource?.parsedJson) {
     data.groupAssignmentJson = groupSource.parsedJson;
+    const parsed = JSON.parse(groupSource.parsedJson) as {
+      assignments?: TeamRasterAssignmentRow[];
+    };
+    if (parsed.assignments?.length) {
+      const groupSizes = new Map<string, number>();
+      for (const assignment of parsed.assignments) {
+        groupSizes.set(
+          assignment.group,
+          (groupSizes.get(assignment.group) ?? 0) + 1,
+        );
+      }
+      const supportedSizes = new Set([5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+      const supportedAssignments = parsed.assignments.filter((assignment) =>
+        supportedSizes.has(groupSizes.get(assignment.group) ?? 0),
+      );
+      const skippedGroups = [...groupSizes.entries()].filter(
+        ([, size]) => !supportedSizes.has(size),
+      );
+      const model =
+        await rasterIngest.buildSeasonModelFromAssignments(supportedAssignments);
+      const existingModes = groupModesByKey(inputSet.seasonModelJson);
+      model.groups = model.groups.map((group) => ({
+        ...group,
+        rasterMode: group.rasterMode ?? existingModes.get(groupKey(group)),
+      }));
+      model.warnings.push(
+        ...skippedGroups.map(
+          ([group, size]) =>
+            `Skipped ${group}: unsupported group size ${size}.`,
+        ),
+      );
+      data.seasonModelJson = JSON.stringify(model);
+    }
   }
   if (wishSources.length) {
+    const parsedWishes = wishSources.map(
+      (source) => JSON.parse(source.parsedJson ?? "{}") as WishParseResult,
+    );
     data.wishesJson = JSON.stringify({
-      sources: wishSources.map((source) => ({
+      sources: wishSources.map((source, index) => ({
         sourceId: source.id,
         sourceRef: source.sourceRef,
-        parsed: JSON.parse(source.parsedJson ?? "{}"),
+        parsed: parsedWishes[index],
       })),
     });
+    await replaceParsedWishes(inputSet.id, {
+      clubs: parsedWishes.flatMap((parsed) => parsed.clubs ?? []),
+      teams: parsedWishes.flatMap((parsed) => parsed.teams ?? []),
+      warnings: parsedWishes.flatMap((parsed) => parsed.warnings ?? []),
+    });
   }
-  if (!data.groupAssignmentJson && !data.wishesJson) return inputSet;
+  if (!data.groupAssignmentJson && !data.wishesJson && !data.seasonModelJson) {
+    return inputSet;
+  }
 
   return prisma.rasterInputSet.update({
     where: { id: inputSet.id },
     data,
   });
+}
+
+function groupModesByKey(seasonModelJson?: string | null) {
+  const modes = new Map<string, "single" | "double">();
+  if (!seasonModelJson) return modes;
+  try {
+    const model = JSON.parse(seasonModelJson) as { groups?: SeasonGroup[] };
+    for (const group of model.groups ?? []) {
+      if (group.rasterMode === "single" || group.rasterMode === "double") {
+        modes.set(groupKey(group), group.rasterMode);
+      }
+    }
+  } catch {
+    return modes;
+  }
+  return modes;
 }
 
 export async function updateSeasonModel(

--- a/webapp/src/services/raster/sources.ts
+++ b/webapp/src/services/raster/sources.ts
@@ -3,11 +3,13 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { prisma } from "@/lib/db";
-import { getFilePath } from "@/lib/file-storage";
+import { deleteStoredFile, getFilePath } from "@/lib/file-storage";
 import { rasterIngest } from "@/lib/raster/pipeline";
+import { normalizeRasterSeason } from "@/lib/raster/season";
 
 export async function listRasterSourcesForDistrict(
   district: string,
+  season = normalizeRasterSeason(undefined),
   sourceType?: string,
 ) {
   const scope = await prisma.scope.findFirst({
@@ -33,6 +35,7 @@ export async function listRasterSourcesForDistrict(
   return prisma.rasterSource.findMany({
     where: {
       scopeId: { in: scopeIds },
+      season: normalizeRasterSeason(season),
       ...(sourceType ? { sourceType } : {}),
     },
     orderBy: [{ updatedAt: "desc" }, { displayName: "asc" }],
@@ -41,6 +44,7 @@ export async function listRasterSourcesForDistrict(
 
 export async function upsertRasterSource(params: {
   scopeId: string;
+  season: string;
   sourceType: string;
   sourceRef: string;
   displayName: string;
@@ -49,8 +53,9 @@ export async function upsertRasterSource(params: {
 }) {
   return prisma.rasterSource.upsert({
     where: {
-      scopeId_sourceType_sourceRef: {
+      scopeId_season_sourceType_sourceRef: {
         scopeId: params.scopeId,
+        season: normalizeRasterSeason(params.season),
         sourceType: params.sourceType,
         sourceRef: params.sourceRef,
       },
@@ -60,7 +65,7 @@ export async function upsertRasterSource(params: {
       contentHash: params.contentHash,
       parsedJson: params.parsedJson,
     },
-    create: params,
+    create: { ...params, season: normalizeRasterSeason(params.season) },
   });
 }
 
@@ -82,13 +87,33 @@ export async function refreshRasterSource(id: string) {
   });
 }
 
+export async function deleteRasterSource(id: string) {
+  const source = await prisma.rasterSource.delete({
+    where: { id },
+    include: { scope: true },
+  });
+  if (!/^https?:\/\//i.test(source.sourceRef)) {
+    await deleteStoredFile(source.sourceRef);
+  }
+  return source;
+}
+
 async function parseSource(sourceType: string, sourceRef: string) {
   const normalizedType = sourceType.trim().toUpperCase();
   if (
     normalizedType === "GROUP_ASSIGNMENT" &&
     /^clicktt:\/\//i.test(sourceRef)
   ) {
-    const assignments = await rasterIngest.scrapeClickTtAssignments();
+    const assignments = await scrapeClickTtGroupAssignments(sourceRef);
+    const payload = { assignments };
+    return {
+      contentHash: hash(Buffer.from(JSON.stringify(payload))),
+      value: payload,
+    };
+  }
+  if (normalizedType === "GROUP_ASSIGNMENT" && isClickTtLeaguePage(sourceRef)) {
+    const assignments =
+      await rasterIngest.scrapeClickTtPublicLeagueAssignments(sourceRef);
     const payload = { assignments };
     return {
       contentHash: hash(Buffer.from(JSON.stringify(payload))),
@@ -116,6 +141,28 @@ async function parseSource(sourceType: string, sourceRef: string) {
   } finally {
     if (file.cleanup) await file.cleanup();
   }
+}
+
+async function scrapeClickTtGroupAssignments(sourceRef: string) {
+  const url = new URL(sourceRef);
+  const publicLeagueUrl = url.searchParams.get("publicLeagueUrl")?.trim();
+  if (publicLeagueUrl) {
+    return rasterIngest.scrapeClickTtPublicLeagueAssignments(publicLeagueUrl);
+  }
+
+  const groupNamePattern = url.searchParams.get("groupNamePattern")?.trim();
+  return groupNamePattern
+    ? rasterIngest.scrapeClickTtAssignments({ groupNamePattern })
+    : rasterIngest.scrapeClickTtAssignments();
+}
+
+function isClickTtLeaguePage(sourceRef: string) {
+  if (!/^https?:\/\//i.test(sourceRef)) return false;
+  const url = new URL(sourceRef);
+  return (
+    /(?:^|\.)click-tt\.de$/i.test(url.hostname) &&
+    /\/wa\/leaguePage$/i.test(url.pathname)
+  );
 }
 
 async function readSourceFile(sourceRef: string) {

--- a/webapp/tests/e2e/helpers/db-worker.ts
+++ b/webapp/tests/e2e/helpers/db-worker.ts
@@ -28,6 +28,22 @@ function normalizeEmail(email: string) {
   return email.toLowerCase();
 }
 
+const wttvDistricts = [
+  ["NIEDERRHEIN", "Niederrhein"],
+  ["RHEIN_RUHR", "Rhein-Ruhr"],
+  ["RHEIN_WUPPER", "Rhein-Wupper"],
+  ["KOELN", "Köln"],
+  ["RHEIN_ERFT_SIEG", "Rhein-Erft-Sieg"],
+  ["AACHEN_EUREGIO", "Aachen/Euregio"],
+  ["MUENSTERLAND", "Münsterland"],
+  ["MUENSTERLAND_HOHE_MARK", "Münsterland/Hohe Mark"],
+  ["OSTWESTFALEN_NORD", "Ostwestfalen-Nord"],
+  ["OWL", "Ostwestfalen/Lippe"],
+  ["MITTLERES_RUHRGEBIET", "Mittleres Ruhrgebiet"],
+  ["WESTFALEN_MITTE", "Westfalen-Mitte"],
+  ["SUEDWESTFALEN", "Südwestfalen"],
+] as const;
+
 async function readJson<T>() {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
@@ -237,20 +253,29 @@ async function main() {
       });
       const wttv = await prisma.scope.upsert({
         where: { code: "WTTV" },
-        update: { name: "WTTV", parentId: de.id },
-        create: { code: "WTTV", name: "WTTV", parentId: de.id },
-        select: { id: true },
-      });
-      const owl = await prisma.scope.upsert({
-        where: { code: "OWL" },
-        update: { name: "Ostwestfalen-Lippe", parentId: wttv.id },
+        update: {
+          name: "Westdeutscher Tischtennis-Verband",
+          parentId: de.id,
+        },
         create: {
-          code: "OWL",
-          name: "Ostwestfalen-Lippe",
-          parentId: wttv.id,
+          code: "WTTV",
+          name: "Westdeutscher Tischtennis-Verband",
+          parentId: de.id,
         },
         select: { id: true },
       });
+      const districts = await Promise.all(
+        wttvDistricts.map(([code, name]) =>
+          prisma.scope.upsert({
+            where: { code },
+            update: { name, parentId: wttv.id },
+            create: { code, name, parentId: wttv.id },
+            select: { id: true, code: true },
+          }),
+        ),
+      );
+      const owl = districts.find((scope) => scope.code === "OWL");
+      if (!owl) throw new Error("OWL scope was not seeded");
 
       process.stdout.write(
         JSON.stringify({ de: de.id, wttv: wttv.id, owl: owl.id }),
@@ -264,9 +289,11 @@ async function main() {
         sourceType: string;
         sourceRef: string;
         displayName: string;
+        season?: string;
         contentHash?: string | null;
         parsedJson?: unknown;
       }>();
+      const season = input.season ?? "2026/27";
       const scope = await prisma.scope.findUnique({
         where: { code: input.scopeCode },
         select: { id: true },
@@ -280,8 +307,9 @@ async function main() {
 
       const source = await prisma.rasterSource.upsert({
         where: {
-          scopeId_sourceType_sourceRef: {
+          scopeId_season_sourceType_sourceRef: {
             scopeId: scope.id,
+            season,
             sourceType: input.sourceType,
             sourceRef: input.sourceRef,
           },
@@ -296,6 +324,7 @@ async function main() {
         },
         create: {
           scopeId: scope.id,
+          season,
           sourceType: input.sourceType,
           sourceRef: input.sourceRef,
           displayName: input.displayName,

--- a/webapp/tests/e2e/helpers/db.ts
+++ b/webapp/tests/e2e/helpers/db.ts
@@ -147,6 +147,7 @@ export function seedRasterSource(input: {
   sourceType: string;
   sourceRef: string;
   displayName: string;
+  season?: string;
   contentHash?: string | null;
   parsedJson?: unknown;
 }) {

--- a/webapp/tests/e2e/raster-generate.spec.ts
+++ b/webapp/tests/e2e/raster-generate.spec.ts
@@ -118,24 +118,29 @@ test("admin can generate and review a raster snapshot", async ({ page }) => {
   );
   expect(wishesResponse.status()).toBe(200);
 
-  const validateResponse = await page.request.post(
-    `${appBasePath}/api/raster/input-sets/${inputSetId}/validate`,
-  );
-  expect(validateResponse.status()).toBe(200);
-  const validation = (await validateResponse.json()) as { errors: string[] };
-  expect(validation.errors).toEqual([]);
+  await page.goto(`${appBasePath}/raster?district=${district}`);
+  await expect(page.getByText(`E2E generated ${suffix}`)).toBeVisible();
+  await page.getByRole("button", { name: "Validate" }).click();
+  await expect(page.getByText("Validate done")).toBeVisible();
+  await page.getByRole("button", { name: "Start run" }).click();
+  await expect(page.getByText("Run done")).toBeVisible();
 
-  const runResponse = await page.request.post(
-    `${appBasePath}/api/raster/input-sets/${inputSetId}/runs`,
-    { data: { timeLimitSeconds: 30 } },
+  const runListResponse = await page.request.get(
+    `${appBasePath}/api/raster/input-sets?district=${district}`,
   );
-  expect(runResponse.status()).toBe(202);
-  const runBody = (await runResponse.json()) as { run: { id: string } };
+  expect(runListResponse.status()).toBe(200);
+  const runList = (await runListResponse.json()) as {
+    inputSets: Array<{ id: string; runs: Array<{ id: string }> }>;
+  };
+  const runBody = runList.inputSets
+    .find((inputSet) => inputSet.id === inputSetId)
+    ?.runs.at(0);
+  expect(runBody?.id).toBeTruthy();
 
   processNextWorkerJob();
 
   const runStatusResponse = await page.request.get(
-    `${appBasePath}/api/raster/runs/${runBody.run.id}`,
+    `${appBasePath}/api/raster/runs/${runBody?.id}`,
   );
   expect(runStatusResponse.status()).toBe(200);
   const runStatus = (await runStatusResponse.json()) as {
@@ -164,8 +169,62 @@ test("admin can generate and review a raster snapshot", async ({ page }) => {
   expect(conflictsResponse.status()).toBe(200);
 
   await page.goto(`${appBasePath}/raster?district=${district}`);
-  await expect(page.getByText(`E2E generated ${suffix}`)).toBeVisible();
-  await expect(page.getByText("READY")).toBeVisible();
+  await page.getByRole("link", { name: "Results" }).click();
+  await expect(page.getByRole("heading", { name: "Raster results" })).toBeVisible();
+  await expect(page.getByText("Assignments")).toBeVisible();
+});
+
+test("admin can use the guided source workflow", async ({ page }) => {
+  const suffix = Date.now();
+  const email = `e2e-raster-flow-${suffix}@example.com`;
+  const password = "RasterFlow123";
+  const urlName = `E2E click-TT groups ${suffix}`;
+  const wishName = `wrong-${suffix}.pdf`;
+
+  await seedRasterScopeHierarchy();
+  await seedLocalUser({
+    email,
+    name: "E2E Raster Flow Admin",
+    role: Role.PLATFORM_ADMIN,
+    password,
+    mustChangePassword: false,
+  });
+
+  await loginWithPassword(page, email, password);
+  await expectOnDashboard(page);
+  await page.goto(`${appBasePath}/raster?district=${district}&season=2026%2F27`);
+
+  await page.getByText("Advanced: register external source").click();
+  await page
+    .getByPlaceholder("Example: WTTV group assignment 2026")
+    .last()
+    .fill(urlName);
+  await page
+    .getByPlaceholder(
+      "https://wttv.click-tt.de/.../leaguePage?championship=WTTV%2026/27",
+    )
+    .fill(
+      "https://wttv.click-tt.de/cgi-bin/WebObjects/nuLigaTTDE.woa/wa/leaguePage?championship=WTTV%2026/27",
+    );
+  await page.getByRole("button", { name: "Save external source" }).click();
+  await expect(page.getByText(urlName)).toBeVisible();
+  await expect(page.getByText("Needs parse")).toBeVisible();
+
+  await page
+    .locator('input[name="file"][multiple]')
+    .setInputFiles([
+      {
+        name: wishName,
+        mimeType: "application/pdf",
+        buffer: Buffer.from("%PDF-1.4\n% e2e"),
+      },
+    ]);
+  await page.getByRole("button", { name: "Upload wish PDFs" }).click();
+  await expect(page.getByText(wishName)).toBeVisible();
+
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByLabel(`Delete ${wishName}`).click();
+  await expect(page.getByText(wishName)).not.toBeVisible();
 });
 
 function buildSeasonModel() {

--- a/webapp/tests/unit/raster-access.test.ts
+++ b/webapp/tests/unit/raster-access.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { prismaMock } from "@/lib/__mocks__/db";
-import { canAccessRasterDistrict } from "@/lib/raster/access";
+import {
+  canAccessRasterDistrict,
+  listAccessibleRasterScopes,
+} from "@/lib/raster/access";
 import { Role } from "../../generated/prisma/enums";
 
 vi.mock("@/lib/db", () => ({
@@ -45,5 +48,88 @@ describe("raster access", () => {
       },
       select: { id: true },
     });
+  });
+
+  it("lists scopes a scoped user may open", async () => {
+    prismaMock.scope.findMany.mockResolvedValue([
+      {
+        code: "OWL",
+        name: "Ostwestfalen-Lippe",
+        parent: {
+          code: "WTTV",
+          name: "Westdeutscher Tischtennis-Verband",
+          parent: { code: "DE", name: "Germany" },
+        },
+      },
+    ] as never);
+
+    await expect(
+      listAccessibleRasterScopes({ id: "user-1", role: Role.SCOPE_USER }),
+    ).resolves.toEqual([
+      {
+        code: "OWL",
+        name: "Ostwestfalen-Lippe",
+        parent: {
+          code: "WTTV",
+          name: "Westdeutscher Tischtennis-Verband",
+          parent: { code: "DE", name: "Germany" },
+        },
+      },
+    ]);
+
+    expect(prismaMock.scope.findMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { userAssignments: { some: { userId: "user-1" } } },
+          { parent: { userAssignments: { some: { userId: "user-1" } } } },
+          {
+            parent: {
+              parent: { userAssignments: { some: { userId: "user-1" } } },
+            },
+          },
+        ],
+      },
+      select: {
+        code: true,
+        name: true,
+        parent: {
+          select: {
+            code: true,
+            name: true,
+            parent: { select: { code: true, name: true } },
+          },
+        },
+      },
+    });
+  });
+
+  it("sorts accessible scopes by hierarchy path", async () => {
+    prismaMock.scope.findMany.mockResolvedValue([
+      {
+        code: "OWL",
+        name: "Ostwestfalen-Lippe",
+        parent: {
+          code: "WTTV",
+          name: "Westdeutscher Tischtennis-Verband",
+          parent: { code: "DE", name: "Germany" },
+        },
+      },
+      {
+        code: "AACHEN_EUREGIO",
+        name: "Aachen/Euregio",
+        parent: {
+          code: "WTTV",
+          name: "Westdeutscher Tischtennis-Verband",
+          parent: { code: "DE", name: "Germany" },
+        },
+      },
+    ] as never);
+
+    await expect(
+      listAccessibleRasterScopes({ id: "admin-1", role: Role.PLATFORM_ADMIN }),
+    ).resolves.toMatchObject([
+      { code: "AACHEN_EUREGIO" },
+      { code: "OWL" },
+    ]);
   });
 });

--- a/webapp/tests/unit/raster-input-sets-route.test.ts
+++ b/webapp/tests/unit/raster-input-sets-route.test.ts
@@ -77,7 +77,12 @@ describe("raster input set route", () => {
 
     expect(response.status).toBe(201);
     expect(prismaMock.rasterInputSet.create).toHaveBeenCalledWith({
-      data: { district: "OWL", name: "OWL 2026", createdById: "admin-1" },
+      data: {
+        district: "OWL",
+        season: "2026/27",
+        name: "OWL 2026",
+        createdById: "admin-1",
+      },
     });
   });
 });

--- a/webapp/tests/unit/raster-runs-route.test.ts
+++ b/webapp/tests/unit/raster-runs-route.test.ts
@@ -54,4 +54,61 @@ describe("raster runs route", () => {
     });
     expect(prismaMock.rasterOptimizationRun.create).not.toHaveBeenCalled();
   });
+
+  it("starts a run without fixed Rasterzahlen", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      id: "input-wttv",
+      name: "WTTV 2026",
+      district: "WTTV",
+      createdById: "admin-1",
+      createdAt: new Date("2026-07-10T00:00:00Z"),
+      status: InputSetStatus.READY,
+      seasonModelJson: "{}",
+      _count: { wishes: 12, fixedRasterzahlen: 0 },
+    } as never);
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(prismaMock),
+    );
+    prismaMock.rasterOptimizationRun.create.mockResolvedValue({
+      id: "run-1",
+      inputSetId: "input-wttv",
+    } as never);
+    prismaMock.backgroundJob.create.mockResolvedValue({ id: "job-1" } as never);
+    prismaMock.rasterOptimizationRun.update.mockResolvedValue({
+      id: "run-1",
+      jobId: "job-1",
+    } as never);
+    prismaMock.auditEntry.create.mockResolvedValue({ id: "audit-1" } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/input-sets/input-wttv/runs", {
+        method: "POST",
+        body: JSON.stringify({ timeLimitSeconds: 60 }),
+      }),
+      { params: Promise.resolve({ id: "input-wttv" }) },
+    );
+
+    expect(response.status).toBe(202);
+    expect(prismaMock.rasterOptimizationRun.create).toHaveBeenCalledWith({
+      data: {
+        inputSetId: "input-wttv",
+        startedById: "admin-1",
+        settings: JSON.stringify({ timeLimitSeconds: 60, weights: {} }),
+      },
+    });
+    expect(prismaMock.backgroundJob.create).toHaveBeenCalledWith({
+      data: {
+        jobType: "raster_run",
+        payload: JSON.stringify({ runId: "run-1" }),
+        createdByUserId: "admin-1",
+      },
+    });
+  });
 });

--- a/webapp/tests/unit/raster-sources-delete-route.test.ts
+++ b/webapp/tests/unit/raster-sources-delete-route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const { deleteRasterSource, requireApiUser } = vi.hoisted(() => ({
+  deleteRasterSource: vi.fn(),
+  requireApiUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/route-auth", () => ({
+  requireApiUser,
+}));
+
+vi.mock("@/services/raster", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/raster")>()),
+  deleteRasterSource,
+}));
+
+import { DELETE } from "@/app/api/raster/sources/[id]/route";
+
+describe("raster source delete route", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes an existing source for platform admins", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.rasterSource.findUnique.mockResolvedValue({
+      id: "source-1",
+      scope: { code: "WTTV" },
+    } as never);
+    deleteRasterSource.mockResolvedValue({ id: "source-1" });
+
+    const response = await DELETE(
+      new Request("http://localhost/api/raster/sources/source-1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id: "source-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(deleteRasterSource).toHaveBeenCalledWith("source-1");
+  });
+
+  it("returns 404 for missing sources", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.rasterSource.findUnique.mockResolvedValue(null);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/raster/sources/missing", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ id: "missing" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(deleteRasterSource).not.toHaveBeenCalled();
+  });
+});

--- a/webapp/tests/unit/raster-sources-route.test.ts
+++ b/webapp/tests/unit/raster-sources-route.test.ts
@@ -40,7 +40,10 @@ describe("raster sources route", () => {
     expect(response.status).toBe(200);
     expect(prismaMock.rasterSource.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { scopeId: { in: ["owl", "wttv", "de"] } },
+        where: expect.objectContaining({
+          scopeId: { in: ["owl", "wttv", "de"] },
+          season: "2026/27",
+        }),
       }),
     );
   });
@@ -74,6 +77,7 @@ describe("raster sources route", () => {
       expect.objectContaining({
         create: expect.objectContaining({
           scopeId: "wttv",
+          season: "2026/27",
           sourceType: "GROUP_ASSIGNMENT",
         }),
       }),

--- a/webapp/tests/unit/raster-sources-service.test.ts
+++ b/webapp/tests/unit/raster-sources-service.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/raster/pipeline", async (importOriginal) => {
     rasterIngest: {
       ...actual.rasterIngest,
       scrapeClickTtAssignments: vi.fn(),
+      scrapeClickTtPublicLeagueAssignments: vi.fn(),
     },
   };
 });
@@ -34,11 +35,12 @@ describe("raster sources service", () => {
     } as never);
     prismaMock.rasterSource.findMany.mockResolvedValue([] as never);
 
-    await listRasterSourcesForDistrict("OWL", "GROUP_ASSIGNMENT");
+    await listRasterSourcesForDistrict("OWL", "2026/27", "GROUP_ASSIGNMENT");
 
     expect(prismaMock.rasterSource.findMany).toHaveBeenCalledWith({
       where: {
         scopeId: { in: ["owl", "wttv", "de"] },
+        season: "2026/27",
         sourceType: "GROUP_ASSIGNMENT",
       },
       orderBy: [{ updatedAt: "desc" }, { displayName: "asc" }],
@@ -116,5 +118,76 @@ describe("raster sources service", () => {
       },
       include: { scope: true },
     });
+  });
+
+  it("passes click-TT group filters from source refs", async () => {
+    const { rasterIngest } = await import("@/lib/raster/pipeline");
+    vi.mocked(rasterIngest.scrapeClickTtAssignments).mockResolvedValue([]);
+    prismaMock.rasterSource.findUnique.mockResolvedValue({
+      id: "source-filtered",
+      sourceType: "GROUP_ASSIGNMENT",
+      sourceRef:
+        "clicktt://group-assignment?groupNamePattern=^(?:NRW-Liga|Verbandsliga|Landesliga)",
+      scope: { id: "wttv", code: "WTTV" },
+    } as never);
+    prismaMock.rasterSource.update.mockResolvedValue({
+      id: "source-filtered",
+    } as never);
+
+    await refreshRasterSource("source-filtered");
+
+    expect(rasterIngest.scrapeClickTtAssignments).toHaveBeenCalledWith({
+      groupNamePattern: "^(?:NRW-Liga|Verbandsliga|Landesliga)",
+    });
+  });
+
+  it("scrapes public league URLs from click-TT source refs", async () => {
+    const { rasterIngest } = await import("@/lib/raster/pipeline");
+    vi.mocked(rasterIngest.scrapeClickTtPublicLeagueAssignments).mockResolvedValue(
+      [],
+    );
+    prismaMock.rasterSource.findUnique.mockResolvedValue({
+      id: "source-public",
+      sourceType: "GROUP_ASSIGNMENT",
+      sourceRef:
+        "clicktt://group-assignment?publicLeagueUrl=https%3A%2F%2Fwttv.click-tt.de%2Fcgi-bin%2FWebObjects%2FnuLigaTTDE.woa%2Fwa%2FleaguePage",
+      scope: { id: "wttv", code: "WTTV" },
+    } as never);
+    prismaMock.rasterSource.update.mockResolvedValue({
+      id: "source-public",
+    } as never);
+
+    await refreshRasterSource("source-public");
+
+    expect(
+      rasterIngest.scrapeClickTtPublicLeagueAssignments,
+    ).toHaveBeenCalledWith(
+      "https://wttv.click-tt.de/cgi-bin/WebObjects/nuLigaTTDE.woa/wa/leaguePage",
+    );
+  });
+
+  it("scrapes raw click-TT league page URLs as group assignments", async () => {
+    const { rasterIngest } = await import("@/lib/raster/pipeline");
+    vi.mocked(rasterIngest.scrapeClickTtPublicLeagueAssignments).mockResolvedValue(
+      [],
+    );
+    prismaMock.rasterSource.findUnique.mockResolvedValue({
+      id: "source-raw-public",
+      sourceType: "GROUP_ASSIGNMENT",
+      sourceRef:
+        "https://wttv.click-tt.de/cgi-bin/WebObjects/ClickWTTV.woa/wa/leaguePage?championship=WTTV%2026/27",
+      scope: { id: "wttv", code: "WTTV" },
+    } as never);
+    prismaMock.rasterSource.update.mockResolvedValue({
+      id: "source-raw-public",
+    } as never);
+
+    await refreshRasterSource("source-raw-public");
+
+    expect(
+      rasterIngest.scrapeClickTtPublicLeagueAssignments,
+    ).toHaveBeenCalledWith(
+      "https://wttv.click-tt.de/cgi-bin/WebObjects/ClickWTTV.woa/wa/leaguePage?championship=WTTV%2026/27",
+    );
   });
 });

--- a/webapp/tests/unit/raster-sources-upload-route.test.ts
+++ b/webapp/tests/unit/raster-sources-upload-route.test.ts
@@ -48,7 +48,7 @@ describe("raster source upload route", () => {
     formData.set("scopeCode", "WTTV");
     formData.set("sourceType", "WISHES_PDF");
     formData.set("displayName", "WTTV wishes");
-    formData.set("file", new File(["pdf"], "wishes.pdf"));
+    formData.set("file", new File(["%PDF-1.4"], "wishes.pdf"));
 
     const response = await POST(
       new Request("http://localhost/api/raster/sources/upload", {
@@ -61,9 +61,86 @@ describe("raster source upload route", () => {
     expect(saveFile).toHaveBeenCalledWith(expect.any(Buffer), "wishes.pdf");
     expect(upsertRasterSource).toHaveBeenCalledWith({
       scopeId: "wttv",
+      season: "2026/27",
       sourceType: "WISHES_PDF",
       sourceRef: "uploads/2026/07/source.pdf",
       displayName: "WTTV wishes",
     });
+  });
+
+  it("saves multiple uploaded files as separate sources", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "owl" } as never);
+    saveFile
+      .mockResolvedValueOnce("uploads/2026/07/wishes-a.pdf")
+      .mockResolvedValueOnce("uploads/2026/07/wishes-b.pdf");
+    upsertRasterSource
+      .mockResolvedValueOnce({ id: "source-a" })
+      .mockResolvedValueOnce({ id: "source-b" });
+
+    const formData = new FormData();
+    formData.set("scopeCode", "OWL");
+    formData.set("sourceType", "WISHES_PDF");
+    formData.append("file", new File(["%PDF-1.4 a"], "wishes-a.pdf"));
+    formData.append("file", new File(["%PDF-1.4 b"], "wishes-b.pdf"));
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/sources/upload", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+    const body = (await response.json()) as { sources: unknown[] };
+
+    expect(response.status).toBe(201);
+    expect(body.sources).toHaveLength(2);
+    expect(saveFile).toHaveBeenCalledTimes(2);
+    expect(upsertRasterSource).toHaveBeenNthCalledWith(1, {
+      scopeId: "owl",
+      season: "2026/27",
+      sourceType: "WISHES_PDF",
+      sourceRef: "uploads/2026/07/wishes-a.pdf",
+      displayName: "wishes-a.pdf",
+    });
+    expect(upsertRasterSource).toHaveBeenNthCalledWith(2, {
+      scopeId: "owl",
+      season: "2026/27",
+      sourceType: "WISHES_PDF",
+      sourceRef: "uploads/2026/07/wishes-b.pdf",
+      displayName: "wishes-b.pdf",
+    });
+  });
+
+  it("rejects wish PDF uploads that are not PDFs", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "owl" } as never);
+
+    const formData = new FormData();
+    formData.set("scopeCode", "OWL");
+    formData.set("sourceType", "WISHES_PDF");
+    formData.set("file", new File(["not a pdf"], "wishes.pdf"));
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/sources/upload", {
+        method: "POST",
+        body: formData,
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    expect(saveFile).not.toHaveBeenCalled();
+    expect(upsertRasterSource).not.toHaveBeenCalled();
   });
 });

--- a/webapp/worker/src/starter_worker/db.py
+++ b/webapp/worker/src/starter_worker/db.py
@@ -1421,6 +1421,7 @@ def _find_overage_rows(model: dict[str, Any], assignment: dict[str, Any]) -> lis
     groups = _dicts(model.get("groups"))
     clubs = _dicts(model.get("clubs"))
     team_group = {str(team_id): group for group in groups for team_id in group.get("teamIds", [])}
+    group_byes = {_group_key(group): _unused_rasterzahl(group, assignment) for group in groups}
     slots: dict[tuple[str, str, str, int], dict[str, Any]] = {}
     for team in teams:
         team_id = str(team.get("id") or "")
@@ -1431,7 +1432,7 @@ def _find_overage_rows(model: dict[str, Any], assignment: dict[str, Any]) -> lis
         capacity = _capacity_for(clubs, team)
         if capacity is None:
             continue
-        for week in _home_weeks(group, rasterzahl):
+        for week in _home_weeks(group, rasterzahl, group_byes.get(_group_key(group))):
             key = (
                 str(team.get("clubId") or ""),
                 str(team.get("hall") or "1"),
@@ -1483,10 +1484,29 @@ def _capacity_for(clubs: list[dict[str, Any]], team: dict[str, Any]) -> int | No
     return None
 
 
-def _home_weeks(group: dict[str, Any], rasterzahl: int) -> list[int]:
+def _group_key(group: dict[str, Any]) -> str:
+    ref = group.get("ref") if isinstance(group.get("ref"), dict) else {}
+    return f"{ref.get('league') or ''}::{ref.get('name') or ''}"
+
+
+def _unused_rasterzahl(group: dict[str, Any], assignment: dict[str, Any]) -> int | None:
+    group_size = int(group.get("size") or 0)
+    if group_size % 2 == 0:
+        return None
+    size = _numeric_raster_size(_raster_size_for_group(group))
+    used = {int(assignment.get(str(team_id)) or 0) for team_id in group.get("teamIds", [])}
+    return next((value for value in range(1, size + 1) if value not in used), None)
+
+
+def _numeric_raster_size(size: int | str) -> int:
+    return 6 if size == "6d" else int(size)
+
+
+def _home_weeks(group: dict[str, Any], rasterzahl: int, bye: int | None = None) -> list[int]:
     size = _raster_size_for_group(group)
     group_size = int(group.get("size") or 0)
-    bye = size if group_size % 2 == 1 else None
+    if bye is None and group_size % 2 == 1:
+        bye = _numeric_raster_size(size)
     if rasterzahl == bye:
         return []
 
@@ -1522,6 +1542,8 @@ def _home_weeks(group: dict[str, Any], rasterzahl: int) -> list[int]:
 
 def _raster_size_for_group(group: dict[str, Any]) -> int | str:
     group_size = int(group.get("size") or 0)
+    if group_size == 5:
+        return 6
     if group_size == 6 and group.get("rasterMode") == "double":
         return "6d"
     if group_size == 6:


### PR DESCRIPTION
## Summary
- Adds the latest raster webapp updates for season-aware input sets, click-TT URL/source handling, guided upload/review flow, and odd-group/solver behavior.
- Adds feature 004 Spec Kit artifacts for raster run comparison, alternative optimizer strategies, manual assignment scoring, shared KPIs, and scenario detail review.

## Notes
- The clean spec-only branch spec/004-compare-raster-runs is redundant with the 004 docs in this PR.
- The claude/speckit-clarify-041a87 branch should stay parked; its useful 003 ideas are captured in its salvage note for later follow-up.