### PR TITLE
Spec 007: Scope access management

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,9 @@ jobs:
       AUTH_BASE_URL: http://localhost:3290/app-starter
       BETTERAUTH_SECRET: ci-betterauth-secret-for-playwright-tests-only
       DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
+      # E2E provisions and resets this database; it never falls back to
+      # DATABASE_URL. On CI the two point at the same throwaway container.
+      E2E_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       MIGRATION_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       WORKER_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       # The worker suite gets its own database on the same container so a pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Auto-generated from all feature plans. Last updated: 2026-07-15
 - TypeScript 5.9 (strict), Node.js LTS 22.x + Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod, Tailwind 4 / shadcn — all already present in `webapp/`; this feature adds none (005-raster-guided-navigation)
 - PostgreSQL via `webapp/prisma/schema.postgres.prisma` (single schema; no dev SQLite schema in this repo) (005-raster-guided-navigation)
 - TypeScript 5.9 (strict), Node.js LTS 22.x; Python 3.12 for the existing CP-SAT solver, invoked as a subprocess + Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod, Tailwind 4 / shadcn — all present; this feature adds none (006-combined-wttv-planning)
+- TypeScript 5.9 (strict), Node.js LTS 22.x + Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod — all present; this feature adds none (007-scope-access-management)
+- PostgreSQL via `webapp/prisma/schema.postgres.prisma`. **No schema change** — `UserScopeAssignment` already exists with `@@unique([userId, scopeId])` (007-scope-access-management)
 
 - TypeScript 5.x, Node.js LTS (22.x) + Playwright (browser automation), dotenv (credentials), minimist (CLI args) (main)
 
@@ -34,6 +36,7 @@ TypeScript 5.x, Node.js LTS (22.x): Follow standard conventions
 - 009-nuliga-team-roster-import: Added TypeScript 5.9 (strict), Node.js LTS 22.x — both halves + CLI — Playwright, dotenv, minimist (all present). Webapp — Next.js 16, Prisma 7, zod (all present). **One new dependency is likely**: a zip reader for the webapp's bundle path (FR-019a), justified below.
 - 008-wish-import-conflicts: Added TypeScript 5.9 (strict), Node.js LTS 22.x + Next.js 16, React 19, Prisma 7, zod — all present; this feature adds none
 - 006-combined-wttv-planning: Added TypeScript 5.9 (strict), Node.js LTS 22.x; Python 3.12 for the existing CP-SAT solver, invoked as a subprocess + Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod, Tailwind 4 / shadcn — all present; this feature adds none
+- 007-scope-access-management: Added TypeScript 5.9 (strict), Node.js LTS 22.x + Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod — all present; this feature adds none
 - 005-raster-guided-navigation: Added TypeScript 5.9 (strict), Node.js LTS 22.x + Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod, Tailwind 4 / shadcn — all already present in `webapp/`; this feature adds none
 - 004-compare-raster-runs: Added TypeScript 5.9 strict for webapp/root raster code; Python 3.12 for the existing CP-SAT subprocess + Existing Next.js 16, React 19, Prisma 7, better-auth, next-intl, zod, Tailwind/shadcn; existing root `src/raster/*`; existing Python OR-Tools CP-SAT script
 

--- a/specs/007-scope-access-management/checklists/requirements.md
+++ b/specs/007-scope-access-management/checklists/requirements.md
@@ -1,0 +1,65 @@
+# Specification Quality Checklist: Scope Access Management
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-07-14  
+**Updated**: 2026-07-14 (clarify session: 5 questions asked and answered; all open questions resolved)  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+**Status: ready for `/speckit.plan`.**
+
+## Notes
+
+### The feature nearly shipped as "read-only access to a Bezirk"
+
+The clarify session's first question changed the shape of this feature. A scope assignment currently grants **viewing and nothing else**: `access.ts` defines a `scheduler` level covering `PLATFORM_ADMIN` and `SCOPE_ADMIN`, but the Raster page never consults it and hardcodes `Role.PLATFORM_ADMIN` in seven places — every source upload, input-set creation, capacity edit, run start, and manual assignment. `SCOPE_ADMIN` is therefore indistinguishable from `SCOPE_USER` in Raster today.
+
+Without asking, this spec would have delivered a way to grant someone the right to look at a Bezirk while every run in all 13 still routed through a platform admin. User Story 2 and FR-016 to FR-019 exist because of that answer, and they are most of the feature's value.
+
+### What the ask turned out to be
+
+Roles, `UserScopeAssignment`, platform admins seeing everything, and scoped filtering all exist. Two things do not: any way to **create or remove an assignment** (the users API has approve, deactivate, reactivate, role, theme — nothing for scopes), and any way for a non-platform-admin to **act** on a scope. This feature is those two things.
+
+### Decisions worth not re-deriving
+
+- **Exact match wins** (FR-010, FR-011). `rbac.ts` matched exactly; `raster/access.ts` walked to grandparent. Blast radius is smaller than it first appeared — `checkScopeAccess` has exactly one caller (`route-context.ts:80`) — but the two rules genuinely disagreed and the Verband case made it visible.
+- **Runs survive revocation** (FR-032 to FR-034). A run is the scope's work, not the individual's. Cancelling a long CP-SAT run because someone changed jobs destroys work the Bezirk still needs.
+- **Search, don't browse** (FR-026 to FR-029). Scope admins need to grant a first scope to someone holding none, which rules out "only show users in my scopes"; exact-identifier search gets that without handing every Bezirk admin the org's user directory.
+- **Lockout is prevented** (FR-012a). Zero platform admins means no scope administration and no recovery except editing the database — the exact thing this feature removes the need for.
+- **Germany is not assignable** (FR-004a). Under exact-match it would grant access to nothing.
+
+### Live risks
+
+- **FR-017 is the risky one.** Replacing seven page-level platform-admin checks with level-based checks widens who can act. Each needs its own API-side enforcement (FR-019); the page gate is not a security boundary. Getting one wrong grants a scope user the ability to start runs.
+- **FR-025 opens user management to a new role.** The page is gated once, in the page component. Widening it means every action needs its own authorisation.
+- **FR-021 to FR-024 are the escalation surface.** A scope admin must not grant beyond their own scopes or raise a role above their own, enforced at the API regardless of what the UI offers.
+
+### Deferred deliberately
+
+- **The WTTV-wide scheduler** (FR-014, FR-015). A known goal, blocked on the organisation establishing the role, gated on the same business change as feature 006. Not built; kept buildable. FR-015 matters more than it looks: if granting 13 Bezirke is tedious enough, someone will reach for a platform admin grant instead, which is the conflation this avoids.
+- **Scope creation** stays with seeding. This feature assigns users to scopes; it does not manage the hierarchy.
+- **Source inheritance** (`003` FR-008c) governs where source material is valid, not who may see it. Untouched.

--- a/specs/007-scope-access-management/checklists/requirements.md
+++ b/specs/007-scope-access-management/checklists/requirements.md
@@ -55,8 +55,14 @@ Roles, `UserScopeAssignment`, platform admins seeing everything, and scoped filt
 ### Live risks
 
 - **FR-017 is the risky one.** Replacing seven page-level platform-admin checks with level-based checks widens who can act. Each needs its own API-side enforcement (FR-019); the page gate is not a security boundary. Getting one wrong grants a scope user the ability to start runs.
-- **FR-025 opens user management to a new role.** The page is gated once, in the page component. Widening it means every action needs its own authorisation.
-- **FR-021 to FR-024 are the escalation surface.** A scope admin must not grant beyond their own scopes or raise a role above their own, enforced at the API regardless of what the UI offers.
+- **FR-025 opens user management to a new role.** The page is gated once, in the page component, and then loads *every* user. Widening it means every action needs its own authorisation — and the **order** of tasks T018–T022 is the safety property, not a preference: widening the gate before the per-action checks exist, even for one commit, hands the directory to every Bezirk admin.
+- **FR-021 to FR-024 are the escalation surface.** A scope admin must not grant beyond their own scopes or raise a role above their own, enforced at the API regardless of what the UI offers. **FR-023 (no self-modification) is what makes FR-021 durable** — without it, a scope admin grants themselves a scope and FR-021 then passes for it. FR-021 constrains an instant; FR-023 constrains the sequence.
+- **FR-012a is already implemented** (found at planning, 2026-07-15). `ensureAdminUserCanChange` in `services/api/user-admin.ts` already refuses to change or deactivate the last admin, inside a `Serializable` transaction with retry. The clarify session asked whether to prevent lockout; the answer was already in the code. T013 tests it rather than building it — nothing currently pins the behaviour, which is the real gap.
+
+### What `/speckit.analyze` caught (2026-07-15)
+
+- **The 005 dependency was described as cosmetic. It is structural.** plan.md claimed this "could be built against 004 with the labels renamed", while T004 reuses 005's `lib/raster/scope-level.ts` and T015 replaces the hardcoded checks *in the step pages 005 creates*. Corrected in both. A wrong dependency claim is worse than no claim — it invites someone to start on a base missing the prerequisites.
+- **FR-014 has no task, deliberately.** Like 005's FR-026, it is a constraint on a design rather than a deliverable: exact match must not foreclose a WTTV-wide scheduler. Nothing is built for it; it constrains what T003 and T007 may do. Treated the same way 005 treats FR-026.
 
 ### Deferred deliberately
 

--- a/specs/007-scope-access-management/contracts/scope-access.md
+++ b/specs/007-scope-access-management/contracts/scope-access.md
@@ -1,0 +1,93 @@
+# Phase 1 Contracts: Scope Access Management
+
+**Feature**: `007-scope-access-management` | **Date**: 2026-07-15
+
+One new endpoint pair, one new lookup, one changed authorisation level across existing raster routes, and one page whose gate moves from the top to each action.
+
+---
+
+## New: scope assignment
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/users/[id]/scopes` | `POST` | Grant a scope (FR-001, FR-020) |
+| `/api/users/[id]/scopes` | `DELETE` | Revoke a scope |
+| `/api/users/[id]/scopes` | `GET` | Which scopes this user holds (FR-041) |
+
+Follows `/api/users/[id]/role` — a thin route delegating to a service (`services/api/scope-assignments.ts`), matching `updateManagedUserRole`.
+
+### Authorisation, per request
+
+Every one of these is enforced **in the service**, not the route and not the UI (FR-024):
+
+| Rule | Applies to | Requirement |
+|---|---|---|
+| Platform admin may grant any assignable scope | `PLATFORM_ADMIN` | FR-001 |
+| Scope admin may grant only scopes they hold | `SCOPE_ADMIN` | FR-021 |
+| Scope admin may not alter their own assignments | `SCOPE_ADMIN` | FR-023 |
+| Germany is never assignable | all | FR-004a |
+| Granting a held scope is a no-op, not an error | all | FR-005 |
+| Refused requests alter nothing | all | FR-031 |
+
+**FR-023 is not a nicety.** Without self-exclusion, a scope admin holding OWL grants themselves Köln; FR-021 then passes for Köln, and the boundary has moved. FR-021 constrains an instant; FR-023 is what makes it hold over time.
+
+### Audit
+
+Every grant and revoke records actor, target user, scope and direction via the existing `safeLogAudit` (FR-030). A refused attempt records nothing and changes nothing (FR-031).
+
+---
+
+## New: user lookup for scope admins
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/users/lookup?email=<exact>` | `GET` | Find one user by exact email (FR-026) |
+
+**Contract**:
+
+- Matches the **full** email, exactly. No prefix, no substring, no wildcard, no `LIKE` (FR-027).
+- Returns at most one user, or nothing. Never a list.
+- A non-match returns a uniform "no user found" (FR-029).
+- Available to `SCOPE_ADMIN` and `PLATFORM_ADMIN`.
+
+Platform admins keep the existing `listUsers` (FR-028). Scope admins have no listing endpoint at all — not a filtered one, not a paginated one. The absence *is* the contract.
+
+---
+
+## Changed: raster authorisation level
+
+Raster API routes currently gate scheduling work at `"admin"`:
+
+```
+requireRasterInputSet(request, id, "admin")
+```
+
+which resolves to `levelRoles.admin = [PLATFORM_ADMIN]`. That is why a scope admin cannot start a run in their own Bezirk.
+
+**Becomes `"scheduler"`** for the work: source upload/refresh/delete, input-set creation, group review, capacity edit, validation, run start, manual assignment (FR-016, FR-017).
+
+`levelRoles.scheduler` already reads `[PLATFORM_ADMIN, SCOPE_ADMIN]` — no change to the levels themselves. `"admin"` stays platform-only for anything genuinely system-level. `"viewer"` keeps `SCOPE_USER` at read (FR-018).
+
+**The seven page checks are the visible half; these routes are the enforcing half.** Changing the page alone would show buttons that 403. Changing the routes alone would leave the capability unreachable. Both, and the routes are what FR-019 is about.
+
+---
+
+## Changed: users page
+
+| Actor | Sees |
+|---|---|
+| `PLATFORM_ADMIN` | The full user list, every action (FR-028) |
+| `SCOPE_ADMIN` | No list. Exact-email lookup, then actions confined to scopes they hold (FR-025, FR-027) |
+| Others | Not authorized, as today |
+
+Today the page gates once, in the component (`page.tsx:12`), then loads every user. Widening that gate without restructuring hands the directory to every Bezirk admin.
+
+So the **data load becomes actor-dependent**, and each action carries its own authorisation. The order of work matters: per-action authorisation first, widen the gate second. The reverse, even briefly, is a privilege escalation.
+
+---
+
+## Unchanged
+
+- `/api/users/[id]/role` keeps its contract and its last-admin guard (**already implemented** — `ensureAdminUserCanChange`). It gains a ceiling: a scope admin may not grant a role above their own (FR-022). Granting an equal role is permitted.
+- `/api/users/[id]/approve`, `/deactivate`, `/reactivate`, `/theme` — unchanged.
+- Authentication — untouched. This feature is authorisation only.

--- a/specs/007-scope-access-management/data-model.md
+++ b/specs/007-scope-access-management/data-model.md
@@ -1,0 +1,103 @@
+# Phase 1 Data Model: Scope Access Management
+
+**Feature**: `007-scope-access-management` | **Date**: 2026-07-15
+
+**No schema change.** This feature is unusual in that its entire data model already exists. Everything below is documentation of what is there and what this feature makes of it.
+
+---
+
+## Unchanged: UserScopeAssignment
+
+The feature's central entity. Already present.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `String @id @default(cuid())` | |
+| `userId` | `String` | FK to `User`, `onDelete: Cascade` |
+| `scopeId` | `String` | FK to `Scope`, `onDelete: Cascade` |
+| `createdAt` | `DateTime @default(now())` | |
+
+**Uniqueness**: `@@unique([userId, scopeId])` — already there, and it is what makes FR-005 (granting a held scope is not destructive) an upsert rather than a check-then-insert race.
+
+**What this feature adds**: nothing to the model. A way to create and delete rows, and a settled meaning for what a row grants.
+
+### What a row means, after FR-010
+
+Exactly the named scope. Not its ancestors, not its descendants.
+
+This is a **narrowing** of today's effective behaviour: `raster/access.ts` currently treats a row as also granting the scope's children and grandchildren. Removing that walk is the change; the row itself is untouched.
+
+### `onDelete: Cascade` on `scopeId`
+
+Worth noting because a spec edge case asks what happens when a scope is deleted while users are assigned. The answer is already decided: the assignments vanish. That is acceptable — scope creation and deletion are seed-only, and a scope that no longer exists cannot meaningfully be held. No change needed; the edge case is closed by existing schema.
+
+---
+
+## Unchanged: Scope
+
+| Field | Notes |
+|---|---|
+| `id`, `code`, `name` | `code` and `name` both unique |
+| `parentId` / `parent` / `children` | Self-relation. `DE` → `WTTV` → 13 Bezirke |
+| `userAssignments` | The relation this feature exercises |
+
+**Level derivation**: parent is root → Verband; grandparent is root → Bezirk. Feature 005 adds `lib/raster/scope-level.ts` for this; this feature reuses it for FR-004a (Germany is not assignable) and for labels.
+
+**Not assignable**: the Germany root (FR-004a). Under exact-match semantics an assignment to it would grant access to nothing, since nothing is planned at that level. Enforced in the service layer — Prisma cannot express "FK to a subset of rows".
+
+---
+
+## Unchanged: User and Role
+
+| Role | Meaning after this feature |
+|---|---|
+| `PLATFORM_ADMIN` | Every scope without assignments (FR-012). Full user list (FR-028). May grant any scope (FR-001) |
+| `SCOPE_ADMIN` | Works in scopes they hold — import, review, capacity, runs (FR-016). May grant those scopes to others (FR-020), not to themselves (FR-023) |
+| `SCOPE_USER` | Views scopes they hold. No import, edit or run (FR-018) |
+
+**No role is added.** The spec's Out of Scope says so explicitly, and R-202 explains why none is needed: `SCOPE_ADMIN` already means "scheduler" in the access layer — the Raster page simply never asks.
+
+---
+
+## Existing behaviour this feature depends on
+
+| What | Where | Why it matters |
+|---|---|---|
+| `ensureAdminUserCanChange` | `services/api/user-admin.ts` | **Already implements FR-012a.** Refuses to change or deactivate the last admin, inside a `Serializable` transaction with retry. Do not rebuild it — verify and test it |
+| `levelRoles` | `lib/raster/access.ts` | Declares `scheduler: [PLATFORM_ADMIN, SCOPE_ADMIN]`. The intent FR-016 makes real |
+| `checkScopeAccess` | `lib/rbac.ts` | Already exact-match. One caller (`route-context.ts:80`). FR-011 resolves in its favour |
+| `safeLogAudit` | `lib/audit.ts` | FR-030's attribution. Add entries; do not build a mechanism |
+| `withSerializableRetry` | `services/api/user-admin.ts` | The concurrency pattern for grant/revoke, matching role changes |
+
+---
+
+## Validation rules
+
+| Rule | Source | Enforced |
+|---|---|---|
+| Only Bezirke and the Verband are assignable | FR-004a | Service layer + test. Not expressible in Prisma |
+| A user may hold several scopes | FR-004 | Already true — `@@unique([userId, scopeId])` is per pair |
+| Granting a held scope is not destructive | FR-005 | Upsert on the unique pair |
+| A scope admin grants only scopes they hold | FR-021 | Authorisation helper, enforced at the API (FR-024) |
+| A scope admin grants no role above their own | FR-022 | Same helper. Granting an equal role (`SCOPE_ADMIN`) is permitted |
+| A scope admin never alters their own assignments | FR-023 | Same helper. **This is what makes FR-021 durable** — without it, a scope admin grants themselves a scope and FR-021 then passes for it |
+| The last platform admin cannot be removed | FR-012a | **Already enforced.** Verify only |
+| Search returns at most one exact match | FR-026, FR-027 | Service layer + test |
+
+---
+
+## Concurrency
+
+Grant and revoke follow the pattern `updateManagedUserRole` already uses: a `Serializable` transaction with `withSerializableRetry`.
+
+This matters for one spec edge case — two admins changing the same user's assignments at once. The unique constraint makes a duplicate grant harmless; serializable isolation makes a concurrent grant-and-revoke resolve to one outcome rather than a lost update.
+
+---
+
+## Migration approach
+
+**None.** No schema change, so nothing to migrate.
+
+Existing `UserScopeAssignment` rows are seeded (`prisma/seed.ts` assigns the demo user to OWL) and stay valid — their meaning narrows under FR-010, but the seeded assignments are Bezirk-level, where exact-match and the ancestor walk agree.
+
+The narrowing only changes behaviour for a user assigned to `WTTV` or `DE`, and the seed creates no such assignment. So even the behaviour change touches nothing that exists.

--- a/specs/007-scope-access-management/plan.md
+++ b/specs/007-scope-access-management/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: Scope Access Management
+
+**Branch**: `007-scope-access-management` | **Date**: 2026-07-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-scope-access-management/spec.md`
+
+## Summary
+
+Let admins assign users to Bezirke and the Verband through the application rather than the database, make an assignment mean exactly one scope everywhere, and let a scope admin actually work in the scopes they hold instead of only looking at them.
+
+Almost nothing here is new construction. `UserScopeAssignment`, the three roles, platform admins seeing every scope, and scoped filtering all exist. The last-admin guard exists. What is missing is any way to **create or remove an assignment**, and any way for a non-platform-admin to **act**. This plan adds one endpoint pair, opens user management to scope admins with server-side authorisation on every action, resolves a genuine disagreement between two access rules, and replaces seven hardcoded role checks with the access levels the codebase already defines but never consults.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 (strict), Node.js LTS 22.x  
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Prisma 7, better-auth, next-intl, zod — all present; this feature adds none  
+**Storage**: PostgreSQL via `webapp/prisma/schema.postgres.prisma`. **No schema change** — `UserScopeAssignment` already exists with `@@unique([userId, scopeId])`  
+**Testing**: vitest (unit/integration), Playwright (e2e)  
+**Target Platform**: Next.js server + browser  
+**Project Type**: Web application, confined to `webapp/`  
+**Performance Goals**: No regression. Access checks already run per request  
+**Constraints**: No production data, so narrowing access from the hierarchy walk to exact match cannot disrupt a live user. Every authorisation decision must hold at the API independently of the interface  
+**Scale/Scope**: 13 Bezirke + Verband + Germany root, seeded. Three roles. Handful of users
+
+**Depends on feature 005**, structurally rather than cosmetically:
+
+- `lib/raster/scope-level.ts` (005's research R-005) — needed by FR-004a to know that Germany is not assignable and that a scope is a Bezirk or the Verband.
+- The Raster **step pages** — FR-017 replaces the seven hardcoded checks *where 005 puts them*. Against 004 those checks are still in one 571-line page, and the task means something different.
+- Bezirk/Verband terminology (005's FR-022a).
+
+An earlier draft of this plan called the coupling cosmetic and said this could be built against 004 with the labels renamed. That was wrong, and it mattered: acting on it would start the work on a base where `scope-level.ts` and the step pages do not exist.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Constitution v3.0.0.
+
+| Principle | Assessment |
+|---|---|
+| **I. Focused click-TT Administration Suite** | PASS. Within `webapp/`, capability 3. No new dependency. Principle I explicitly notes that "user login, user administration, and basic role management are provided by the existing baseline" — this extends that administration rather than inventing a parallel one |
+| **II. Safety-First Automation** | PASS. Read-only toward click-TT. This feature *narrows* access (FR-011) and adds server-side enforcement where a page-level check was the only guard — both in the principle's direction |
+| **III. Credential Security** | PASS. No credentials handled. This is authorisation, not authentication |
+| **IV. Idempotent & Resumable** | PASS. FR-005 requires granting an already-held scope to be non-destructive, which `@@unique([userId, scopeId])` plus an upsert gives naturally |
+| **V. Observable Output** | PASS, and advanced. FR-030 requires every grant and revoke attributable to an actor. The existing `safeLogAudit` carries it |
+| **VI. Quality Gates** | PASS. TypeScript strict, ESLint, Prettier, `webapp/validate.ps1` |
+
+**Result: no violations. Complexity Tracking not required.**
+
+Worth noting rather than filing: FR-016 *widens* what a scope admin may do — from viewing to importing, reviewing and running. That is a real expansion of blast radius, and Principle II's instinct is caution. But the expansion is confined to scopes the user already holds, and the access layer already declares the intent (`scheduler: [PLATFORM_ADMIN, SCOPE_ADMIN]`); the Raster page simply never consults it. This closes a gap between stated and actual behaviour rather than opening a new one. FR-019 (API-side enforcement) is what keeps it honest.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-scope-access-management/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── scope-access.md
+├── checklists/
+│   └── requirements.md  # From /speckit.specify + /speckit.clarify
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+webapp/
+├── prisma/
+│   └── schema.postgres.prisma           # UNCHANGED — UserScopeAssignment already exists
+├── src/
+│   ├── app/
+│   │   ├── (dashboard)/
+│   │   │   └── users/page.tsx           # PLATFORM_ADMIN-gated today; opens to SCOPE_ADMIN, filtered
+│   │   └── api/users/[id]/
+│   │       ├── scopes/route.ts          # new: grant (POST) / revoke (DELETE)
+│   │       └── role/route.ts            # existing: gains a scope-admin ceiling
+│   ├── components/auth/
+│   │   ├── UserManagementTable.tsx      # existing: scope column, per-row authorisation
+│   │   └── ScopeAssignmentDialog.tsx    # new
+│   ├── lib/
+│   │   ├── rbac.ts                      # checkScopeAccess: already exact-match; gains delegation helpers
+│   │   └── raster/access.ts             # ancestor walk removed (FR-011)
+│   └── services/api/
+│       ├── user-admin.ts                # existing patterns reused; last-admin guard already here
+│       └── scope-assignments.ts         # new
+└── tests/
+    ├── unit/                            # delegation rules, exact-match resolution
+    ├── integration/                     # grant/revoke, escalation attempts, search
+    └── e2e/                             # scope admin works in their Bezirk
+```
+
+**Structure Decision**: Existing web application under `webapp/`, extended in place. **No schema change** — this feature is entirely about giving existing data a way to be created, and existing rules a way to agree with each other. New code is one service, one endpoint pair, one dialog. The rest is subtraction: deleting an ancestor walk, deleting seven hardcoded role checks.
+
+## Complexity Tracking
+
+> Not required — Constitution Check passed with no violations.

--- a/specs/007-scope-access-management/quickstart.md
+++ b/specs/007-scope-access-management/quickstart.md
@@ -1,0 +1,109 @@
+# Quickstart: Scope Access Management
+
+**Feature**: `007-scope-access-management` | **Date**: 2026-07-15
+
+---
+
+## What this feature actually is
+
+Smaller than "permissions" suggests. `UserScopeAssignment`, the three roles, platform admins seeing everything, scoped filtering, and the last-admin guard **all already exist**.
+
+Two things do not:
+
+1. **Any way to create or remove an assignment.** The users API has approve, deactivate, reactivate, role, theme — and nothing for scopes. Granting someone a Bezirk today means editing the database.
+2. **Any way for a non-platform-admin to act.** `access.ts` declares `scheduler: [PLATFORM_ADMIN, SCOPE_ADMIN]`, and the Raster page ignores it, checking `PLATFORM_ADMIN` in seven places. So `SCOPE_ADMIN` is indistinguishable from `SCOPE_USER` in Raster.
+
+Much of the work is **subtraction**: delete an ancestor walk, delete seven hardcoded checks.
+
+---
+
+## Orientation
+
+| What | Why |
+|---|---|
+| `webapp/src/lib/rbac.ts` | `checkScopeAccess` — already exact-match, already correct. One caller |
+| `webapp/src/lib/raster/access.ts` | `levelRoles` (the intent) and the ancestor walk (the bug) |
+| `webapp/src/app/(dashboard)/raster/page.tsx` | The seven hardcoded `PLATFORM_ADMIN` checks. Feature 005 moves them; this fixes them |
+| `webapp/src/services/api/user-admin.ts` | The pattern to copy: `requireRouteUserWithRoles`, `withSerializableRetry`, `safeLogAudit`. Also holds `ensureAdminUserCanChange` — **FR-012a is already built** |
+| `webapp/src/app/(dashboard)/users/page.tsx:12` | The single gate that must become many |
+
+---
+
+## Build order
+
+Follows the spec's priorities. The order within Stage 3 is not negotiable.
+
+### Stage 1 — User Story 1: grant and revoke (P1)
+
+1. `services/api/scope-assignments.ts` — grant, revoke, list. Copy `user-admin.ts`'s shape.
+2. `/api/users/[id]/scopes` — POST, DELETE, GET.
+3. Assignment UI for platform admins.
+4. Remove the ancestor walk from `access.ts` (FR-011). `rbac.ts` is already right.
+
+**Verify**: grant a scoped user one Bezirk; they reach it and nothing else. Assign the Verband; they reach Verband-level data and no Bezirk below it.
+
+### Stage 2 — User Story 2: work in your scope (P2)
+
+1. Raster API routes: `"admin"` → `"scheduler"` for the work.
+2. The seven page checks → level-based.
+
+**Verify**: a scope admin holding OWL imports a source and starts a run there; the same attempt in a Bezirk they do not hold fails **at the API**, tested directly rather than through the UI.
+
+### Stage 3 — User Story 3: delegated administration (P3)
+
+**Order matters. Do not reorder.**
+
+1. The authorisation helper (may A grant S to U?) — FR-021, FR-022, FR-023.
+2. Wire it into the endpoints. Enforcement lives here.
+3. Exact-email lookup (FR-026, FR-027).
+4. Actor-dependent data load on the users page.
+5. **Only now** widen the page gate to `SCOPE_ADMIN`.
+
+Widening the gate before the per-action checks — even for one commit — is a privilege escalation, because the page currently loads every user.
+
+**Verify**: a scope admin grants their own Bezirk; attempts one they do not hold and is refused by the API; cannot grant themselves; cannot grant platform admin; cannot list users.
+
+### Stage 4 — User Story 4: see who has access (P4)
+
+Per-scope and per-user views, filtered to what the actor may see.
+
+---
+
+## Verification against success criteria
+
+| SC | How |
+|---|---|
+| SC-001 | Grant a Bezirk in under 30 seconds, no database |
+| SC-002 | A user with one Bezirk reaches it and nothing else, checked in every place that checks access |
+| SC-003 | A Verband assignment reaches Verband data and no Bezirk below |
+| SC-004 | The same user and scope resolve identically everywhere — no path grants more than another |
+| SC-005 | A scope admin cannot reach a scope they do not hold, **via the API directly**, not just the UI |
+| SC-006 | Every access change is attributable afterwards |
+| SC-007 | A scoped user with no assignments gets an explanation, not an error |
+| SC-008 | Answer "who can see this Bezirk?" without the database |
+| SC-009 | A scope admin starts a run in their Bezirk with no platform admin involved |
+| SC-010 | No run in any Bezirk needs a platform admin, given that Bezirk has a scope admin |
+| SC-011 | A scope user reaches no import, edit or run capability anywhere |
+| SC-012 | The system cannot be left with no active platform admin — **already true**; prove it |
+| SC-013 | A revoked user's in-flight run still produces its snapshot; they cannot see it |
+
+Run `webapp/validate.ps1` before commit — constitution Principle VI.
+
+---
+
+## Traps
+
+- **Rebuilding the last-admin guard.** `ensureAdminUserCanChange` exists, inside a `Serializable` transaction with retry. FR-012a needs a test, not an implementation.
+- **Widening the users page before the per-action checks.** The page loads every user. Order is the safety property.
+- **Trusting the UI.** FR-024 and FR-019: every check holds at the API independently. Hiding a button is not authorisation.
+- **Forgetting FR-023.** Without self-exclusion, a scope admin grants themselves a scope and FR-021 then passes for it. FR-021 constrains an instant; FR-023 makes it durable.
+- **Prefix or fuzzy user search.** Enumerable in a few queries. Exact full email, at most one result (FR-027).
+- **Adding a role.** None is needed. `SCOPE_ADMIN` already means scheduler; the page just never asks.
+- **Cancelling in-flight runs on revoke.** FR-032: a run is the scope's work, not the person's. It finishes.
+- **Making `checkScopeAccess` walk ancestors "for consistency".** Backwards. It is already right; the walk in `access.ts` is what goes.
+
+---
+
+## Out of scope
+
+Creating or restructuring scopes (seed-only); new roles; authentication; source inheritance (a different mechanism — where data is *valid*, not who may *see* it); self-service access requests; time-limited grants; the WTTV-wide scheduler (FR-014 keeps it buildable — 13 assignments is the interim, and FR-015 exists so the interim stays tolerable enough that nobody reaches for a platform-admin grant instead).

--- a/specs/007-scope-access-management/research.md
+++ b/specs/007-scope-access-management/research.md
@@ -1,0 +1,121 @@
+# Phase 0 Research: Scope Access Management
+
+**Feature**: `007-scope-access-management` | **Date**: 2026-07-15
+
+IDs numbered from R-201 to avoid collision with features 005 (R-001–R-008) and 006 (R-101–R-106).
+
+---
+
+## R-201: Which access rule survives, and what does removing the other cost?
+
+**Decision**: Exact match wins (FR-011). `rbac.ts` already does this and is correct; the ancestor walk in `raster/access.ts` is removed.
+
+**Rationale**: Two rules disagree today. `checkScopeAccess` in `webapp/src/lib/rbac.ts` matches the assigned scope exactly. `canAccessRasterDistrict` and `listAccessibleRasterScopes` in `webapp/src/lib/raster/access.ts` match on the assignment, **its parent, or its grandparent**. So a user assigned to the Verband reaches every Bezirk's Raster data while failing `checkScopeAccess` for those same Bezirke elsewhere.
+
+The blast radius is smaller than it first appears in each direction:
+
+- `checkScopeAccess` has **exactly one caller** — `webapp/src/services/api/route-context.ts:80`, behind `options.scopeRestricted`. Keeping it costs nothing.
+- The ancestor walk lives in two functions in one file. Removing it is local.
+
+The cost is real but bounded: a Verband assignment stops conferring Bezirk access, and a WTTV-wide scheduler needs 13 assignments. No production data exists, so nothing shifts under a live user. FR-014 keeps a cascading grant buildable later; FR-015 requires bulk assignment to stay tolerable so nobody reaches for a platform-admin grant instead.
+
+**Alternatives considered**:
+- *Cascade wins*: fewer assignments for a WTTV-wide role, but every assignment's blast radius becomes implicit — "assigned to WTTV" would silently mean 14 scopes. The explicit version is auditable; FR-014 leaves the door open if the tedium proves real.
+- *Per-assignment cascade flag*: the eventual answer if a WTTV-wide scheduler materialises, and premature now. It is FR-014's most likely shape.
+
+---
+
+## R-202: How does a scope admin gain the ability to act?
+
+**Decision**: Replace the seven hardcoded `Role.PLATFORM_ADMIN` checks in the Raster page with the existing `RasterAccessLevel` levels, and change the API routes that gate on `"admin"` to gate on `"scheduler"`.
+
+**Rationale**: `webapp/src/lib/raster/access.ts` already defines the intent:
+
+```
+viewer:    [PLATFORM_ADMIN, SCOPE_ADMIN, SCOPE_USER]
+scheduler: [PLATFORM_ADMIN, SCOPE_ADMIN]
+admin:     [PLATFORM_ADMIN]
+```
+
+A scope admin is already declared a scheduler. The Raster page never consults this — it checks `user.role === Role.PLATFORM_ADMIN` in seven places, gating every source upload, input-set creation, capacity edit, run start and manual assignment. So `SCOPE_ADMIN` is today indistinguishable from `SCOPE_USER` in Raster.
+
+The mapping is: **scheduler** for import, review, capacity edit and run start (the work); **admin** stays platform-only for anything genuinely system-level. FR-018 keeps `SCOPE_USER` at viewer.
+
+Note the API side is the larger half. `requireRasterInputSet(request, id, "admin")` appears across the raster routes; those become `"scheduler"`. The page checks are the visible half but the routes are the enforcing half — FR-019 exists because hiding a button is not authorisation.
+
+**Alternatives considered**:
+- *A new role*: unnecessary. The role exists and means this.
+- *Widen `levelRoles.admin` to include `SCOPE_ADMIN`*: collapses the distinction between scheduling work and system administration, and would grant scope admins anything later gated at `admin`.
+
+---
+
+## R-203: How is delegated administration enforced without escalation?
+
+**Decision**: One authorisation helper deciding "may actor A grant scope S to user U", called by the endpoint and by nothing else. The UI asks the same helper to decide what to offer, but the endpoint's call is the enforcement.
+
+**Rationale**: FR-021 to FR-024 are the escalation surface: a scope admin must not grant beyond scopes they hold (FR-021), must not grant a role above their own (FR-022), must not alter their own assignments (FR-023), and every one of those must hold at the API regardless of the interface (FR-024).
+
+The failure mode is scattering these checks — one in the dialog, one in the endpoint, one forgotten. A single helper with one enforcing caller makes "did we check?" answerable by reading one file.
+
+FR-023 (no self-modification) deserves emphasis: without it a scope admin holding OWL could grant themselves Köln, and the FR-021 check would then pass for Köln. Self-exclusion is what makes FR-021 hold over time rather than instantaneously.
+
+**Alternatives considered**:
+- *Check in the endpoint only*: correct but offers users actions that then fail.
+- *Middleware*: the decision needs the target user and scope from the body, which middleware would have to parse anyway.
+
+---
+
+## R-204: Is the last-platform-admin guard needed?
+
+**Decision**: It already exists. Verify and test it; do not build it.
+
+**Rationale**: `ensureAdminUserCanChange` in `webapp/src/services/api/user-admin.ts` already refuses to change the last admin's role ("Cannot change role of the last Admin user", line 347) and carries a `lastAdminMessage` path for status changes. Both run inside a `Serializable` transaction with retry, which is the right isolation — two concurrent demotions could otherwise each see another admin remaining.
+
+FR-012a is therefore satisfied by existing code. The clarify session asked whether to prevent lockout and the answer was yes; the answer was already implemented. What remains is a test proving it, since nothing currently pins the behaviour.
+
+**Consequence**: FR-012a's task is verification, not construction. Worth stating plainly so nobody re-implements a guard that exists.
+
+---
+
+## R-205: How is exact-identifier search built without enabling enumeration?
+
+**Decision**: A lookup returning at most one user, matching the full email exactly, with no partial matching, no wildcards, and no listing. Available to scope admins; platform admins keep `listUsers`.
+
+**Rationale**: FR-026 requires a scope admin to find a user holding no scopes yet — the common case for a first grant. FR-027 forbids browsing or enumerating. Exact match on the full email satisfies both: you can act on someone you already know of, and you cannot discover who exists.
+
+FR-029 (search must not reveal whether a non-matching identifier belongs to a user) is weaker than it sounds and should not be over-engineered. Granting access to an address inherently confirms it exists — the requirement is that *search itself* adds no signal beyond what granting requires. A uniform "no user found" response satisfies it.
+
+**Alternatives considered**:
+- *Prefix or fuzzy search*: friendlier, and enumerable with a few queries. Directly contradicts FR-027.
+- *Return the full list, filter client-side*: the list crosses the wire. FR-027 is a server concern.
+
+---
+
+## R-206: How does user management open to scope admins?
+
+**Decision**: Replace the page-level role gate with per-action authorisation, driven by R-203's helper, and scope the data the page loads to what the actor may see.
+
+**Rationale**: `webapp/src/app/(dashboard)/users/page.tsx:12` returns "not authorized" unless `user.role === Role.PLATFORM_ADMIN`, then loads **every** user with `prisma.user.findMany()`. That single gate is the only thing standing between a non-admin and the full user list.
+
+Widening it to `SCOPE_ADMIN` without restructuring would hand every Bezirk admin the whole directory — violating FR-027 immediately. So the page's data load becomes actor-dependent: platform admins get the list, scope admins get search only (R-205).
+
+This is the feature's riskiest change, and it is a subtraction of a guard before an addition of finer ones. The order matters: build the per-action authorisation first, open the page second.
+
+**Alternatives considered**:
+- *A separate page for scope admins*: avoids touching the existing gate, and duplicates the table, the actions and the authorisation. Two places to get right instead of one.
+- *Keep users platform-admin-only, delegate elsewhere*: contradicts FR-025, and delegation is the whole of User Story 3.
+
+---
+
+## Resolved unknowns summary
+
+| ID | Unknown | Decision |
+|---|---|---|
+| R-201 | Which access rule | Exact match; remove the ancestor walk. One caller of `checkScopeAccess` |
+| R-202 | Scope admin acting | Use the existing `scheduler` level; routes move `"admin"` → `"scheduler"` |
+| R-203 | Escalation | One authorisation helper, one enforcing caller. FR-023 is what makes FR-021 durable |
+| R-204 | Last-admin guard | **Already exists.** Verify and test; do not rebuild |
+| R-205 | User search | Exact full-email match, at most one result, no listing |
+| R-206 | Opening the users page | Per-action authorisation first, then widen the gate. Data load becomes actor-dependent |
+
+**No NEEDS CLARIFICATION remain.** Spec Q1, Q2 and Q3 were resolved in the clarify session.

--- a/specs/007-scope-access-management/spec.md
+++ b/specs/007-scope-access-management/spec.md
@@ -1,0 +1,256 @@
+# Feature Specification: Scope Access Management
+
+**Feature Branch**: `007-scope-access-management`  
+**Created**: 2026-07-14  
+**Status**: Draft  
+**Input**: User description: "Having permissions on the districts and also verband and be able to assign roles to users / that only some users can see all and others can only see certain district(s)."
+
+**Terminology**: "Scope" is the existing system's word for a level of the Germany → Verband → Bezirk tree. A Bezirk is a scope; the Verband (WTTV) is a scope. Following feature 005, the UI names these levels "Bezirk" and "Verband", never "District".
+
+## Clarifications
+
+### Session 2026-07-14
+
+- Q: Should a scope admin be able to import, review, and run within a Bezirk they hold? → A: Yes. A scope admin works in the scopes they hold, exactly as a platform admin does in any scope. The `scheduler` access level already declares this (`PLATFORM_ADMIN` and `SCOPE_ADMIN`) but the Raster page ignores it and hardcodes `PLATFORM_ADMIN` in seven places. This feature wires the page to the levels that already exist, so that assigning a scope grants the ability to work in it rather than only to look at it.
+- Q: When a scope admin manages access, which users can they see? → A: Only users they find by searching an exact identifier. No browsable user list for scope admins. This keeps first-time grants possible without exposing the organisation's user directory to every Bezirk admin. Platform admins keep the full list.
+- Q: What happens to a queued or running run when the user who started it loses access to that scope? → A: It finishes. A run is the scope's work, not the individual's, and it survives their access changing. The revoked user simply stops seeing it, like everything else in that scope. Revocation does not cancel compute.
+- Q: Should the system prevent removing the last platform admin? → A: Yes. Demoting or deactivating the last active platform admin is refused, with a stated reason. Recovery from zero platform admins means editing the database by hand, which is the thing this feature exists to eliminate.
+- Q: Should the Germany (DE) scope be assignable? → A: No. Only Bezirke and the Verband are assignable. Germany remains the root of the hierarchy and an owner of source material, but is not a level anyone is granted access to; under exact-match rules such an assignment would grant nothing.
+
+## Context: what already exists
+
+Most of the requested capability is built. The gap is narrower than "permissions".
+
+**Already working:**
+
+- `UserScopeAssignment` links a user to a scope, unique per pair.
+- Three roles exist: `PLATFORM_ADMIN`, `SCOPE_ADMIN`, `SCOPE_USER`.
+- A `PLATFORM_ADMIN` already sees every scope; scoped users already see a filtered set.
+- Role assignment already has an API and a UI.
+
+**Missing:**
+
+- There is no way to assign a scope to a user. The users API exposes approve, deactivate, reactivate, role, and theme — and nothing for scopes. Neither the users page nor any users API route mentions scope. Assignments exist only because the seed creates them, so granting someone access to a Bezirk today means editing the database by hand. This is the feature.
+
+**Broken, first:** a scope assignment currently grants only viewing. The access layer defines a `scheduler` level covering `PLATFORM_ADMIN` and `SCOPE_ADMIN` (`webapp/src/lib/raster/access.ts`), but the Raster page never consults it — it hardcodes `Role.PLATFORM_ADMIN` in seven places, gating every source upload, input-set creation, capacity edit, run start, and manual assignment. So a scope admin assigned to a Bezirk can look at it and do nothing else, and `SCOPE_ADMIN` is indistinguishable from `SCOPE_USER` in Raster. The intent exists in the access layer; it was never wired to the page.
+
+**Broken, second:** two access rules disagree about what an assignment means.
+
+- `checkScopeAccess` in `webapp/src/lib/rbac.ts` matches the assigned scope **exactly**, with no hierarchy walk.
+- `listAccessibleRasterScopes` and `canAccessRasterDistrict` in `webapp/src/lib/raster/access.ts` match an assignment on the scope, **its parent, or its grandparent**.
+
+So a user assigned to the Verband can reach every Bezirk's Raster data, while failing `checkScopeAccess` for those same Bezirke elsewhere. Both cannot be right. This feature settles it: an assignment grants that scope and nothing else.
+
+**Consequence, accepted deliberately**: removing the hierarchy walk narrows current Raster access. A user assigned to the Verband stops seeing Bezirk data, and a genuine WTTV-wide scheduler needs one assignment per Bezirk. There is no production data, so no live access changes underfoot.
+
+## Context: the WTTV-wide scheduler is coming, but not yet
+
+A single scheduler responsible for every Bezirk and the Verband together is a known goal. It is not built here because the organisation has not established the role yet, and until it does, Bezirke and the Verband are planned separately by separate people. This feature serves that present reality.
+
+Two things follow.
+
+First, this is the same organisational change that feature `006-combined-wttv-planning` waits on. A WTTV-wide scheduler is the natural operator of a combined WTTV run, and both are gated on the same business precondition rather than on any technical one. They will likely arrive together.
+
+Second, there is a gap in today's model worth naming. "Sees every scope" currently means exactly one thing: being a platform admin. A WTTV-wide scheduler who is not a platform admin has no representation — the only ways to express them today are 13 separate assignments, or granting them platform admin, which conflates system administration with planning reach. Neither is right. Whatever eventually represents this role (a cascading assignment, a Verband-wide grant, or a distinct role) is out of scope here, but FR-014 keeps it reachable.
+
+**Not in play**: source inheritance. A Bezirk input set consuming Verband-level sources (`specs/003-raster-review-webapp/spec.md`, FR-008c) is a separate mechanism about where data is valid, not about who may see it. It is unchanged.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Grant and revoke a user's access to a Bezirk or the Verband (Priority: P1)
+
+A platform admin opens user management, picks a user, and grants them access to one or more Bezirke, or to the Verband. They can revoke access the same way. The grant means exactly the scopes named: assigning the Verband grants Verband-level data only, not the Bezirke beneath it.
+
+**Why this priority**: It is the missing capability, and today the only alternative is editing the database by hand. Everything else here builds on it.
+
+**Independent Test**: As a platform admin, grant a scoped user access to one Bezirk, sign in as that user, and verify they see exactly that Bezirk's Raster data and no other. Revoke it and verify the access disappears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with no scope assignments, **When** a platform admin grants them a Bezirk, **Then** that user can reach that Bezirk's Raster data and no other scope's.
+2. **Given** a user assigned to the Verband, **When** they open Raster, **Then** they see Verband-level data and no Bezirk beneath it.
+3. **Given** a user with a scope assignment, **When** a platform admin revokes it, **Then** the user can no longer reach that scope's data.
+4. **Given** a user with no scope assignments and a scoped role, **When** they open Raster, **Then** they are told they have no scopes rather than shown an error.
+5. **Given** a platform admin, **When** they open Raster, **Then** they still see every scope without needing an assignment.
+6. **Given** any scope grant or revoke, **When** it is applied, **Then** it is recorded in the audit trail with the actor, the user, the scope, and the change.
+7. **Given** a user's scope list, **When** a platform admin views the user, **Then** the currently assigned scopes are visible without opening another page.
+
+---
+
+### User Story 2 - Work in the Bezirk you were granted (Priority: P2)
+
+A scope admin granted a Bezirk imports its sources, reviews its data, starts its runs, and edits its gym capacities — the same work a platform admin can do anywhere, confined to the scopes they hold. A scope user granted the same Bezirk sees all of it and changes none of it.
+
+**Why this priority**: Without it, User Story 1 grants the ability to look at a Bezirk and nothing more, and every run in all 13 Bezirke still routes through a platform admin. It is what makes an assignment worth granting. It is second only because a grant must exist before it can mean anything.
+
+**Independent Test**: Grant a scope admin one Bezirk. Signed in as them, import a source, start a run in that Bezirk, and verify both succeed. Attempt the same in a Bezirk they do not hold and verify both are refused, by the API as well as the interface.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scope admin holding a Bezirk, **When** they open it in Raster, **Then** they can import sources, review data, edit gym capacities, and start runs.
+2. **Given** a scope admin holding a Bezirk, **When** they attempt to act on a Bezirk they do not hold, **Then** the attempt is refused by the API independently of what the interface shows.
+3. **Given** a scope user holding a Bezirk, **When** they open it in Raster, **Then** they see its data and are offered no import, edit, or run controls.
+4. **Given** a scope admin holding the Verband, **When** they open it in Raster, **Then** they can work on Verband-level planning and on no Bezirk beneath it.
+5. **Given** a platform admin, **When** they open any scope, **Then** their capabilities are unchanged by this feature.
+
+---
+
+### User Story 3 - A Bezirk admin manages access to their own Bezirk (Priority: P3)
+
+A scope admin can grant and revoke access to the scopes they themselves hold, without waiting on a platform admin. They cannot grant access to any scope they do not hold, and cannot raise anyone's role beyond their own.
+
+**Why this priority**: It removes the platform admin as a bottleneck for routine access requests, but the system is usable without it — User Story 1 covers every grant, just centrally. It is also the most security-sensitive part, so it benefits from landing on top of a working, tested foundation.
+
+**Independent Test**: As a scope admin holding one Bezirk, grant a user access to that Bezirk and verify it works. Then attempt to grant a Bezirk you do not hold, and verify it is refused.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scope admin holding a Bezirk, **When** they grant a user access to that Bezirk, **Then** the grant succeeds.
+2. **Given** a scope admin, **When** they attempt to grant a scope they do not hold, **Then** the attempt is refused, by the interface and by the API independently.
+3. **Given** a scope admin, **When** they attempt to grant a user the platform admin role, **Then** the attempt is refused.
+4. **Given** a scope admin, **When** they attempt to grant themselves an additional scope, **Then** the attempt is refused.
+5. **Given** a scope admin, **When** they open user management, **Then** they can act only within their own scopes and the interface does not offer actions they cannot take.
+6. **Given** a scope admin revokes a user's access, **When** the change is applied, **Then** it is audited with the acting scope admin recorded.
+
+---
+
+### User Story 4 - See who has access to what (Priority: P4)
+
+An admin can see, for a scope, which users hold it, and for a user, which scopes they hold. They use it to answer "who can see OWL?" without reading the database.
+
+**Why this priority**: It makes access reviewable rather than merely settable. It is genuinely useful but nothing is blocked without it, and User Story 1 already shows a user's own scope list.
+
+**Independent Test**: With several users assigned across several scopes, open a scope and verify its user list is correct and complete.
+
+**Acceptance Scenarios**:
+
+1. **Given** several users assigned to a Bezirk, **When** an admin views that Bezirk's access, **Then** every user holding it is listed.
+2. **Given** a scope with no users assigned, **When** an admin views its access, **Then** it is shown as having no users rather than as an error.
+3. **Given** a scope admin, **When** they view access, **Then** they see it only for scopes they hold.
+
+---
+
+### Edge Cases
+
+- A scoped user has no assignments at all, so they can see nothing.
+- A user's last scope is revoked while they are working in it.
+- A user's scope is revoked while they have a run queued or running in that scope.
+- A user is deactivated but retains scope assignments.
+- A scope admin's own scope is revoked, removing their ability to manage the users they just granted.
+- A scope is deleted while users are assigned to it.
+- A user holds both the Verband and a Bezirk.
+- A platform admin is demoted to a scoped role and holds no assignments.
+- The last platform admin is demoted or deactivated, leaving nobody able to grant scopes.
+- A scope admin attempts to act on a user who holds scopes outside the admin's own.
+- Two admins change the same user's assignments at once.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Assignment
+
+- **FR-001**: A platform admin MUST be able to grant a user access to any scope, and revoke it.
+- **FR-002**: A user's currently assigned scopes MUST be visible wherever their access is managed.
+- **FR-003**: Granting and revoking MUST be available through the application, with no database editing required for any routine access change.
+- **FR-004**: A user MUST be able to hold several scopes at once.
+- **FR-004a**: Only Bezirke and the Verband MUST be offered as assignable scopes. The Germany scope MUST NOT be assignable, since nothing is planned at that level and, under FR-010, such an assignment would grant access to nothing.
+- **FR-005**: Granting a scope a user already holds MUST NOT create a duplicate or fail destructively.
+
+#### Access semantics
+
+- **FR-010**: A scope assignment MUST grant access to exactly that scope. It MUST NOT grant access to ancestor or descendant scopes.
+- **FR-011**: All access checks across the application MUST apply the same rule as FR-010. The current disagreement between `rbac.ts` (exact match) and `raster/access.ts` (assignment, parent, or grandparent) MUST be resolved in favour of exact match.
+- **FR-012**: A platform admin MUST continue to reach every scope without holding assignments.
+- **FR-012a**: The system MUST refuse any change that would leave no active platform admin, whether by demotion or deactivation, and MUST state why. Recovery from zero platform admins requires editing the database, which this feature exists to make unnecessary.
+- **FR-013**: A user holding a scoped role and no assignments MUST be able to sign in and MUST be told they have no scopes, rather than shown an error or an empty page with no explanation.
+- **FR-014**: The exact-match rule of FR-010 MUST NOT foreclose a later WTTV-wide scheduler — one user with access to every Bezirk and the Verband, without being a platform admin. This feature does not build it; it must leave it buildable, whether as a cascading assignment, a Verband-wide grant, or a distinct role.
+- **FR-015**: Granting many scopes to one user MUST remain workable in the meantime, since 13 assignments is the only way to express a WTTV-wide scheduler until FR-014's successor exists. Assignment MUST NOT be so laborious that it forces a platform admin grant instead.
+
+#### What a scope grants
+
+- **FR-016**: A scope admin MUST be able to do in the scopes they hold whatever a platform admin can do in any scope: import sources, review data, start runs, and edit gym capacities.
+- **FR-017**: Capability MUST be determined by the user's role together with their access to the scope in question, not by a check for platform admin. The Raster page's seven hardcoded platform-admin checks MUST be replaced by the access levels the access layer already defines.
+- **FR-018**: A scope user MUST retain viewing access without gaining the ability to import, review, or run.
+- **FR-019**: Every capability opened up by FR-016 MUST be enforced at the API for the acting user and the scope acted on, independently of the interface.
+
+#### Delegated administration
+
+- **FR-020**: A scope admin MUST be able to grant and revoke access to scopes they themselves hold.
+- **FR-021**: A scope admin MUST NOT be able to grant, revoke, or view access for any scope they do not hold.
+- **FR-022**: A scope admin MUST NOT be able to grant a role higher than their own, and MUST NOT be able to grant the platform admin role.
+- **FR-023**: A scope admin MUST NOT be able to alter their own scope assignments.
+- **FR-024**: Every restriction in FR-021 through FR-023 MUST be enforced at the API independently of the interface. Hiding an action in the UI MUST NOT be the only thing preventing it.
+- **FR-025**: User management MUST become reachable by scope admins, showing only what they may act on. It is currently reachable only by platform admins.
+- **FR-026**: A scope admin MUST be able to find a user by searching an exact identifier, so they can grant a scope to someone who holds none yet.
+- **FR-027**: A scope admin MUST NOT be able to browse or enumerate the user list. Search MUST require an exact identifier and MUST NOT return partial matches or allow listing.
+- **FR-028**: A platform admin MUST retain the full browsable user list.
+- **FR-029**: Search MUST NOT reveal whether a non-matching identifier belongs to an existing user, beyond what granting itself requires.
+
+#### Auditability
+
+- **FR-030**: Every grant and revoke MUST be recorded in the audit trail with the actor, the affected user, the scope, and the direction of the change.
+- **FR-031**: A refused grant or revoke MUST NOT alter any assignment.
+
+#### Revocation and work in flight
+
+- **FR-032**: Revoking a user's access to a scope MUST NOT cancel or interrupt runs already queued or executing in that scope. A run belongs to the scope, not to the user who started it.
+- **FR-033**: A run started before revocation MUST complete, and its snapshot MUST remain available to users who still hold the scope.
+- **FR-034**: A user whose access is revoked MUST immediately stop being able to see or act on that scope's runs and snapshots, including any they started.
+
+#### Review
+
+- **FR-040**: An admin MUST be able to see which users hold a given scope.
+- **FR-041**: An admin MUST be able to see which scopes a given user holds.
+- **FR-042**: A scope admin MUST see the above only for scopes they hold.
+
+### Key Entities
+
+- **User scope assignment**: Links a user to a scope, at most once per pair. Already exists. This feature gives it a way to be created and removed, and settles what it means.
+- **Scope**: An existing hierarchy node — Germany → Verband → Bezirk. Unchanged by this feature.
+- **Role**: `PLATFORM_ADMIN`, `SCOPE_ADMIN`, `SCOPE_USER`. Already assignable. This feature does not add roles; it constrains who may assign them.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An admin can grant a user access to a Bezirk in under 30 seconds, without touching the database.
+- **SC-002**: A user assigned to one Bezirk can reach that Bezirk's data and no other scope's, verified across every part of the application that checks access.
+- **SC-009**: A scope admin granted a Bezirk can start a run in it without any platform admin involvement.
+- **SC-010**: No run in any Bezirk requires a platform admin, provided that Bezirk has a scope admin.
+- **SC-011**: A scope user can reach no import, edit, or run capability in any scope, whatever they are assigned.
+- **SC-003**: A user assigned to the Verband reaches Verband-level data and no Bezirk beneath it.
+- **SC-004**: Access decisions are identical everywhere in the application for the same user and scope, with no path granting more than another.
+- **SC-005**: A scope admin cannot obtain access to a scope they do not hold, through the interface or by calling the API directly.
+- **SC-006**: Every access change is attributable to an actor after the fact.
+- **SC-007**: A user with a scoped role and no assignments receives a clear explanation rather than an error.
+- **SC-008**: An admin can answer "who can see this Bezirk?" without reading the database.
+- **SC-012**: The system can never be left with no active platform admin through any action available in the application.
+- **SC-013**: A revoked user's in-flight run still produces its snapshot for the scope, and the revoked user cannot see it.
+
+## Assumptions
+
+- The scope hierarchy itself (which Bezirke exist, and that they sit under WTTV) is managed by seeding and is not edited in the app. This feature assigns users to scopes; it does not create scopes.
+- Role assignment already exists and works; this feature constrains who may use it rather than rebuilding it.
+- Planning at the Germany level is not a real case, consistent with feature 005, so the Germany scope is not assignable (FR-004a). It remains the root of the hierarchy and may still own source material.
+- There is no production data, so narrowing access from the current hierarchy walk to exact match cannot disrupt a live user.
+- Bezirke and the Verband are planned separately, by separate people, for now. A single WTTV-wide scheduler is a known goal but is not yet established on the business side, so this feature serves the present arrangement and keeps the future one reachable (FR-014).
+- Per-Bezirk assignment (13 assignments for a WTTV-wide scheduler) is acceptable as an interim, because the role does not exist yet. Once it does, the interim stops being acceptable and FR-014's successor is needed.
+- The WTTV-wide scheduler and feature 006's combined WTTV run wait on the same organisational change, not on separate ones. Whichever arrives first, the other is likely close behind.
+- Existing audit infrastructure is reused; this feature adds entries rather than an audit mechanism.
+- Existing authentication is unchanged. This feature is about authorisation only.
+
+## Out of Scope
+
+- Creating, renaming, or restructuring scopes.
+- Adding new roles or changing what existing roles may do beyond scope assignment.
+- Any change to authentication, sign-in, or SSO.
+- Source inheritance, which governs where source material is valid rather than who may see it, and is unchanged.
+- Self-service access requests, approval workflows, or time-limited grants.
+- A WTTV-wide scheduler role — one user covering every Bezirk and the Verband without platform admin rights. A known goal, blocked on the organisation establishing the role, and gated on the same business change as feature 006. FR-014 keeps it buildable; this feature does not build it.
+
+## Open Questions
+
+- **Q1 (resolved 2026-07-14)**: A scope admin finds users by exact-identifier search only, with no browsable list. Platform admins keep the full list. See FR-026 to FR-029.
+- **Q2 (resolved 2026-07-14)**: The Germany scope is not assignable. Only Bezirke and the Verband are. See FR-004a.
+- **Q3 (resolved 2026-07-14)**: A queued or running run finishes despite its starter losing access. A run is the scope's work and survives personnel changes; the revoked user simply stops seeing it. See FR-032 to FR-034.

--- a/specs/007-scope-access-management/tasks.md
+++ b/specs/007-scope-access-management/tasks.md
@@ -17,7 +17,7 @@
 
 ## Phase 1: Setup
 
-- [ ] T001 [P] Add next-intl keys for scope assignment, the scope column, and access-related messages in `webapp/src/i18n/messages/{en,de,es,fr,pt}.json`. Scope levels use "Bezirk"/"Verband" as proper names per feature 005's FR-022a.
+- [x] T001 [P] Add next-intl keys for scope assignment, the scope column, and access-related messages in `webapp/src/i18n/messages/{en,de,es,fr,pt}.json`. Scope levels use "Bezirk"/"Verband" as proper names per feature 005's FR-022a.
 
 **No schema task.** `UserScopeAssignment` already exists with `@@unique([userId, scopeId])`. This feature adds no migration.
 
@@ -25,10 +25,10 @@
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-- [ ] T002 Create `webapp/src/services/api/scope-assignments.ts` with grant, revoke and list, following `webapp/src/services/api/user-admin.ts`'s established shape: `requireRouteUserWithRoles`, `withSerializableRetry`, `safeLogAudit`. Grant is an **upsert** on `@@unique([userId, scopeId])` so granting a held scope is a no-op rather than an error (FR-005).
-- [ ] T003 Add the authorisation helper to `webapp/src/lib/rbac.ts`: may actor A grant/revoke scope S for user U? Encodes FR-021 (only scopes the actor holds), FR-022 (no role above the actor's own; equal is permitted) and FR-023 (never the actor's own assignments). **One helper, one enforcing caller** — scattering these across dialog, route and service makes "did we check?" unanswerable (research R-203).
-- [ ] T004 Enforce FR-004a in `scope-assignments.ts`: only Bezirke and the Verband are assignable; the Germany root is not. Under exact-match an assignment to it grants nothing. Reuse feature 005's `lib/raster/scope-level.ts`.
-- [ ] T005 [P] Unit-test the authorisation helper in `webapp/tests/unit/auth/scope-grant-authorization.test.ts`: a scope admin may grant a scope they hold; may not grant one they do not; may not grant `PLATFORM_ADMIN`; may not alter their own assignments; a platform admin may grant any assignable scope; nobody may grant Germany.
+- [x] T002 Create `webapp/src/services/api/scope-assignments.ts` with grant, revoke and list, following `webapp/src/services/api/user-admin.ts`'s established shape: `requireRouteUserWithRoles`, `withSerializableRetry`, `safeLogAudit`. Grant is an **upsert** on `@@unique([userId, scopeId])` so granting a held scope is a no-op rather than an error (FR-005).
+- [x] T003 Add the authorisation helper to `webapp/src/lib/rbac.ts`: may actor A grant/revoke scope S for user U? Encodes FR-021 (only scopes the actor holds), FR-022 (no role above the actor's own; equal is permitted) and FR-023 (never the actor's own assignments). **One helper, one enforcing caller** — scattering these across dialog, route and service makes "did we check?" unanswerable (research R-203).
+- [x] T004 Enforce FR-004a in `scope-assignments.ts`: only Bezirke and the Verband are assignable; the Germany root is not. Under exact-match an assignment to it grants nothing. Reuse feature 005's `lib/raster/scope-level.ts`.
+- [x] T005 [P] Unit-test the authorisation helper in `webapp/tests/unit/auth/scope-grant-authorization.test.ts`: a scope admin may grant a scope they hold; may not grant one they do not; may not grant `PLATFORM_ADMIN`; may not alter their own assignments; a platform admin may grant any assignable scope; nobody may grant Germany.
 
 **Checkpoint**: assignments can be created and refused correctly, before anything exposes them.
 
@@ -42,14 +42,14 @@
 
 ### Implementation
 
-- [ ] T006 [US1] Create `webapp/src/app/api/users/[id]/scopes/route.ts`: `POST` grant, `DELETE` revoke, `GET` list (FR-001, FR-041). Thin route delegating to `scope-assignments.ts`, matching `/api/users/[id]/role`.
-- [ ] T007 [US1] Remove the ancestor walk from `webapp/src/lib/raster/access.ts` — both `canAccessRasterDistrict` and `listAccessibleRasterScopes` currently match on the assignment, its parent, **or its grandparent**. An assignment grants exactly its own scope (FR-010, FR-011). Do **not** touch `checkScopeAccess` in `rbac.ts`: it is already exact-match and already correct (research R-201).
-- [ ] T008 [P] [US1] Create `webapp/src/components/auth/ScopeAssignmentDialog.tsx`: assign and revoke scopes for a user, showing each scope's hierarchy position and level.
-- [ ] T009 [P] [US1] Show a user's current scopes in `webapp/src/components/auth/UserManagementTable.tsx` without opening another page (FR-002).
-- [ ] T010 [US1] Tell a scoped user holding no assignments that they have no scopes, rather than showing an error or a bare empty page (FR-013).
-- [ ] T011 [US1] Audit every grant and revoke with actor, target user, scope and direction via the existing `safeLogAudit` (FR-030). A refused attempt records nothing and changes nothing (FR-031).
-- [ ] T012 [P] [US1] Integration-test exact-match access in `webapp/tests/integration/scope-exact-match.test.ts`: a user assigned one Bezirk reaches it and no other scope (SC-002); a user assigned the Verband reaches Verband-level data and **no Bezirk beneath it** (SC-003); a platform admin reaches every scope without assignments (FR-012).
-- [ ] T013 [P] [US1] Test that FR-012a already holds, in `webapp/tests/integration/last-admin-guard.test.ts`: demoting or deactivating the last active platform admin is refused with a stated reason (SC-012). **This guard already exists** — `ensureAdminUserCanChange` in `user-admin.ts`, inside a `Serializable` transaction. Do not reimplement it; nothing currently pins the behaviour, which is the gap.
+- [x] T006 [US1] Create `webapp/src/app/api/users/[id]/scopes/route.ts`: `POST` grant, `DELETE` revoke, `GET` list (FR-001, FR-041). Thin route delegating to `scope-assignments.ts`, matching `/api/users/[id]/role`.
+- [x] T007 [US1] Remove the ancestor walk from `webapp/src/lib/raster/access.ts` — both `canAccessRasterDistrict` and `listAccessibleRasterScopes` currently match on the assignment, its parent, **or its grandparent**. An assignment grants exactly its own scope (FR-010, FR-011). Do **not** touch `checkScopeAccess` in `rbac.ts`: it is already exact-match and already correct (research R-201).
+- [x] T008 [P] [US1] Create `webapp/src/components/auth/ScopeAssignmentDialog.tsx`: assign and revoke scopes for a user, showing each scope's hierarchy position and level.
+- [x] T009 [P] [US1] Show a user's current scopes in `webapp/src/components/auth/UserManagementTable.tsx` without opening another page (FR-002).
+- [x] T010 [US1] Tell a scoped user holding no assignments that they have no scopes, rather than showing an error or a bare empty page (FR-013).
+- [x] T011 [US1] Audit every grant and revoke with actor, target user, scope and direction via the existing `safeLogAudit` (FR-030). A refused attempt records nothing and changes nothing (FR-031).
+- [x] T012 [P] [US1] Integration-test exact-match access in `webapp/tests/integration/scope-exact-match.test.ts`: a user assigned one Bezirk reaches it and no other scope (SC-002); a user assigned the Verband reaches Verband-level data and **no Bezirk beneath it** (SC-003); a platform admin reaches every scope without assignments (FR-012).
+- [x] T013 [P] [US1] Test that FR-012a already holds, in `webapp/tests/integration/last-admin-guard.test.ts`: demoting or deactivating the last active platform admin is refused with a stated reason (SC-012). **This guard already exists** — `ensureAdminUserCanChange` in `user-admin.ts`, inside a `Serializable` transaction. Do not reimplement it; nothing currently pins the behaviour, which is the gap.
 
 **Checkpoint**: scopes can be granted through the app, and an assignment means exactly one scope everywhere.
 
@@ -63,10 +63,10 @@
 
 ### Implementation
 
-- [ ] T014 [US2] Change raster API routes from `requireRasterInputSet(request, id, "admin")` to `"scheduler"` for the work: source upload/refresh/delete, input-set creation, group review, capacity edit, validation, run start, manual assignment (FR-016, FR-019). `levelRoles.scheduler` already reads `[PLATFORM_ADMIN, SCOPE_ADMIN]` — the levels need no change. **This is the enforcing half**; leave `"admin"` on anything genuinely system-level.
-- [ ] T015 [US2] Replace the seven hardcoded `Role.PLATFORM_ADMIN` checks in the Raster step pages with level-based checks (FR-017). Feature 005's T024 moves them unchanged; this fixes them. The visible half — pointless without T014, and misleading without it (buttons that 403).
-- [ ] T016 [US2] Keep `SCOPE_USER` at viewer: no import, edit or run controls anywhere, whatever they are assigned (FR-018, SC-011).
-- [ ] T017 [P] [US2] Integration-test capability by role and scope in `webapp/tests/integration/scope-scheduler-access.test.ts`, **calling the API directly**: a scope admin holding OWL starts a run in OWL (SC-009) and is refused in Köln (SC-005); a scope user is refused everywhere (SC-011); a platform admin is unaffected. Testing through the UI would prove nothing — FR-019 is precisely about the API standing alone.
+- [x] T014 [US2] Change raster API routes from `requireRasterInputSet(request, id, "admin")` to `"scheduler"` for the work: source upload/refresh/delete, input-set creation, group review, capacity edit, validation, run start, manual assignment (FR-016, FR-019). `levelRoles.scheduler` already reads `[PLATFORM_ADMIN, SCOPE_ADMIN]` — the levels need no change. **This is the enforcing half**; leave `"admin"` on anything genuinely system-level.
+- [x] T015 [US2] Replace the seven hardcoded `Role.PLATFORM_ADMIN` checks in the Raster step pages with level-based checks (FR-017). Feature 005's T024 moves them unchanged; this fixes them. The visible half — pointless without T014, and misleading without it (buttons that 403).
+- [x] T016 [US2] Keep `SCOPE_USER` at viewer: no import, edit or run controls anywhere, whatever they are assigned (FR-018, SC-011).
+- [x] T017 [P] [US2] Integration-test capability by role and scope in `webapp/tests/integration/scope-scheduler-access.test.ts`, **calling the API directly**: a scope admin holding OWL starts a run in OWL (SC-009) and is refused in Köln (SC-005); a scope user is refused everywhere (SC-011); a platform admin is unaffected. Testing through the UI would prove nothing — FR-019 is precisely about the API standing alone.
 
 **Checkpoint**: no run in any Bezirk needs a platform admin, given that Bezirk has a scope admin (SC-010).
 
@@ -82,15 +82,15 @@
 
 ### Implementation
 
-- [ ] T018 [US3] Wire T003's authorisation helper into `scope-assignments.ts` so every grant and revoke is checked in the **service** (FR-024). Not the route, not the dialog. The UI may ask the same helper what to offer, but this call is the enforcement.
-- [ ] T019 [US3] Add a role ceiling to `webapp/src/services/api/user-admin.ts`: a scope admin may not grant a role above their own, and may not grant `PLATFORM_ADMIN` (FR-022). Granting an equal role is permitted.
-- [ ] T020 [US3] Add exact-email lookup to `webapp/src/services/api/user-admin.ts` and `webapp/src/app/api/users/lookup/route.ts`: match the **full** email exactly, return at most one user, never a list (FR-026, FR-027). No prefix, no substring, no wildcard, no `LIKE`. A non-match returns a uniform "no user found" (FR-029).
-- [ ] T021 [US3] Make the users page's data load actor-dependent in `webapp/src/app/(dashboard)/users/page.tsx`: platform admins get the full list (FR-028); scope admins get lookup only, never a list — not filtered, not paginated (FR-027). The page today calls `prisma.user.findMany()` unconditionally.
-- [ ] T022 [US3] **Only now** widen the page gate at `webapp/src/app/(dashboard)/users/page.tsx:12` from `PLATFORM_ADMIN` to also admit `SCOPE_ADMIN` (FR-025). Depends on T018 through T021. Doing this first is a privilege escalation.
-- [ ] T023 [US3] Offer scope admins no action they cannot take, in `webapp/src/components/auth/UserManagementTable.tsx` (FR-025). Presentation only — T018 is what prevents them.
-- [ ] T024 [US3] Audit scope-admin grants and revokes with the acting admin recorded (FR-030).
-- [ ] T025 [P] [US3] Integration-test escalation attempts in `webapp/tests/integration/scope-admin-escalation.test.ts`, **calling the API directly with the UI bypassed** (FR-024, SC-005): granting a scope not held → refused; granting `PLATFORM_ADMIN` → refused; granting oneself → refused; listing users → refused; a refused attempt alters nothing (FR-031). This is the file that proves the feature does not open a hole.
-- [ ] T026 [P] [US3] Integration-test lookup in `webapp/tests/integration/user-lookup.test.ts`: an exact email returns one user; a prefix returns nothing; a non-match returns the same uniform response as a match to a user the caller may not act on (FR-027, FR-029).
+- [x] T018 [US3] Wire T003's authorisation helper into `scope-assignments.ts` so every grant and revoke is checked in the **service** (FR-024). Not the route, not the dialog. The UI may ask the same helper what to offer, but this call is the enforcement.
+- [x] T019 [US3] Add a role ceiling to `webapp/src/services/api/user-admin.ts`: a scope admin may not grant a role above their own, and may not grant `PLATFORM_ADMIN` (FR-022). Granting an equal role is permitted.
+- [x] T020 [US3] Add exact-email lookup to `webapp/src/services/api/user-admin.ts` and `webapp/src/app/api/users/lookup/route.ts`: match the **full** email exactly, return at most one user, never a list (FR-026, FR-027). No prefix, no substring, no wildcard, no `LIKE`. A non-match returns a uniform "no user found" (FR-029).
+- [x] T021 [US3] Make the users page's data load actor-dependent in `webapp/src/app/(dashboard)/users/page.tsx`: platform admins get the full list (FR-028); scope admins get lookup only, never a list — not filtered, not paginated (FR-027). The page today calls `prisma.user.findMany()` unconditionally.
+- [x] T022 [US3] **Only now** widen the page gate at `webapp/src/app/(dashboard)/users/page.tsx:12` from `PLATFORM_ADMIN` to also admit `SCOPE_ADMIN` (FR-025). Depends on T018 through T021. Doing this first is a privilege escalation.
+- [x] T023 [US3] Offer scope admins no action they cannot take, in `webapp/src/components/auth/UserManagementTable.tsx` (FR-025). Presentation only — T018 is what prevents them.
+- [x] T024 [US3] Audit scope-admin grants and revokes with the acting admin recorded (FR-030).
+- [x] T025 [P] [US3] Integration-test escalation attempts in `webapp/tests/integration/scope-admin-escalation.test.ts`, **calling the API directly with the UI bypassed** (FR-024, SC-005): granting a scope not held → refused; granting `PLATFORM_ADMIN` → refused; granting oneself → refused; listing users → refused; a refused attempt alters nothing (FR-031). This is the file that proves the feature does not open a hole.
+- [x] T026 [P] [US3] Integration-test lookup in `webapp/tests/integration/user-lookup.test.ts`: an exact email returns one user; a prefix returns nothing; a non-match returns the same uniform response as a match to a user the caller may not act on (FR-027, FR-029).
 
 **Checkpoint**: delegation works and cannot be turned into escalation.
 
@@ -98,9 +98,9 @@
 
 ## Phase 6: User Story 4 - See who has access to what (Priority: P4)
 
-- [ ] T027 [US4] Show which users hold a given scope (FR-040), filtered to scopes the actor may see (FR-042).
-- [ ] T028 [US4] Show which scopes a given user holds (FR-041).
-- [ ] T029 [P] [US4] Integration-test that a scope admin sees access only for scopes they hold, in `webapp/tests/integration/scope-access-review.test.ts` (FR-042).
+- [x] T027 [US4] Show which users hold a given scope (FR-040), filtered to scopes the actor may see (FR-042).
+- [x] T028 [US4] Show which scopes a given user holds (FR-041).
+- [x] T029 [P] [US4] Integration-test that a scope admin sees access only for scopes they hold, in `webapp/tests/integration/scope-access-review.test.ts` (FR-042).
 
 **Checkpoint**: "who can see OWL?" is answerable without the database (SC-008).
 
@@ -108,11 +108,11 @@
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T030 Verify revoking access does not cancel a queued or running run in that scope (FR-032, FR-033), and that the revoked user immediately stops seeing it (FR-034, SC-013). A run is the scope's work, not the person's.
-- [ ] T031 Confirm bulk assignment stays workable enough that nobody reaches for a platform-admin grant instead (FR-015). 13 assignments is the interim expression of a WTTV-wide scheduler until FR-014's successor exists — if it is tedious enough, the interim defeats itself.
-- [ ] T032 [P] Verify no path grants more than another for the same user and scope (SC-004): `checkScopeAccess`, `canAccessRasterDistrict` and `listAccessibleRasterScopes` must agree after T007.
-- [ ] T033 [P] Walk `specs/007-scope-access-management/quickstart.md` § "Verification against success criteria" end to end.
-- [ ] T034 Run `webapp/validate.ps1` (typecheck + lint) — constitution Principle VI.
+- [x] T030 Verify revoking access does not cancel a queued or running run in that scope (FR-032, FR-033), and that the revoked user immediately stops seeing it (FR-034, SC-013). A run is the scope's work, not the person's.
+- [x] T031 Confirm bulk assignment stays workable enough that nobody reaches for a platform-admin grant instead (FR-015). 13 assignments is the interim expression of a WTTV-wide scheduler until FR-014's successor exists — if it is tedious enough, the interim defeats itself.
+- [x] T032 [P] Verify no path grants more than another for the same user and scope (SC-004): `checkScopeAccess`, `canAccessRasterDistrict` and `listAccessibleRasterScopes` must agree after T007.
+- [x] T033 [P] Walk `specs/007-scope-access-management/quickstart.md` § "Verification against success criteria" end to end.
+- [x] T034 Run `webapp/validate.ps1` (typecheck + lint) — constitution Principle VI.
 
 ---
 

--- a/specs/007-scope-access-management/tasks.md
+++ b/specs/007-scope-access-management/tasks.md
@@ -1,0 +1,185 @@
+# Tasks: Scope Access Management
+
+**Input**: Design documents from `/specs/007-scope-access-management/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/scope-access.md, quickstart.md
+
+**Tests**: Not a TDD pass. Test tasks appear where a requirement is security-relevant and cannot be verified by inspection — chiefly FR-024 and FR-019 (every authorisation check holds at the API independently of the interface), which by definition cannot be tested through the UI.
+
+**Organization**: Grouped by user story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1, US2, US3, US4 per spec.md
+- All paths repo-relative; this feature lives entirely under `webapp/`
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 [P] Add next-intl keys for scope assignment, the scope column, and access-related messages in `webapp/src/i18n/messages/{en,de,es,fr,pt}.json`. Scope levels use "Bezirk"/"Verband" as proper names per feature 005's FR-022a.
+
+**No schema task.** `UserScopeAssignment` already exists with `@@unique([userId, scopeId])`. This feature adds no migration.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+- [ ] T002 Create `webapp/src/services/api/scope-assignments.ts` with grant, revoke and list, following `webapp/src/services/api/user-admin.ts`'s established shape: `requireRouteUserWithRoles`, `withSerializableRetry`, `safeLogAudit`. Grant is an **upsert** on `@@unique([userId, scopeId])` so granting a held scope is a no-op rather than an error (FR-005).
+- [ ] T003 Add the authorisation helper to `webapp/src/lib/rbac.ts`: may actor A grant/revoke scope S for user U? Encodes FR-021 (only scopes the actor holds), FR-022 (no role above the actor's own; equal is permitted) and FR-023 (never the actor's own assignments). **One helper, one enforcing caller** — scattering these across dialog, route and service makes "did we check?" unanswerable (research R-203).
+- [ ] T004 Enforce FR-004a in `scope-assignments.ts`: only Bezirke and the Verband are assignable; the Germany root is not. Under exact-match an assignment to it grants nothing. Reuse feature 005's `lib/raster/scope-level.ts`.
+- [ ] T005 [P] Unit-test the authorisation helper in `webapp/tests/unit/auth/scope-grant-authorization.test.ts`: a scope admin may grant a scope they hold; may not grant one they do not; may not grant `PLATFORM_ADMIN`; may not alter their own assignments; a platform admin may grant any assignable scope; nobody may grant Germany.
+
+**Checkpoint**: assignments can be created and refused correctly, before anything exposes them.
+
+---
+
+## Phase 3: User Story 1 - Grant and revoke (Priority: P1) 🎯 MVP
+
+**Goal**: A platform admin assigns and revokes Bezirke and the Verband through the app, and an assignment means exactly that scope.
+
+**Independent Test**: Grant a scoped user one Bezirk; signed in as them, verify they reach exactly that Bezirk's Raster data and no other. Revoke; verify it disappears.
+
+### Implementation
+
+- [ ] T006 [US1] Create `webapp/src/app/api/users/[id]/scopes/route.ts`: `POST` grant, `DELETE` revoke, `GET` list (FR-001, FR-041). Thin route delegating to `scope-assignments.ts`, matching `/api/users/[id]/role`.
+- [ ] T007 [US1] Remove the ancestor walk from `webapp/src/lib/raster/access.ts` — both `canAccessRasterDistrict` and `listAccessibleRasterScopes` currently match on the assignment, its parent, **or its grandparent**. An assignment grants exactly its own scope (FR-010, FR-011). Do **not** touch `checkScopeAccess` in `rbac.ts`: it is already exact-match and already correct (research R-201).
+- [ ] T008 [P] [US1] Create `webapp/src/components/auth/ScopeAssignmentDialog.tsx`: assign and revoke scopes for a user, showing each scope's hierarchy position and level.
+- [ ] T009 [P] [US1] Show a user's current scopes in `webapp/src/components/auth/UserManagementTable.tsx` without opening another page (FR-002).
+- [ ] T010 [US1] Tell a scoped user holding no assignments that they have no scopes, rather than showing an error or a bare empty page (FR-013).
+- [ ] T011 [US1] Audit every grant and revoke with actor, target user, scope and direction via the existing `safeLogAudit` (FR-030). A refused attempt records nothing and changes nothing (FR-031).
+- [ ] T012 [P] [US1] Integration-test exact-match access in `webapp/tests/integration/scope-exact-match.test.ts`: a user assigned one Bezirk reaches it and no other scope (SC-002); a user assigned the Verband reaches Verband-level data and **no Bezirk beneath it** (SC-003); a platform admin reaches every scope without assignments (FR-012).
+- [ ] T013 [P] [US1] Test that FR-012a already holds, in `webapp/tests/integration/last-admin-guard.test.ts`: demoting or deactivating the last active platform admin is refused with a stated reason (SC-012). **This guard already exists** — `ensureAdminUserCanChange` in `user-admin.ts`, inside a `Serializable` transaction. Do not reimplement it; nothing currently pins the behaviour, which is the gap.
+
+**Checkpoint**: scopes can be granted through the app, and an assignment means exactly one scope everywhere.
+
+---
+
+## Phase 4: User Story 2 - Work in the Bezirk you were granted (Priority: P2)
+
+**Goal**: A scope admin imports, reviews and runs in scopes they hold. A scope user sees and changes nothing.
+
+**Independent Test**: Grant a scope admin one Bezirk. As them, import a source and start a run there — both succeed. Attempt both in a Bezirk they do not hold — both refused **by the API**, tested directly rather than through the interface.
+
+### Implementation
+
+- [ ] T014 [US2] Change raster API routes from `requireRasterInputSet(request, id, "admin")` to `"scheduler"` for the work: source upload/refresh/delete, input-set creation, group review, capacity edit, validation, run start, manual assignment (FR-016, FR-019). `levelRoles.scheduler` already reads `[PLATFORM_ADMIN, SCOPE_ADMIN]` — the levels need no change. **This is the enforcing half**; leave `"admin"` on anything genuinely system-level.
+- [ ] T015 [US2] Replace the seven hardcoded `Role.PLATFORM_ADMIN` checks in the Raster step pages with level-based checks (FR-017). Feature 005's T024 moves them unchanged; this fixes them. The visible half — pointless without T014, and misleading without it (buttons that 403).
+- [ ] T016 [US2] Keep `SCOPE_USER` at viewer: no import, edit or run controls anywhere, whatever they are assigned (FR-018, SC-011).
+- [ ] T017 [P] [US2] Integration-test capability by role and scope in `webapp/tests/integration/scope-scheduler-access.test.ts`, **calling the API directly**: a scope admin holding OWL starts a run in OWL (SC-009) and is refused in Köln (SC-005); a scope user is refused everywhere (SC-011); a platform admin is unaffected. Testing through the UI would prove nothing — FR-019 is precisely about the API standing alone.
+
+**Checkpoint**: no run in any Bezirk needs a platform admin, given that Bezirk has a scope admin (SC-010).
+
+---
+
+## Phase 5: User Story 3 - A Bezirk admin manages access to their own Bezirk (Priority: P3)
+
+**Goal**: A scope admin grants and revokes access within their own scopes, and cannot escalate.
+
+**Independent Test**: As a scope admin holding one Bezirk, grant a user that Bezirk — succeeds. Attempt a Bezirk you do not hold — refused. Attempt to grant yourself, or to grant platform admin — refused. All refusals verified at the API.
+
+**⚠️ Task order in this phase is a safety property, not a preference.** The users page currently gates once, in the component, then loads *every* user. Widening that gate before the per-action checks exist — even for one commit — hands the directory to every Bezirk admin.
+
+### Implementation
+
+- [ ] T018 [US3] Wire T003's authorisation helper into `scope-assignments.ts` so every grant and revoke is checked in the **service** (FR-024). Not the route, not the dialog. The UI may ask the same helper what to offer, but this call is the enforcement.
+- [ ] T019 [US3] Add a role ceiling to `webapp/src/services/api/user-admin.ts`: a scope admin may not grant a role above their own, and may not grant `PLATFORM_ADMIN` (FR-022). Granting an equal role is permitted.
+- [ ] T020 [US3] Add exact-email lookup to `webapp/src/services/api/user-admin.ts` and `webapp/src/app/api/users/lookup/route.ts`: match the **full** email exactly, return at most one user, never a list (FR-026, FR-027). No prefix, no substring, no wildcard, no `LIKE`. A non-match returns a uniform "no user found" (FR-029).
+- [ ] T021 [US3] Make the users page's data load actor-dependent in `webapp/src/app/(dashboard)/users/page.tsx`: platform admins get the full list (FR-028); scope admins get lookup only, never a list — not filtered, not paginated (FR-027). The page today calls `prisma.user.findMany()` unconditionally.
+- [ ] T022 [US3] **Only now** widen the page gate at `webapp/src/app/(dashboard)/users/page.tsx:12` from `PLATFORM_ADMIN` to also admit `SCOPE_ADMIN` (FR-025). Depends on T018 through T021. Doing this first is a privilege escalation.
+- [ ] T023 [US3] Offer scope admins no action they cannot take, in `webapp/src/components/auth/UserManagementTable.tsx` (FR-025). Presentation only — T018 is what prevents them.
+- [ ] T024 [US3] Audit scope-admin grants and revokes with the acting admin recorded (FR-030).
+- [ ] T025 [P] [US3] Integration-test escalation attempts in `webapp/tests/integration/scope-admin-escalation.test.ts`, **calling the API directly with the UI bypassed** (FR-024, SC-005): granting a scope not held → refused; granting `PLATFORM_ADMIN` → refused; granting oneself → refused; listing users → refused; a refused attempt alters nothing (FR-031). This is the file that proves the feature does not open a hole.
+- [ ] T026 [P] [US3] Integration-test lookup in `webapp/tests/integration/user-lookup.test.ts`: an exact email returns one user; a prefix returns nothing; a non-match returns the same uniform response as a match to a user the caller may not act on (FR-027, FR-029).
+
+**Checkpoint**: delegation works and cannot be turned into escalation.
+
+---
+
+## Phase 6: User Story 4 - See who has access to what (Priority: P4)
+
+- [ ] T027 [US4] Show which users hold a given scope (FR-040), filtered to scopes the actor may see (FR-042).
+- [ ] T028 [US4] Show which scopes a given user holds (FR-041).
+- [ ] T029 [P] [US4] Integration-test that a scope admin sees access only for scopes they hold, in `webapp/tests/integration/scope-access-review.test.ts` (FR-042).
+
+**Checkpoint**: "who can see OWL?" is answerable without the database (SC-008).
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T030 Verify revoking access does not cancel a queued or running run in that scope (FR-032, FR-033), and that the revoked user immediately stops seeing it (FR-034, SC-013). A run is the scope's work, not the person's.
+- [ ] T031 Confirm bulk assignment stays workable enough that nobody reaches for a platform-admin grant instead (FR-015). 13 assignments is the interim expression of a WTTV-wide scheduler until FR-014's successor exists — if it is tedious enough, the interim defeats itself.
+- [ ] T032 [P] Verify no path grants more than another for the same user and scope (SC-004): `checkScopeAccess`, `canAccessRasterDistrict` and `listAccessibleRasterScopes` must agree after T007.
+- [ ] T033 [P] Walk `specs/007-scope-access-management/quickstart.md` § "Verification against success criteria" end to end.
+- [ ] T034 Run `webapp/validate.ps1` (typecheck + lint) — constitution Principle VI.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: blocks all stories.
+- **US1 (Phase 3)**: the MVP.
+- **US2 (Phase 4)**: independent of US1 in principle — but pointless without assignments to hold.
+- **US3 (Phase 5)**: needs Phase 2's helper. **Internal order is mandatory** (T018–T021 before T022).
+- **US4 (Phase 6)**: needs US1's assignments to display.
+- **Polish (Phase 7)**: after the desired stories.
+
+### Feature dependency
+
+Depends on **005**, structurally. T004 reuses `lib/raster/scope-level.ts`; T015 replaces the seven hardcoded checks *in the step pages 005 creates* — against 004 those checks are still in one 571-line page and the task means something else. This cannot be built on 004 or `main`.
+
+(An earlier draft called this coupling cosmetic. `/speckit.analyze` caught it. Acting on the wrong claim would have started the work on a base missing both prerequisites.)
+
+### Within US3
+
+T018 → T019 → T020 → T021 → **T022**. T022 last, always. The page's gate is currently the only thing preventing a non-admin from loading every user.
+
+### Parallel Opportunities
+
+- T005 with anything else in Phase 2.
+- T008, T009 — dialog and table column are separate files.
+- T012, T013 — different test files.
+- T025, T026 — different test files.
+- Phase 6 (US4) can proceed alongside Phase 5 by another developer.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Create ScopeAssignmentDialog in webapp/src/components/auth/ScopeAssignmentDialog.tsx"
+Task: "Show current scopes in webapp/src/components/auth/UserManagementTable.tsx"
+Task: "Integration-test exact-match access in webapp/tests/integration/scope-exact-match.test.ts"
+Task: "Test the existing last-admin guard in webapp/tests/integration/last-admin-guard.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (Phases 1–3)
+
+Grant and revoke through the app, with an assignment meaning exactly one scope. Removes the need to edit the database, which is the whole ask.
+
+**STOP and VALIDATE** against SC-001, SC-002, SC-003.
+
+### Then
+
+1. US2 → scope admins can actually work. This is where the feature stops being read-only and starts being worth having.
+2. US3 → delegation. The security-sensitive part, landing on a tested foundation.
+3. US4 → access review.
+
+---
+
+## Notes
+
+- **This feature is mostly subtraction.** An ancestor walk and seven hardcoded checks come out. `UserScopeAssignment`, the roles, the last-admin guard and the audit mechanism all already exist.
+- **T013 tests something that already works.** FR-012a is implemented (`ensureAdminUserCanChange`). The gap is that nothing pins it.
+- **T022's position is the safety property of this feature.** Not its content — its position.
+- **T017 and T025 must call the API directly.** FR-019 and FR-024 are exactly the claim that the UI is not the boundary. Testing through the UI would assert the opposite of what they require.
+- **T007 removes the walk from `access.ts`, not from `rbac.ts`.** The temptation to "make them consistent" by adding the walk to `rbac.ts` is backwards.
+- Commit after each task or logical group.

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,12 +1,19 @@
 # Local dev/test uses PostgreSQL. Docker Compose can provide the database.
 DATABASE_URL="postgresql://starter:replace-with-a-real-secret@localhost:3288/business_app_starter?connection_limit=10"
 
-# Database the E2E suite provisions and RESETS on every run (prisma migrate
-# reset --force destroys all its data). It is deliberately separate from
-# DATABASE_URL and never falls back to it, so E2E can never wipe your dev or
-# production database. Leave blank to use the throwaway local container at
-# localhost:45432; set it only to point E2E at another dedicated, disposable
-# database.
+# E2E_DATABASE_URL: the database the end-to-end (Playwright) test suite runs
+# against. Used only by the E2E tooling -- playwright.config.ts, global.setup.ts
+# and scripts/ensure-e2e-db.mjs -- never by the app at runtime.
+#
+# The E2E setup runs `prisma migrate reset --force` on this database before the
+# tests, which DROPS AND RECREATES it and destroys all its data. So it must be a
+# dedicated, disposable database, never your dev or production one.
+#
+# It is deliberately independent of DATABASE_URL and never falls back to it, so
+# running the E2E suite can never wipe the database your app uses. Leave this
+# blank to use the throwaway local container at localhost:45432 (started by
+# `node scripts/ensure-e2e-db.mjs`); set it only to point the suite at another
+# dedicated, disposable database.
 # E2E_DATABASE_URL="postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test"
 
 # Runtime-specific PostgreSQL Docker/production configuration.

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,6 +1,14 @@
 # Local dev/test uses PostgreSQL. Docker Compose can provide the database.
 DATABASE_URL="postgresql://starter:replace-with-a-real-secret@localhost:3288/business_app_starter?connection_limit=10"
 
+# Database the E2E suite provisions and RESETS on every run (prisma migrate
+# reset --force destroys all its data). It is deliberately separate from
+# DATABASE_URL and never falls back to it, so E2E can never wipe your dev or
+# production database. Leave blank to use the throwaway local container at
+# localhost:45432; set it only to point E2E at another dedicated, disposable
+# database.
+# E2E_DATABASE_URL="postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test"
+
 # Runtime-specific PostgreSQL Docker/production configuration.
 # APP_DATABASE_URL is used by the Next.js app runtime.
 # WORKER_DATABASE_URL is used by the Python worker runtime.

--- a/webapp/eslint.config.mjs
+++ b/webapp/eslint.config.mjs
@@ -22,6 +22,8 @@ const config = [
       ".agents/**",
       ".claude/**",
       "**/*.min.js",
+      "**/*.d.ts",
+      "**/*.d.mts",
     ],
   },
   ...nextVitals,

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,9 +1,11 @@
+import "dotenv/config";
 import { defineConfig } from "@playwright/test";
 
 const port = Number(process.env.E2E_PORT ?? "3280");
 const normalizedBasePath = process.env.E2E_BASE_PATH ?? "/app-starter";
 const authBaseUrl = `http://localhost:${port}${normalizedBasePath}`;
 const databaseUrl =
+  process.env.E2E_DATABASE_URL ??
   process.env.DATABASE_URL ??
   "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
 const reuseExistingServer = process.env.E2E_REUSE_SERVER === "1";

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,13 +1,11 @@
 import "dotenv/config";
 import { defineConfig } from "@playwright/test";
+import { resolveE2eDatabaseUrl } from "./scripts/e2e-database-url.mjs";
 
 const port = Number(process.env.E2E_PORT ?? "3280");
 const normalizedBasePath = process.env.E2E_BASE_PATH ?? "/app-starter";
 const authBaseUrl = `http://localhost:${port}${normalizedBasePath}`;
-const databaseUrl =
-  process.env.E2E_DATABASE_URL ??
-  process.env.DATABASE_URL ??
-  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+const databaseUrl = resolveE2eDatabaseUrl();
 const reuseExistingServer = process.env.E2E_REUSE_SERVER === "1";
 
 process.env.E2E_PORT = String(port);

--- a/webapp/scripts/e2e-database-url.d.mts
+++ b/webapp/scripts/e2e-database-url.d.mts
@@ -1,0 +1,4 @@
+export const DEFAULT_E2E_DATABASE_URL: string;
+export function resolveE2eDatabaseUrl(
+  env?: Record<string, string | undefined>,
+): string;

--- a/webapp/scripts/e2e-database-url.mjs
+++ b/webapp/scripts/e2e-database-url.mjs
@@ -1,0 +1,20 @@
+// Port 45432 sits below the Windows dynamic port range (49152+), where Hyper-V
+// reserves blocks at boot. A published port inside that range can become
+// unbindable after a reboot: see waitForPublishedPort in ensure-e2e-db.mjs.
+export const DEFAULT_E2E_DATABASE_URL =
+  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+
+/**
+ * The database the E2E suite provisions and RESETS.
+ *
+ * This deliberately does NOT fall back to DATABASE_URL. DATABASE_URL may point
+ * at a real, even production, database, and the E2E setup runs
+ * `prisma migrate reset --force` — which irreversibly destroys all data. A
+ * previous `E2E_DATABASE_URL ?? DATABASE_URL ?? default` chain aimed exactly
+ * that reset at a live LAN database; only Prisma's agent guard stopped it. So
+ * E2E uses E2E_DATABASE_URL when explicitly set, otherwise the throwaway local
+ * default, and never the ambient DATABASE_URL. Do not add DATABASE_URL back.
+ */
+export function resolveE2eDatabaseUrl(env = process.env) {
+  return env.E2E_DATABASE_URL?.trim() || DEFAULT_E2E_DATABASE_URL;
+}

--- a/webapp/scripts/ensure-e2e-db.mjs
+++ b/webapp/scripts/ensure-e2e-db.mjs
@@ -1,16 +1,9 @@
 import { spawnSync } from "node:child_process";
 import net from "node:net";
 
-// Port 45432 sits below the Windows dynamic port range (49152+), where Hyper-V
-// reserves blocks at boot. A published port inside that range can become
-// unbindable after a reboot: see waitForPublishedPort.
-const DEFAULT_E2E_DATABASE_URL =
-  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+import { resolveE2eDatabaseUrl } from "./e2e-database-url.mjs";
 
-const databaseUrl =
-  process.env.E2E_DATABASE_URL?.trim() ||
-  process.env.DATABASE_URL?.trim() ||
-  DEFAULT_E2E_DATABASE_URL;
+const databaseUrl = resolveE2eDatabaseUrl();
 
 if (
   !databaseUrl.startsWith("postgresql://") &&

--- a/webapp/scripts/ensure-e2e-db.mjs
+++ b/webapp/scripts/ensure-e2e-db.mjs
@@ -138,7 +138,7 @@ async function waitForPublishedPort() {
         ? [
             "On Windows this usually means the port falls inside a reserved range. Check:",
             "  netsh interface ipv4 show excludedportrange protocol=tcp",
-            `If ${hostPort} falls inside a listed range, set DATABASE_URL to a free port below 49152.`,
+            `If ${hostPort} falls inside a listed range, set E2E_DATABASE_URL to a free port below 49152.`,
           ].join("\n")
         : "Check that the container's published port is not blocked by the host.",
     ].join("\n"),

--- a/webapp/scripts/ensure-e2e-db.mjs
+++ b/webapp/scripts/ensure-e2e-db.mjs
@@ -8,7 +8,9 @@ const DEFAULT_E2E_DATABASE_URL =
   "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
 
 const databaseUrl =
-  process.env.DATABASE_URL?.trim() || DEFAULT_E2E_DATABASE_URL;
+  process.env.E2E_DATABASE_URL?.trim() ||
+  process.env.DATABASE_URL?.trim() ||
+  DEFAULT_E2E_DATABASE_URL;
 
 if (
   !databaseUrl.startsWith("postgresql://") &&
@@ -29,8 +31,10 @@ const postgresDb =
   parsed.pathname.replace(/^\//, "") || "business_app_starter_e2e_test";
 const hostPort = parsed.port || "45432";
 
-await ensureDockerPostgres();
-ensureTargetDatabase();
+if (isLocalPostgres(parsed.hostname)) {
+  await ensureDockerPostgres();
+  ensureTargetDatabase();
+}
 
 const env = {
   APP_DATABASE_URL: databaseUrl,
@@ -167,6 +171,12 @@ function probeHostPort() {
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isLocalPostgres(hostname) {
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
 }
 
 function waitForPostgres() {

--- a/webapp/specs/OVERVIEW.md
+++ b/webapp/specs/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Business App Starter Specs Overview
 
-Last Updated: 2026-07-16
+Last Updated: 2026-07-18
 
 Purpose: Track the status of all planned features, their implementation progress, and next steps.
 

--- a/webapp/src/app/(dashboard)/raster/_lib/step-context.tsx
+++ b/webapp/src/app/(dashboard)/raster/_lib/step-context.tsx
@@ -8,6 +8,7 @@ import { normalizeRasterSeason } from "@/lib/raster/season";
 
 export type RasterStepSearchParams = Promise<{
   scope?: string;
+  district?: string;
   season?: string;
 }>;
 
@@ -26,11 +27,12 @@ export async function requireRasterStep(
   const user = await requireSession();
   const scopes = await listAccessibleRasterScopes(user);
   const params = await searchParams;
-  const scopeCode = params.scope?.trim() || scopes[0]?.code;
+  const scopeCode =
+    params.scope?.trim() || params.district?.trim() || scopes[0]?.code;
   const season = normalizeRasterSeason(params.season);
 
   if (!scopeCode) {
-    return { error: "No Raster scopes are configured for your account." };
+    return { error: "You have no assigned Raster scopes." };
   }
 
   const access = await assertRasterAccess(user, scopeCode, "viewer");

--- a/webapp/src/app/(dashboard)/raster/import/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/import/page.tsx
@@ -1,7 +1,7 @@
-import { Role } from "../../../../../generated/prisma/enums";
 import { CreateInputSetForm } from "@/components/raster/input-set-actions";
 import { RasterSourcesPanel } from "@/components/raster/sources/raster-sources-panel";
 import { WishImportReviewPanel } from "@/components/raster/wish-import-review-panel";
+import { canUseRasterLevel } from "@/lib/raster/access";
 import {
   listInputSets,
   listRasterSourcesForScope,
@@ -27,7 +27,7 @@ export default async function RasterImportPage({
   ]);
   const inputSet = inputSets[0] ?? null;
   const review = inputSet ? await listWishImportReview(inputSet.id) : null;
-  const canEdit = context.user.role === Role.PLATFORM_ADMIN;
+  const canEdit = canUseRasterLevel(context.user, "scheduler");
 
   return (
     <div className="space-y-4">

--- a/webapp/src/app/(dashboard)/raster/review/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/review/page.tsx
@@ -1,8 +1,8 @@
-import { Role } from "../../../../../generated/prisma/enums";
 import { CapacityTable } from "@/components/raster/capacity/capacity-table";
 import { InferCapacitiesButton } from "@/components/raster/capacity/infer-capacities-button";
 import { MatchReviewPanel } from "@/components/raster/match-review-panel";
 import { WishImportReviewPanel } from "@/components/raster/wish-import-review-panel";
+import { canUseRasterLevel } from "@/lib/raster/access";
 import { listMatchReviewState } from "@/lib/raster/match-review";
 import { FixedScheduleNumbersForm } from "@/components/raster/input-set-actions";
 import {
@@ -49,7 +49,7 @@ export default async function RasterReviewPage({
         listWishImportReview(inputSet.id),
       ])
     : [null, [], null];
-  const canEdit = context.user.role === Role.PLATFORM_ADMIN;
+  const canEdit = canUseRasterLevel(context.user, "scheduler");
 
   if (!inputSet) {
     return (

--- a/webapp/src/app/(dashboard)/raster/run/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/run/page.tsx
@@ -1,5 +1,5 @@
-import { Role } from "../../../../../generated/prisma/enums";
 import { InputSetRunActions } from "@/components/raster/input-set-actions";
+import { canUseRasterLevel } from "@/lib/raster/access";
 import {
   listInputSets,
   reviewHallCapacitiesForInputSet,
@@ -45,7 +45,7 @@ export default async function RasterRunPage({
           ? "This run is provisional because excluded groups are not planned yet."
           : "The goal is a run covering every group in this input set."}
       </p>
-      {context.user.role === Role.PLATFORM_ADMIN ? (
+      {canUseRasterLevel(context.user, "scheduler") ? (
         <InputSetRunActions
           capacityReview={capacityReview ?? undefined}
           combined={inputSet.spannedScopes.length > 1}
@@ -56,8 +56,7 @@ export default async function RasterRunPage({
         />
       ) : (
         <p className="mt-3 text-sm text-[var(--muted-foreground)]">
-          You can view this step, but run controls are only shown to platform
-          admins.
+          You can view this step, but run controls are only shown to schedulers.
         </p>
       )}
     </section>

--- a/webapp/src/app/(dashboard)/users/page.tsx
+++ b/webapp/src/app/(dashboard)/users/page.tsx
@@ -1,19 +1,52 @@
 import { Role } from "../../../../generated/prisma/enums";
 import { CreateUserDialog } from "@/components/auth/CreateUserDialog";
+import { UserLookupPanel } from "@/components/auth/UserLookupPanel";
 import { UserManagementTable } from "@/components/auth/UserManagementTable";
 import { requireSession } from "@/lib/auth";
 import { prisma } from "@/lib/db";
+import { isSelectableRasterScope } from "@/lib/raster/scope-level";
 import { getTranslations } from "next-intl/server";
 
 export default async function UsersPage() {
   const user = await requireSession();
   const t = await getTranslations("users");
 
-  if (user.role !== Role.PLATFORM_ADMIN) {
+  if (user.role !== Role.PLATFORM_ADMIN && user.role !== Role.SCOPE_ADMIN) {
     return <div className="text-lg font-medium">{t("notAuthorized")}</div>;
   }
 
-  const users = await prisma.user.findMany({ orderBy: { createdAt: "desc" } });
+  const isPlatformAdmin = user.role === Role.PLATFORM_ADMIN;
+  const users = isPlatformAdmin
+    ? await prisma.user.findMany({
+        orderBy: { createdAt: "desc" },
+        include: {
+          scopeAssignments: { include: { scope: { select: scopeSelect } } },
+        },
+      })
+    : [];
+  const scopes = await prisma.scope.findMany({
+    where: isPlatformAdmin
+      ? undefined
+      : { userAssignments: { some: { userId: user.id } } },
+    select: scopeSelect,
+    orderBy: { name: "asc" },
+  });
+  const assignableScopes = scopes.filter(isSelectableRasterScope);
+  const accessReviewScopes = await prisma.scope.findMany({
+    where: {
+      id: { in: assignableScopes.map((scope) => scope.id) },
+    },
+    select: {
+      ...scopeSelect,
+      userAssignments: {
+        select: {
+          user: { select: { id: true, name: true, email: true, role: true } },
+        },
+        orderBy: { user: { email: "asc" } },
+      },
+    },
+    orderBy: { name: "asc" },
+  });
   const activeUsers = users.filter((entry) => entry.status === "ACTIVE").length;
   const pendingUsers = users.filter(
     (entry) => entry.status === "PENDING_APPROVAL",
@@ -44,19 +77,51 @@ export default async function UsersPage() {
       </section>
 
       <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
-        <CreateUserDialog />
+        {isPlatformAdmin ? <CreateUserDialog /> : null}
         <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
           <div className="border-b border-[var(--border)] px-4 py-4 sm:px-6">
             <h2 className="text-lg font-semibold tracking-tight">
               {t("title")}
             </h2>
           </div>
-          <UserManagementTable currentUserId={user.id} users={users} />
+          {isPlatformAdmin ? (
+            <UserManagementTable
+              availableScopes={assignableScopes}
+              currentUserId={user.id}
+              users={users.map((entry) => ({
+                ...entry,
+                scopes: entry.scopeAssignments.map(
+                  (assignment) => assignment.scope,
+                ),
+              }))}
+            />
+          ) : (
+            <div className="p-4 sm:p-6">
+              <UserLookupPanel
+                availableScopes={assignableScopes}
+                currentUserId={user.id}
+              />
+            </div>
+          )}
         </section>
       </div>
+      <ScopeAccessReview scopes={accessReviewScopes} />
     </div>
   );
 }
+
+const scopeSelect = {
+  id: true,
+  code: true,
+  name: true,
+  parent: {
+    select: {
+      code: true,
+      name: true,
+      parent: { select: { code: true, name: true } },
+    },
+  },
+} as const;
 
 function UserMetric({ label, value }: { label: string; value: number }) {
   return (
@@ -70,3 +135,50 @@ function UserMetric({ label, value }: { label: string; value: number }) {
     </div>
   );
 }
+
+function ScopeAccessReview({ scopes }: { scopes: ScopeAccessReviewScope[] }) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--panel)]">
+      <div className="border-b border-[var(--border)] px-4 py-4 sm:px-6">
+        <h2 className="text-lg font-semibold tracking-tight">Scope access</h2>
+      </div>
+      <div className="divide-y divide-[var(--border)]">
+        {scopes.map((scope) => (
+          <div className="grid gap-3 px-4 py-4 sm:px-6" key={scope.id}>
+            <div>
+              <h3 className="font-medium">{scope.name}</h3>
+              <p className="text-xs text-[var(--muted-foreground)]">
+                {scope.code}
+              </p>
+            </div>
+            {scope.userAssignments.length === 0 ? (
+              <p className="text-sm text-[var(--muted-foreground)]">
+                No users assigned.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {scope.userAssignments.map(({ user }) => (
+                  <span
+                    className="rounded-full border border-[var(--border)] bg-[var(--secondary)] px-3 py-1 text-xs font-semibold text-[var(--secondary-foreground)]"
+                    key={user.id}
+                  >
+                    {user.name || user.email}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+type ScopeAccessReviewScope = {
+  id: string;
+  code: string;
+  name: string;
+  userAssignments: Array<{
+    user: { id: string; name: string; email: string; role: Role };
+  }>;
+};

--- a/webapp/src/app/api/raster/capacity/upload/route.ts
+++ b/webapp/src/app/api/raster/capacity/upload/route.ts
@@ -22,7 +22,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "CSV is empty" }, { status: 400 });
   }
 
-  const headers = rasterIngest.parseCsvLine(headerLine);
+  const headers = rasterIngest
+    .parseCsvLine(headerLine)
+    .map((header) => (header === "district" ? "scope" : header));
   const rows = lines.map((line) => {
     const values = rasterIngest.parseCsvLine(line);
     return Object.fromEntries(

--- a/webapp/src/app/api/raster/input-sets/[id]/capacities/infer/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/capacities/infer/route.ts
@@ -9,7 +9,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/fixed-rasterzahlen/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/fixed-rasterzahlen/route.ts
@@ -17,7 +17,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/groups/[groupId]/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/groups/[groupId]/route.ts
@@ -18,7 +18,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string; groupId: string }> },
 ) {
   const { id, groupId } = await params;
-  const context = await requireRasterInputSet(request, id, "admin");
+  const context = await requireRasterInputSet(request, id, "scheduler");
   if ("error" in context) return context.error;
 
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));

--- a/webapp/src/app/api/raster/input-sets/[id]/manual-assignments/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/manual-assignments/route.ts
@@ -12,7 +12,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/match-review/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/match-review/route.ts
@@ -32,7 +32,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const context = await requireRasterInputSet(request, id, "admin");
+  const context = await requireRasterInputSet(request, id, "scheduler");
   if ("error" in context) return context.error;
 
   const parsed = postSchema.safeParse(await request.json().catch(() => null));

--- a/webapp/src/app/api/raster/input-sets/[id]/runs/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/runs/route.ts
@@ -14,7 +14,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
   if (context.inputSet.status !== InputSetStatus.READY) {

--- a/webapp/src/app/api/raster/input-sets/[id]/season-model/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/season-model/route.ts
@@ -12,7 +12,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/teams/[teamId]/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/teams/[teamId]/route.ts
@@ -15,7 +15,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string; teamId: string }> },
 ) {
   const { id, teamId } = await params;
-  const context = await requireRasterInputSet(request, id, "admin");
+  const context = await requireRasterInputSet(request, id, "scheduler");
   if ("error" in context) return context.error;
 
   const parsed = bodySchema.safeParse(await request.json().catch(() => null));

--- a/webapp/src/app/api/raster/input-sets/[id]/validate/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/validate/route.ts
@@ -9,7 +9,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/wishes/[wishId]/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/wishes/[wishId]/route.ts
@@ -8,7 +8,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string; wishId: string }> },
 ) {
   const { id, wishId } = await params;
-  const context = await requireRasterInputSet(request, id, "admin");
+  const context = await requireRasterInputSet(request, id, "scheduler");
   if ("error" in context) return context.error;
 
   const parsed = wishJsonSchema.safeParse(

--- a/webapp/src/app/api/raster/input-sets/[id]/wishes/json/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/wishes/json/route.ts
@@ -17,7 +17,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/wishes/pdf/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/wishes/pdf/route.ts
@@ -15,7 +15,7 @@ export async function POST(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/[id]/wishes/prompt/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/wishes/prompt/route.ts
@@ -8,7 +8,7 @@ export async function GET(
   const context = await requireRasterInputSet(
     request,
     (await params).id,
-    "admin",
+    "scheduler",
   );
   if ("error" in context) return context.error;
 

--- a/webapp/src/app/api/raster/input-sets/route.ts
+++ b/webapp/src/app/api/raster/input-sets/route.ts
@@ -6,7 +6,8 @@ import { createInputSet, listInputSets } from "@/services/raster";
 import { z } from "zod";
 
 const createInputSetBodySchema = z.object({
-  scope: z.string().trim().min(1),
+  scope: z.string().trim().min(1).optional(),
+  district: z.string().trim().min(1).optional(),
   season: z.string().trim().optional(),
   name: z.string().trim().min(1),
 });
@@ -15,10 +16,10 @@ export async function GET(request: Request) {
   const auth = await requireApiUser(request);
   if ("error" in auth) return auth.error;
 
-  const scopeCode = new URL(request.url).searchParams.get("scope")?.trim();
-  const season = normalizeRasterSeason(
-    new URL(request.url).searchParams.get("season"),
-  );
+  const searchParams = new URL(request.url).searchParams;
+  const scopeCode =
+    searchParams.get("scope")?.trim() ?? searchParams.get("district")?.trim();
+  const season = normalizeRasterSeason(searchParams.get("season"));
   if (!scopeCode) {
     return NextResponse.json({ error: "scope is required" }, { status: 400 });
   }
@@ -49,13 +50,17 @@ export async function POST(request: Request) {
     );
   }
 
-  const access = await assertRasterAccess(
-    auth.user,
-    parsed.data.scope,
-    "admin",
-  );
+  const scopeCode = parsed.data.scope ?? parsed.data.district;
+  if (!scopeCode) {
+    return NextResponse.json(
+      { error: "Invalid input set payload" },
+      { status: 400 },
+    );
+  }
+
+  const access = await assertRasterAccess(auth.user, scopeCode, "scheduler");
   if (access !== true) return access.error;
-  const scope = await resolveRasterScope(parsed.data.scope);
+  const scope = await resolveRasterScope(scopeCode);
   if (!scope) {
     return NextResponse.json({ error: "Scope not found" }, { status: 404 });
   }

--- a/webapp/src/app/api/raster/manual-assignments/[id]/score/route.ts
+++ b/webapp/src/app/api/raster/manual-assignments/[id]/score/route.ts
@@ -23,7 +23,7 @@ export async function POST(
   const access = await assertRasterAccess(
     auth.user,
     draft.inputSet.scope.code,
-    "admin",
+    "scheduler",
   );
   if (access !== true) return access.error;
 

--- a/webapp/src/app/api/raster/manual-assignments/[id]/validate/route.ts
+++ b/webapp/src/app/api/raster/manual-assignments/[id]/validate/route.ts
@@ -23,7 +23,7 @@ export async function POST(
   const access = await assertRasterAccess(
     auth.user,
     draft.inputSet.scope.code,
-    "admin",
+    "scheduler",
   );
   if (access !== true) return access.error;
 

--- a/webapp/src/app/api/raster/snapshots/import/route.ts
+++ b/webapp/src/app/api/raster/snapshots/import/route.ts
@@ -50,7 +50,8 @@ const conflictSchema = z.object({
 });
 
 const bodySchema = z.object({
-  scope: z.string().trim().min(1),
+  scope: z.string().trim().min(1).optional(),
+  district: z.string().trim().min(1).optional(),
   objectiveBreakdown: z.record(z.string(), z.unknown()).optional(),
   assignments: z.array(assignmentSchema),
   conflicts: z.array(conflictSchema).default([]),
@@ -68,13 +69,17 @@ export async function POST(request: Request) {
     );
   }
 
-  const access = await assertRasterAccess(
-    auth.user,
-    parsed.data.scope,
-    "admin",
-  );
+  const scopeCode = parsed.data.scope ?? parsed.data.district;
+  if (!scopeCode) {
+    return NextResponse.json(
+      { error: "Invalid snapshot import" },
+      { status: 422 },
+    );
+  }
+
+  const access = await assertRasterAccess(auth.user, scopeCode, "admin");
   if (access !== true) return access.error;
-  const scope = await resolveRasterScope(parsed.data.scope);
+  const scope = await resolveRasterScope(scopeCode);
   if (!scope) {
     return NextResponse.json({ error: "Scope not found" }, { status: 404 });
   }
@@ -93,7 +98,7 @@ export async function POST(request: Request) {
   await logRasterAudit({
     action: AuditAction.RASTER_INPUT_UPLOADED,
     actorId: auth.user.id,
-    scope: parsed.data.scope,
+    scope: scopeCode,
     entityType: "RasterSnapshot",
     entityId: snapshot.id,
     details: {

--- a/webapp/src/app/api/raster/sources/[id]/refresh/route.ts
+++ b/webapp/src/app/api/raster/sources/[id]/refresh/route.ts
@@ -22,7 +22,7 @@ export async function POST(
   const access = await assertRasterAccess(
     auth.user,
     source.scope.code,
-    "admin",
+    "scheduler",
   );
   if (access !== true) return access.error;
 

--- a/webapp/src/app/api/raster/sources/[id]/route.ts
+++ b/webapp/src/app/api/raster/sources/[id]/route.ts
@@ -24,7 +24,7 @@ export async function PATCH(
   const access = await assertRasterAccess(
     auth.user,
     source.scope.code,
-    "admin",
+    "scheduler",
   );
   if (access !== true) return access.error;
 
@@ -80,7 +80,7 @@ export async function DELETE(
   const access = await assertRasterAccess(
     auth.user,
     source.scope.code,
-    "admin",
+    "scheduler",
   );
   if (access !== true) return access.error;
 

--- a/webapp/src/app/api/raster/sources/route.ts
+++ b/webapp/src/app/api/raster/sources/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request) {
   const access = await assertRasterAccess(
     auth.user,
     parsed.data.scopeCode,
-    "admin",
+    "scheduler",
   );
   if (access !== true) return access.error;
 

--- a/webapp/src/app/api/users/[id]/scopes/route.ts
+++ b/webapp/src/app/api/users/[id]/scopes/route.ts
@@ -1,0 +1,43 @@
+import {
+  grantManagedUserScope,
+  listManagedUserScopes,
+  revokeManagedUserScope,
+} from "@/services/api/scope-assignments";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const result = await listManagedUserScopes(params, request);
+  if ("error" in result) {
+    return result.error;
+  }
+
+  return Response.json({ scopes: result.scopes });
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const body = (await request.json()) as { scopeId?: string };
+  const result = await grantManagedUserScope(params, body, request);
+  if ("error" in result) {
+    return result.error;
+  }
+
+  return Response.json({ scope: result.scope });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const body = (await request.json()) as { scopeId?: string };
+  const result = await revokeManagedUserScope(params, body, request);
+  if ("error" in result) {
+    return result.error;
+  }
+
+  return Response.json({ scope: result.scope });
+}

--- a/webapp/src/app/api/users/lookup/route.ts
+++ b/webapp/src/app/api/users/lookup/route.ts
@@ -1,0 +1,11 @@
+import { lookupUserByEmail } from "@/services/api/user-admin";
+
+export async function GET(request: Request) {
+  const email = new URL(request.url).searchParams.get("email");
+  const result = await lookupUserByEmail(email, request);
+  if ("error" in result) {
+    return result.error;
+  }
+
+  return Response.json({ user: result.user });
+}

--- a/webapp/src/components/auth/ScopeAssignmentDialog.tsx
+++ b/webapp/src/components/auth/ScopeAssignmentDialog.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/shadcn/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select";
+import { Button } from "@/components/ui/Button";
+import { useToast } from "@/components/ui/Toast";
+import { withBasePath } from "@/lib/base-path";
+import { getRasterScopeLevel } from "@/lib/raster/scope-level";
+
+export type ScopeAssignmentScope = {
+  id: string;
+  code: string;
+  name: string;
+  parent: {
+    code: string;
+    name: string;
+    parent: { code: string; name: string } | null;
+  } | null;
+};
+
+export function ScopeAssignmentDialog({
+  userId,
+  assignedScopes,
+  availableScopes,
+}: {
+  userId: string;
+  assignedScopes: ScopeAssignmentScope[];
+  availableScopes: ScopeAssignmentScope[];
+}) {
+  const router = useRouter();
+  const { pushToast } = useToast();
+  const t = useTranslations("users");
+  const tCommon = useTranslations("common");
+  const [open, setOpen] = useState(false);
+  const [scopeId, setScopeId] = useState("");
+  const [busyScopeId, setBusyScopeId] = useState<string | null>(null);
+
+  const assignableScopes = useMemo(() => {
+    const assigned = new Set(assignedScopes.map((scope) => scope.id));
+    return availableScopes.filter((scope) => !assigned.has(scope.id));
+  }, [assignedScopes, availableScopes]);
+
+  async function updateScope(method: "POST" | "DELETE", nextScopeId: string) {
+    setBusyScopeId(nextScopeId);
+    try {
+      const response = await fetch(
+        withBasePath(`/api/users/${userId}/scopes`),
+        {
+          method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scopeId: nextScopeId }),
+        },
+      );
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        pushToast(payload?.error ?? t("couldNotUpdate"));
+        return;
+      }
+
+      pushToast(method === "POST" ? t("scopeGranted") : t("scopeRevoked"));
+      setScopeId("");
+      router.refresh();
+    } finally {
+      setBusyScopeId(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="secondary">
+          <Plus className="size-4" aria-hidden="true" />
+          {t("assignScope")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-xl rounded-lg border-[var(--border)] bg-[var(--panel)] dark:bg-[var(--panel)]">
+        <DialogHeader>
+          <DialogTitle>{t("scopes")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <Select value={scopeId} onValueChange={setScopeId}>
+              <SelectTrigger
+                aria-label={t("assignScope")}
+                className="min-h-10 flex-1 rounded-lg border-[var(--border)] bg-white px-3 py-2 shadow-none dark:bg-[var(--panel)]"
+              >
+                <SelectValue placeholder={t("assignScope")} />
+              </SelectTrigger>
+              <SelectContent className="rounded-lg border-[var(--border)]">
+                {assignableScopes.map((scope) => (
+                  <SelectItem key={scope.id} value={scope.id}>
+                    {scopeLabel(scope, t)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              disabled={!scopeId || busyScopeId === scopeId}
+              onClick={() => void updateScope("POST", scopeId)}
+              type="button"
+            >
+              <Plus className="size-4" aria-hidden="true" />
+              {t("assignScope")}
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            {assignedScopes.length === 0 ? (
+              <p className="text-sm text-[var(--muted-foreground)]">
+                {t("noScopes")}
+              </p>
+            ) : (
+              assignedScopes.map((scope) => (
+                <div
+                  className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border)] px-3 py-2"
+                  key={scope.id}
+                >
+                  <span className="min-w-0 text-sm">
+                    {scopeLabel(scope, t)}
+                  </span>
+                  <Button
+                    className="shrink-0"
+                    disabled={busyScopeId === scope.id}
+                    onClick={() => void updateScope("DELETE", scope.id)}
+                    type="button"
+                    variant="secondary"
+                  >
+                    <Trash2 className="size-4" aria-hidden="true" />
+                    {t("revokeScope")}
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={() => setOpen(false)}
+            type="button"
+            variant="secondary"
+          >
+            {tCommon("cancel")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function scopeLabel(
+  scope: ScopeAssignmentScope,
+  t: ReturnType<typeof useTranslations<"users">>,
+) {
+  const level = getRasterScopeLevel(scope);
+  return `${t(`scopeLevels.${level === "bezirk" ? "bezirk" : "association"}`)}: ${rasterScopePath(scope)}`;
+}
+
+function rasterScopePath(scope: ScopeAssignmentScope) {
+  return [scope.parent?.parent, scope.parent, scope]
+    .filter((item): item is { code: string; name: string } => Boolean(item))
+    .map((item) => item.name)
+    .join(" / ");
+}

--- a/webapp/src/components/auth/UserLookupPanel.tsx
+++ b/webapp/src/components/auth/UserLookupPanel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { useToast } from "@/components/ui/Toast";
+import { withBasePath } from "@/lib/base-path";
+import { Role } from "../../../generated/prisma/enums";
+import {
+  UserManagementTable,
+  type UserRow,
+} from "@/components/auth/UserManagementTable";
+import type { ScopeAssignmentScope } from "@/components/auth/ScopeAssignmentDialog";
+
+export function UserLookupPanel({
+  currentUserId,
+  availableScopes,
+}: {
+  currentUserId: string;
+  availableScopes: ScopeAssignmentScope[];
+}) {
+  const t = useTranslations("users");
+  const { pushToast } = useToast();
+  const [email, setEmail] = useState("");
+  const [users, setUsers] = useState<UserRow[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  async function lookup(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      const response = await fetch(
+        withBasePath(`/api/users/lookup?email=${encodeURIComponent(email)}`),
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        user?: UserRow | null;
+        error?: string;
+      } | null;
+      if (!response.ok) {
+        pushToast(payload?.error ?? t("couldNotUpdate"));
+        return;
+      }
+
+      setUsers(payload?.user ? [payload.user] : []);
+      if (!payload?.user) {
+        pushToast(t("noUserFound"));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <form className="flex gap-2" onSubmit={lookup}>
+        <Input
+          aria-label={t("email")}
+          placeholder={t("emailPlaceholder")}
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          required
+        />
+        <Button disabled={busy} type="submit">
+          <Search className="size-4" aria-hidden="true" />
+          {t("lookupUser")}
+        </Button>
+      </form>
+      <p className="text-sm text-[var(--muted-foreground)]">
+        {t("accessLookupOnly")}
+      </p>
+      {users.length ? (
+        <section className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--panel)]">
+          <UserManagementTable
+            availableScopes={availableScopes}
+            canManageStatus={false}
+            currentUserId={currentUserId}
+            roleOptions={[Role.SCOPE_USER, Role.SCOPE_ADMIN]}
+            users={users}
+          />
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/webapp/src/components/auth/UserManagementTable.tsx
+++ b/webapp/src/components/auth/UserManagementTable.tsx
@@ -113,24 +113,6 @@ export function UserManagementTable({
                   {entry.email}
                 </td>
                 <td className="px-4 py-4">
-                  <div className="flex max-w-[18rem] flex-wrap gap-1">
-                    {entry.scopes.length === 0 ? (
-                      <span className="text-xs text-[var(--muted-foreground)]">
-                        {t("noScopes")}
-                      </span>
-                    ) : (
-                      entry.scopes.map((scope) => (
-                        <span
-                          className="rounded-full border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs font-semibold text-[var(--secondary-foreground)]"
-                          key={scope.id}
-                        >
-                          {scope.name}
-                        </span>
-                      ))
-                    )}
-                  </div>
-                </td>
-                <td className="px-4 py-4">
                   <Select
                     disabled={!canEditSelfRole || Boolean(isBusy)}
                     value={entry.role}
@@ -161,6 +143,24 @@ export function UserManagementTable({
                       ))}
                     </SelectContent>
                   </Select>
+                </td>
+                <td className="px-4 py-4">
+                  <div className="flex max-w-[18rem] flex-wrap gap-1">
+                    {entry.scopes.length === 0 ? (
+                      <span className="text-xs text-[var(--muted-foreground)]">
+                        {t("noScopes")}
+                      </span>
+                    ) : (
+                      entry.scopes.map((scope) => (
+                        <span
+                          className="rounded-full border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs font-semibold text-[var(--secondary-foreground)]"
+                          key={scope.id}
+                        >
+                          {scope.name}
+                        </span>
+                      ))
+                    )}
+                  </div>
                 </td>
                 <td className="px-4 py-4">
                   <span className="rounded-full border border-[var(--border)] bg-[var(--secondary)] px-3 py-1 text-xs font-semibold text-[var(--secondary-foreground)]">

--- a/webapp/src/components/auth/UserManagementTable.tsx
+++ b/webapp/src/components/auth/UserManagementTable.tsx
@@ -22,22 +22,33 @@ import {
 import { withBasePath } from "@/lib/base-path";
 import { Button } from "@/components/ui/Button";
 import { useToast } from "@/components/ui/Toast";
+import {
+  ScopeAssignmentDialog,
+  type ScopeAssignmentScope,
+} from "@/components/auth/ScopeAssignmentDialog";
 
-type UserRow = {
+export type UserRow = {
   id: string;
   name: string;
   email: string;
   role: Role;
   status: UserStatus;
   authMethod: AuthMethod;
+  scopes: ScopeAssignmentScope[];
 };
 
 export function UserManagementTable({
+  canManageStatus = true,
   currentUserId,
+  roleOptions = Object.values(RoleEnum),
   users,
+  availableScopes,
 }: {
+  canManageStatus?: boolean;
   currentUserId: string;
+  roleOptions?: Role[];
   users: UserRow[];
+  availableScopes: ScopeAssignmentScope[];
 }) {
   const router = useRouter();
   const { pushToast } = useToast();
@@ -79,6 +90,7 @@ export function UserManagementTable({
             <th className="px-4 py-3 sm:px-6">{t("name")}</th>
             <th className="px-4 py-3">{t("email")}</th>
             <th className="px-4 py-3">{t("role")}</th>
+            <th className="px-4 py-3">{t("scopeColumn")}</th>
             <th className="px-4 py-3">{t("statusLabel")}</th>
             <th className="px-4 py-3">{t("auth")}</th>
             <th className="px-4 py-3 sm:px-6">{t("actions")}</th>
@@ -99,6 +111,24 @@ export function UserManagementTable({
                 </td>
                 <td className="px-4 py-4 text-[var(--muted-foreground)]">
                   {entry.email}
+                </td>
+                <td className="px-4 py-4">
+                  <div className="flex max-w-[18rem] flex-wrap gap-1">
+                    {entry.scopes.length === 0 ? (
+                      <span className="text-xs text-[var(--muted-foreground)]">
+                        {t("noScopes")}
+                      </span>
+                    ) : (
+                      entry.scopes.map((scope) => (
+                        <span
+                          className="rounded-full border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs font-semibold text-[var(--secondary-foreground)]"
+                          key={scope.id}
+                        >
+                          {scope.name}
+                        </span>
+                      ))
+                    )}
+                  </div>
                 </td>
                 <td className="px-4 py-4">
                   <Select
@@ -124,7 +154,7 @@ export function UserManagementTable({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent className="rounded-lg border-[var(--border)]">
-                      {Object.values(RoleEnum).map((role) => (
+                      {roleOptions.map((role) => (
                         <SelectItem key={role} value={role}>
                           {t(`roles.${role}`)}
                         </SelectItem>
@@ -142,7 +172,14 @@ export function UserManagementTable({
                 </td>
                 <td className="px-4 py-4 sm:px-6">
                   <div className="flex flex-wrap gap-2">
-                    {entry.status === UserStatusEnum.PENDING_APPROVAL ? (
+                    <ScopeAssignmentDialog
+                      assignedScopes={entry.scopes}
+                      availableScopes={availableScopes}
+                      userId={entry.id}
+                    />
+
+                    {canManageStatus &&
+                    entry.status === UserStatusEnum.PENDING_APPROVAL ? (
                       <Button
                         disabled={Boolean(isBusy)}
                         onClick={() =>
@@ -160,7 +197,8 @@ export function UserManagementTable({
                       </Button>
                     ) : null}
 
-                    {entry.status === UserStatusEnum.ACTIVE ? (
+                    {canManageStatus &&
+                    entry.status === UserStatusEnum.ACTIVE ? (
                       <Button
                         disabled={Boolean(isBusy)}
                         onClick={() =>
@@ -178,7 +216,8 @@ export function UserManagementTable({
                       </Button>
                     ) : null}
 
-                    {entry.status === UserStatusEnum.INACTIVE ? (
+                    {canManageStatus &&
+                    entry.status === UserStatusEnum.INACTIVE ? (
                       <Button
                         disabled={Boolean(isBusy)}
                         onClick={() =>

--- a/webapp/src/i18n/messages/de.json
+++ b/webapp/src/i18n/messages/de.json
@@ -84,6 +84,21 @@
     "lastAdminDeactivateError": "Der letzte Admin-Benutzer kann nicht deaktiviert werden",
     "lastAdminRoleError": "Die Rolle des letzten Admin-Benutzers kann nicht geandert werden",
     "couldNotUpdate": "Benutzer konnte nicht aktualisiert werden",
+    "scopes": "Scopes",
+    "noScopes": "Keine Scopes zugewiesen",
+    "assignScope": "Scope zuweisen",
+    "revokeScope": "Scope entziehen",
+    "scopeGranted": "Scope zugewiesen",
+    "scopeRevoked": "Scope entzogen",
+    "scopeColumn": "Scope-Zugriff",
+    "accessLookupOnly": "Exakte E-Mail suchen, um einen Benutzer zu verwalten.",
+    "lookupUser": "Benutzer suchen",
+    "noUserFound": "Kein Benutzer gefunden",
+    "noScopeAccess": "Ihnen sind keine Scopes zugewiesen.",
+    "scopeLevels": {
+      "association": "Verband",
+      "bezirk": "Bezirk"
+    },
     "roles": {
       "PLATFORM_ADMIN": "Plattform-Admin",
       "SCOPE_ADMIN": "Bereichs-Admin",

--- a/webapp/src/i18n/messages/en.json
+++ b/webapp/src/i18n/messages/en.json
@@ -84,6 +84,21 @@
     "lastAdminDeactivateError": "Cannot deactivate the last Admin user",
     "lastAdminRoleError": "Cannot change role of the last Admin user",
     "couldNotUpdate": "Could not update user",
+    "scopes": "Scopes",
+    "noScopes": "No scopes assigned",
+    "assignScope": "Assign scope",
+    "revokeScope": "Revoke scope",
+    "scopeGranted": "Scope granted",
+    "scopeRevoked": "Scope revoked",
+    "scopeColumn": "Scope access",
+    "accessLookupOnly": "Search by exact email to manage a user.",
+    "lookupUser": "Find user",
+    "noUserFound": "No user found",
+    "noScopeAccess": "You have no assigned scopes.",
+    "scopeLevels": {
+      "association": "Verband",
+      "bezirk": "Bezirk"
+    },
     "roles": {
       "PLATFORM_ADMIN": "Platform Admin",
       "SCOPE_ADMIN": "Scoped Admin",

--- a/webapp/src/i18n/messages/es.json
+++ b/webapp/src/i18n/messages/es.json
@@ -84,6 +84,21 @@
     "lastAdminDeactivateError": "No se puede desactivar al ultimo usuario administrador",
     "lastAdminRoleError": "No se puede cambiar el rol del ultimo usuario administrador",
     "couldNotUpdate": "No se pudo actualizar el usuario",
+    "scopes": "Ambitos",
+    "noScopes": "Sin ambitos asignados",
+    "assignScope": "Asignar ambito",
+    "revokeScope": "Revocar ambito",
+    "scopeGranted": "Ambito asignado",
+    "scopeRevoked": "Ambito revocado",
+    "scopeColumn": "Acceso por ambito",
+    "accessLookupOnly": "Busca por email exacto para gestionar un usuario.",
+    "lookupUser": "Buscar usuario",
+    "noUserFound": "No se encontro ningun usuario",
+    "noScopeAccess": "No tienes ambitos asignados.",
+    "scopeLevels": {
+      "association": "Verband",
+      "bezirk": "Bezirk"
+    },
     "roles": {
       "PLATFORM_ADMIN": "Administrador de plataforma",
       "SCOPE_ADMIN": "Administrador de alcance",

--- a/webapp/src/i18n/messages/fr.json
+++ b/webapp/src/i18n/messages/fr.json
@@ -84,6 +84,21 @@
     "lastAdminDeactivateError": "Impossible de desactiver le dernier utilisateur admin",
     "lastAdminRoleError": "Impossible de changer le role du dernier utilisateur admin",
     "couldNotUpdate": "Impossible de mettre a jour l'utilisateur",
+    "scopes": "Perimetres",
+    "noScopes": "Aucun perimetre attribue",
+    "assignScope": "Attribuer un perimetre",
+    "revokeScope": "Retirer le perimetre",
+    "scopeGranted": "Perimetre attribue",
+    "scopeRevoked": "Perimetre retire",
+    "scopeColumn": "Acces par perimetre",
+    "accessLookupOnly": "Recherchez par email exact pour gerer un utilisateur.",
+    "lookupUser": "Chercher utilisateur",
+    "noUserFound": "Aucun utilisateur trouve",
+    "noScopeAccess": "Aucun perimetre ne vous est attribue.",
+    "scopeLevels": {
+      "association": "Verband",
+      "bezirk": "Bezirk"
+    },
     "roles": {
       "PLATFORM_ADMIN": "Admin plateforme",
       "SCOPE_ADMIN": "Admin perimetre",

--- a/webapp/src/i18n/messages/pt.json
+++ b/webapp/src/i18n/messages/pt.json
@@ -84,6 +84,21 @@
     "lastAdminDeactivateError": "Nao e possivel desativar o ultimo utilizador administrador",
     "lastAdminRoleError": "Nao e possivel alterar a funcao do ultimo utilizador administrador",
     "couldNotUpdate": "Nao foi possivel atualizar o utilizador",
+    "scopes": "Ambitos",
+    "noScopes": "Sem ambitos atribuidos",
+    "assignScope": "Atribuir ambito",
+    "revokeScope": "Revogar ambito",
+    "scopeGranted": "Ambito atribuido",
+    "scopeRevoked": "Ambito revogado",
+    "scopeColumn": "Acesso por ambito",
+    "accessLookupOnly": "Pesquise pelo email exato para gerir um utilizador.",
+    "lookupUser": "Procurar utilizador",
+    "noUserFound": "Nenhum utilizador encontrado",
+    "noScopeAccess": "Nao tem ambitos atribuidos.",
+    "scopeLevels": {
+      "association": "Verband",
+      "bezirk": "Bezirk"
+    },
     "roles": {
       "PLATFORM_ADMIN": "Admin da plataforma",
       "SCOPE_ADMIN": "Admin de escopo",

--- a/webapp/src/lib/raster/access.ts
+++ b/webapp/src/lib/raster/access.ts
@@ -41,17 +41,7 @@ export async function listAccessibleRasterScopes(
     where:
       user.role === Role.PLATFORM_ADMIN
         ? undefined
-        : {
-            OR: [
-              { userAssignments: { some: { userId: user.id } } },
-              { parent: { userAssignments: { some: { userId: user.id } } } },
-              {
-                parent: {
-                  parent: { userAssignments: { some: { userId: user.id } } },
-                },
-              },
-            ],
-          },
+        : { userAssignments: { some: { userId: user.id } } },
     select: {
       code: true,
       id: true,
@@ -90,20 +80,8 @@ export async function canAccessRasterScope(
 
   const scope = await prisma.scope.findFirst({
     where: {
-      AND: [
-        { code: scopeCode },
-        {
-          OR: [
-            { userAssignments: { some: { userId: user.id } } },
-            { parent: { userAssignments: { some: { userId: user.id } } } },
-            {
-              parent: {
-                parent: { userAssignments: { some: { userId: user.id } } },
-              },
-            },
-          ],
-        },
-      ],
+      code: scopeCode,
+      userAssignments: { some: { userId: user.id } },
     },
     select: { id: true },
   });

--- a/webapp/src/lib/rbac.ts
+++ b/webapp/src/lib/rbac.ts
@@ -15,6 +15,16 @@ export function isAdmin(role: Role) {
   return role === Role.PLATFORM_ADMIN;
 }
 
+const roleRank: Record<Role, number> = {
+  [Role.SCOPE_USER]: 0,
+  [Role.SCOPE_ADMIN]: 1,
+  [Role.PLATFORM_ADMIN]: 2,
+};
+
+export function canAssignRole(actor: Pick<User, "role">, targetRole: Role) {
+  return roleRank[targetRole] <= roleRank[actor.role];
+}
+
 export async function getUserScopeIds(userId: string) {
   const assignments = await prisma.userScopeAssignment.findMany({
     where: { userId },
@@ -38,4 +48,30 @@ export async function checkScopeAccess(
 
   const scopeIds = await getUserScopeIds(user.id);
   return scopeIds.includes(scopeId);
+}
+
+export async function mayManageScopeAssignment(
+  actor: Pick<User, "id" | "role">,
+  target: Pick<User, "id" | "role">,
+  scopeId: string,
+  getActorScopeIds: (userId: string) => Promise<string[]> = getUserScopeIds,
+  isAssignableScope: (scopeId: string) => Promise<boolean> = async () => true,
+) {
+  if (!(await isAssignableScope(scopeId))) {
+    return false;
+  }
+
+  if (actor.role === Role.PLATFORM_ADMIN) {
+    return true;
+  }
+
+  if (actor.role !== Role.SCOPE_ADMIN || actor.id === target.id) {
+    return false;
+  }
+
+  if (!canAssignRole(actor, target.role)) {
+    return false;
+  }
+
+  return (await getActorScopeIds(actor.id)).includes(scopeId);
 }

--- a/webapp/src/lib/rbac.ts
+++ b/webapp/src/lib/rbac.ts
@@ -75,3 +75,54 @@ export async function mayManageScopeAssignment(
 
   return (await getActorScopeIds(actor.id)).includes(scopeId);
 }
+
+async function actorSharesScopeWithTarget(actorId: string, targetId: string) {
+  const actorScopeIds = await getUserScopeIds(actorId);
+  if (actorScopeIds.length === 0) {
+    return false;
+  }
+  const shared = await prisma.userScopeAssignment.findFirst({
+    where: { userId: targetId, scopeId: { in: actorScopeIds } },
+    select: { scopeId: true },
+  });
+  return !!shared;
+}
+
+/**
+ * Whether `actor` may set `target`'s role to `nextRole`.
+ *
+ * `canAssignRole` alone guards only the destination rank, which lets a scope
+ * admin demote a user ranked above them (a platform admin) or reroll a user in
+ * a scope they do not hold. The spec confines a scope admin to acting within
+ * their own scopes (User Story 2 scenario 5; edge case "acts on a user who
+ * holds scopes outside the admin's own"), so a scope admin may change a role
+ * only for a target at or below their own rank and sharing at least one scope,
+ * and never their own.
+ */
+export async function mayManageUserRole(
+  actor: Pick<User, "id" | "role">,
+  target: Pick<User, "id" | "role">,
+  nextRole: Role,
+  sharesScope: (
+    actorId: string,
+    targetId: string,
+  ) => Promise<boolean> = actorSharesScopeWithTarget,
+) {
+  if (!canAssignRole(actor, nextRole)) {
+    return false;
+  }
+
+  if (actor.role === Role.PLATFORM_ADMIN) {
+    return true;
+  }
+
+  if (actor.role !== Role.SCOPE_ADMIN || actor.id === target.id) {
+    return false;
+  }
+
+  if (!canAssignRole(actor, target.role)) {
+    return false;
+  }
+
+  return sharesScope(actor.id, target.id);
+}

--- a/webapp/src/services/api/scope-assignments.ts
+++ b/webapp/src/services/api/scope-assignments.ts
@@ -1,0 +1,193 @@
+import { safeLogAudit } from "@/lib/audit";
+import { prisma } from "@/lib/db";
+import { jsonError } from "@/lib/http";
+import { mayManageScopeAssignment } from "@/lib/rbac";
+import { isSelectableRasterScope } from "@/lib/raster/scope-level";
+import { requireRouteUserWithRoles } from "@/services/api/route-context";
+import { withSerializableRetry } from "@/services/api/serializable-retry";
+import type { RouteParamsWithId } from "@/services/api/types";
+import { Prisma } from "../../../generated/prisma/client";
+import { AuditAction, Role } from "../../../generated/prisma/enums";
+
+type ScopeBody = { scopeId?: string };
+type ManagedScope = Prisma.ScopeGetPayload<{ select: typeof scopeSelect }>;
+
+export async function listManagedUserScopes(
+  params: RouteParamsWithId,
+  request?: Request,
+) {
+  const managed = await requireScopeAssignmentContext(
+    params,
+    undefined,
+    request,
+  );
+  if ("error" in managed) {
+    return managed;
+  }
+
+  const assignments = await prisma.userScopeAssignment.findMany({
+    where:
+      managed.actor.role === Role.PLATFORM_ADMIN
+        ? { userId: managed.target.id }
+        : {
+            userId: managed.target.id,
+            scope: { userAssignments: { some: { userId: managed.actor.id } } },
+          },
+    select: { scope: { select: scopeSelect } },
+    orderBy: { scope: { name: "asc" } },
+  });
+
+  return { scopes: assignments.map((assignment) => assignment.scope) };
+}
+
+export async function grantManagedUserScope(
+  params: RouteParamsWithId,
+  body: ScopeBody,
+  request?: Request,
+) {
+  const managed = await requireScopeActionContext(
+    params,
+    body.scopeId,
+    request,
+  );
+  if ("error" in managed) {
+    return managed;
+  }
+
+  const assignment = await withSerializableRetry(() =>
+    prisma.userScopeAssignment.upsert({
+      where: {
+        userId_scopeId: {
+          userId: managed.target.id,
+          scopeId: managed.scope.id,
+        },
+      },
+      create: {
+        userId: managed.target.id,
+        scopeId: managed.scope.id,
+      },
+      update: {},
+    }),
+  );
+
+  await safeLogAudit({
+    action: AuditAction.SCOPE_ASSIGNMENT_CHANGED,
+    entityType: "UserScopeAssignment",
+    entityId: assignment.id,
+    actorId: managed.actor.id,
+    scopeId: managed.scope.id,
+    details: {
+      direction: "grant",
+      userId: managed.target.id,
+      scopeId: managed.scope.id,
+    },
+  });
+
+  return { scope: managed.scope };
+}
+
+export async function revokeManagedUserScope(
+  params: RouteParamsWithId,
+  body: ScopeBody,
+  request?: Request,
+) {
+  const managed = await requireScopeActionContext(
+    params,
+    body.scopeId,
+    request,
+  );
+  if ("error" in managed) {
+    return managed;
+  }
+
+  const deleted = await withSerializableRetry(() =>
+    prisma.userScopeAssignment.deleteMany({
+      where: { userId: managed.target.id, scopeId: managed.scope.id },
+    }),
+  );
+
+  if (deleted.count > 0) {
+    await safeLogAudit({
+      action: AuditAction.SCOPE_ASSIGNMENT_CHANGED,
+      entityType: "UserScopeAssignment",
+      entityId: `${managed.target.id}:${managed.scope.id}`,
+      actorId: managed.actor.id,
+      scopeId: managed.scope.id,
+      details: {
+        direction: "revoke",
+        userId: managed.target.id,
+        scopeId: managed.scope.id,
+      },
+    });
+  }
+
+  return { scope: managed.scope };
+}
+
+async function requireScopeAssignmentContext(
+  params: RouteParamsWithId,
+  scopeId?: string,
+  request?: Request,
+) {
+  const auth = await requireRouteUserWithRoles(
+    [Role.PLATFORM_ADMIN, Role.SCOPE_ADMIN],
+    request,
+  );
+  if ("error" in auth) {
+    return auth;
+  }
+
+  const { id } = await params;
+  const target = await prisma.user.findUnique({ where: { id } });
+  if (!target) {
+    return { error: jsonError("User not found", 404) };
+  }
+
+  if (!scopeId) {
+    return { actor: auth.user, target };
+  }
+
+  const scope = await prisma.scope.findUnique({
+    where: { id: scopeId },
+    select: scopeSelect,
+  });
+  if (!scope || !isSelectableRasterScope(scope)) {
+    return { error: jsonError("Scope is not assignable", 400) };
+  }
+
+  if (!(await mayManageScopeAssignment(auth.user, target, scope.id))) {
+    return { error: jsonError("Not authorized for this scope", 403) };
+  }
+
+  return { actor: auth.user, target, scope };
+}
+
+async function requireScopeActionContext(
+  params: RouteParamsWithId,
+  scopeId?: string,
+  request?: Request,
+) {
+  const managed = await requireScopeAssignmentContext(params, scopeId, request);
+  if ("error" in managed) {
+    return managed;
+  }
+
+  if (!("scope" in managed)) {
+    return { error: jsonError("Scope ID is required", 400) };
+  }
+
+  return managed as typeof managed & { scope: ManagedScope };
+}
+
+const scopeSelect = {
+  id: true,
+  code: true,
+  name: true,
+  parent: {
+    select: {
+      code: true,
+      name: true,
+      parent: { select: { code: true, name: true } },
+    },
+  },
+} satisfies Prisma.ScopeSelect;

--- a/webapp/src/services/api/serializable-retry.ts
+++ b/webapp/src/services/api/serializable-retry.ts
@@ -1,0 +1,40 @@
+import { Prisma } from "../../../generated/prisma/client";
+
+const SERIALIZABLE_RETRY_LIMIT = 3;
+
+export async function withSerializableRetry<T>(run: () => Promise<T>) {
+  let attempt = 0;
+  while (attempt < SERIALIZABLE_RETRY_LIMIT) {
+    try {
+      return await run();
+    } catch (error) {
+      if (error instanceof Response) {
+        throw error;
+      }
+
+      if (
+        isSerializableConflict(error) &&
+        attempt < SERIALIZABLE_RETRY_LIMIT - 1
+      ) {
+        attempt += 1;
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw new Error("Unreachable serializable retry state");
+}
+
+function isSerializableConflict(error: unknown) {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code === "P2034";
+  }
+
+  if (typeof error === "object" && error !== null && "code" in error) {
+    return (error as { code?: string }).code === "P2034";
+  }
+
+  return false;
+}

--- a/webapp/src/services/api/tokens.ts
+++ b/webapp/src/services/api/tokens.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { prisma } from "@/lib/db";
 import { jsonError } from "@/lib/http";
 import { logger } from "@/lib/logger";
+import { withSerializableRetry } from "@/services/api/serializable-retry";
 import { Prisma } from "../../../generated/prisma/client";
 import {
   TokenStatus,
@@ -15,7 +16,6 @@ const DEFAULT_CLI_EXPIRY_DAYS = 30;
 const DEFAULT_PAT_LIMIT = 10;
 const RECENTLY_VISIBLE_WINDOW_DAYS = 90;
 const TOKEN_SEGMENT_LENGTH = 8;
-const SERIALIZABLE_RETRY_LIMIT = 3;
 const tokenLogger = logger.child({ component: "tokens" });
 
 function readPositiveInteger(value: string | undefined, fallback: number) {
@@ -201,43 +201,6 @@ export async function createToken(
       createdAt: created.createdAt,
     },
   };
-}
-
-async function withSerializableRetry<T>(run: () => Promise<T>) {
-  let attempt = 0;
-  while (attempt < SERIALIZABLE_RETRY_LIMIT) {
-    try {
-      return await run();
-    } catch (error) {
-      if (error instanceof Response) {
-        throw error;
-      }
-
-      if (
-        isSerializableConflict(error) &&
-        attempt < SERIALIZABLE_RETRY_LIMIT - 1
-      ) {
-        attempt += 1;
-        continue;
-      }
-
-      throw error;
-    }
-  }
-
-  throw new Error("Unreachable serializable retry state");
-}
-
-function isSerializableConflict(error: unknown) {
-  if (error instanceof Prisma.PrismaClientKnownRequestError) {
-    return error.code === "P2034";
-  }
-
-  if (typeof error === "object" && error !== null && "code" in error) {
-    return (error as { code?: string }).code === "P2034";
-  }
-
-  return false;
 }
 
 export async function validateToken(tokenValue: string) {

--- a/webapp/src/services/api/user-admin.ts
+++ b/webapp/src/services/api/user-admin.ts
@@ -6,7 +6,7 @@ import {
 import { safeLogAudit } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { jsonError } from "@/lib/http";
-import { canAssignRole } from "@/lib/rbac";
+import { canAssignRole, getUserScopeIds, mayManageUserRole } from "@/lib/rbac";
 import {
   requireRouteUser,
   requireRouteUserWithRoles,
@@ -98,6 +98,16 @@ export async function lookupUserByEmail(
     return { user: null };
   }
 
+  // FR-042: a scope admin sees a user's assignments only for scopes they hold.
+  // listManagedUserScopes filters the same way; the lookup must not be the leak.
+  const visibleAssignments =
+    auth.user.role === Role.PLATFORM_ADMIN
+      ? user.scopeAssignments
+      : await filterAssignmentsToActorScopes(
+          auth.user.id,
+          user.scopeAssignments,
+        );
+
   return {
     user: {
       id: user.id,
@@ -106,9 +116,21 @@ export async function lookupUserByEmail(
       role: user.role,
       status: user.status,
       authMethod: user.authMethod,
-      scopes: user.scopeAssignments.map((assignment) => assignment.scope),
+      scopes: visibleAssignments.map((assignment) => assignment.scope),
     },
   };
+}
+
+async function filterAssignmentsToActorScopes<
+  T extends { scopeId: string },
+>(actorId: string, assignments: T[]): Promise<T[]> {
+  if (assignments.length === 0) {
+    return assignments;
+  }
+  const actorScopeIds = new Set(await getUserScopeIds(actorId));
+  return assignments.filter((assignment) =>
+    actorScopeIds.has(assignment.scopeId),
+  );
 }
 
 export async function createLocalUser(
@@ -377,7 +399,7 @@ export async function updateManagedUserRole(
     return managed;
   }
 
-  if (!canAssignRole(managed.actor, body.role)) {
+  if (!(await mayManageUserRole(managed.actor, managed.user, body.role))) {
     return { error: jsonError("Not authorized to assign this role", 403) };
   }
 

--- a/webapp/src/services/api/user-admin.ts
+++ b/webapp/src/services/api/user-admin.ts
@@ -6,10 +6,12 @@ import {
 import { safeLogAudit } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { jsonError } from "@/lib/http";
+import { canAssignRole } from "@/lib/rbac";
 import {
   requireRouteUser,
   requireRouteUserWithRoles,
 } from "@/services/api/route-context";
+import { withSerializableRetry } from "@/services/api/serializable-retry";
 import {
   safeQueueRoleChangedNotifications,
   safeQueueUserCreatedNotifications,
@@ -29,8 +31,6 @@ import {
 } from "../../../generated/prisma/enums";
 import type { User } from "../../../generated/prisma/client";
 import { Prisma } from "../../../generated/prisma/client";
-
-const SERIALIZABLE_RETRY_LIMIT = 3;
 
 export function parseUserStatusFilter(value: string | null) {
   if (!value) {
@@ -64,6 +64,51 @@ export async function listUsers(status: UserStatus | null) {
     authMethod: user.authMethod,
     createdAt: user.createdAt,
   }));
+}
+
+export async function lookupUserByEmail(
+  email: string | null,
+  request?: Request,
+) {
+  const auth = await requireRouteUserWithRoles(
+    [Role.PLATFORM_ADMIN, Role.SCOPE_ADMIN],
+    request,
+  );
+  if ("error" in auth) {
+    return auth;
+  }
+
+  const normalizedEmail = email?.trim().toLowerCase();
+  if (!normalizedEmail) {
+    return { user: null };
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: normalizedEmail },
+    include: {
+      scopeAssignments: { include: { scope: { select: scopeSelect } } },
+    },
+  });
+
+  if (
+    !user ||
+    user.id === auth.user.id ||
+    !canAssignRole(auth.user, user.role)
+  ) {
+    return { user: null };
+  }
+
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      status: user.status,
+      authMethod: user.authMethod,
+      scopes: user.scopeAssignments.map((assignment) => assignment.scope),
+    },
+  };
 }
 
 export async function createLocalUser(
@@ -171,8 +216,9 @@ export async function updateOwnThemePreference(
 export async function requireManagedUserContext(
   params: RouteParamsWithId,
   request?: Request,
+  roles: Role[] = [Role.PLATFORM_ADMIN],
 ): Promise<ManagedUserResult> {
-  const auth = await requireRouteUserWithRoles([Role.PLATFORM_ADMIN], request);
+  const auth = await requireRouteUserWithRoles(roles, request);
   if ("error" in auth) {
     return auth;
   }
@@ -323,9 +369,16 @@ export async function updateManagedUserRole(
     return { error: jsonError("Invalid role", 400) };
   }
 
-  const managed = await requireManagedUserContext(params, request);
+  const managed = await requireManagedUserContext(params, request, [
+    Role.PLATFORM_ADMIN,
+    Role.SCOPE_ADMIN,
+  ]);
   if ("error" in managed) {
     return managed;
+  }
+
+  if (!canAssignRole(managed.actor, body.role)) {
+    return { error: jsonError("Not authorized to assign this role", 403) };
   }
 
   let updated: User;
@@ -391,39 +444,15 @@ export async function updateManagedUserRole(
   return { user: { id: updated.id, role: updated.role } };
 }
 
-async function withSerializableRetry<T>(run: () => Promise<T>) {
-  let attempt = 0;
-  while (attempt < SERIALIZABLE_RETRY_LIMIT) {
-    try {
-      return await run();
-    } catch (error) {
-      if (error instanceof Response) {
-        throw error;
-      }
-
-      if (
-        isSerializableConflict(error) &&
-        attempt < SERIALIZABLE_RETRY_LIMIT - 1
-      ) {
-        attempt += 1;
-        continue;
-      }
-
-      throw error;
-    }
-  }
-
-  throw new Error("Unreachable serializable retry state");
-}
-
-function isSerializableConflict(error: unknown) {
-  if (error instanceof Prisma.PrismaClientKnownRequestError) {
-    return error.code === "P2034";
-  }
-
-  if (typeof error === "object" && error !== null && "code" in error) {
-    return (error as { code?: string }).code === "P2034";
-  }
-
-  return false;
-}
+const scopeSelect = {
+  id: true,
+  code: true,
+  name: true,
+  parent: {
+    select: {
+      code: true,
+      name: true,
+      parent: { select: { code: true, name: true } },
+    },
+  },
+} satisfies Prisma.ScopeSelect;

--- a/webapp/src/services/api/user-admin.ts
+++ b/webapp/src/services/api/user-admin.ts
@@ -390,6 +390,7 @@ export async function updateManagedUserRole(
   if (!Object.values(Role).includes(body.role)) {
     return { error: jsonError("Invalid role", 400) };
   }
+  const nextRole = body.role;
 
   const managed = await requireManagedUserContext(params, request, [
     Role.PLATFORM_ADMIN,
@@ -397,10 +398,6 @@ export async function updateManagedUserRole(
   ]);
   if ("error" in managed) {
     return managed;
-  }
-
-  if (!(await mayManageUserRole(managed.actor, managed.user, body.role))) {
-    return { error: jsonError("Not authorized to assign this role", 403) };
   }
 
   let updated: User;
@@ -415,10 +412,38 @@ export async function updateManagedUserRole(
             throw jsonError("User not found", 404);
           }
 
+          const canManageFreshRole = await mayManageUserRole(
+            managed.actor,
+            fresh,
+            nextRole,
+            async (actorId, targetId) => {
+              const actorScopeIds = await tx.userScopeAssignment.findMany({
+                where: { userId: actorId },
+                select: { scopeId: true },
+              });
+              if (actorScopeIds.length === 0) {
+                return false;
+              }
+
+              return !!(await tx.userScopeAssignment.findFirst({
+                where: {
+                  userId: targetId,
+                  scopeId: {
+                    in: actorScopeIds.map((assignment) => assignment.scopeId),
+                  },
+                },
+                select: { scopeId: true },
+              }));
+            },
+          );
+          if (!canManageFreshRole) {
+            throw jsonError("Not authorized to assign this role", 403);
+          }
+
           const denied = await ensureAdminUserCanChange(
             fresh,
             {
-              role: body.role,
+              role: nextRole,
               message: "Cannot change role of the last Admin user",
             },
             tx.user.count,
@@ -429,7 +454,7 @@ export async function updateManagedUserRole(
 
           return tx.user.update({
             where: { id: managed.user.id },
-            data: { role: body.role },
+            data: { role: nextRole },
           });
         },
         { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },

--- a/webapp/tests/e2e/global.setup.ts
+++ b/webapp/tests/e2e/global.setup.ts
@@ -1,14 +1,19 @@
+import "dotenv/config";
 import { spawnSync } from "node:child_process";
 
 const defaultE2eDatabaseUrl =
   "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
 
 export default async function globalSetup() {
+  const databaseUrl =
+    process.env.E2E_DATABASE_URL ??
+    process.env.DATABASE_URL ??
+    defaultE2eDatabaseUrl;
   const env = {
     ...process.env,
-    APP_DATABASE_URL: process.env.DATABASE_URL ?? defaultE2eDatabaseUrl,
-    DATABASE_URL: process.env.DATABASE_URL ?? defaultE2eDatabaseUrl,
-    MIGRATION_DATABASE_URL: process.env.DATABASE_URL ?? defaultE2eDatabaseUrl,
+    APP_DATABASE_URL: databaseUrl,
+    DATABASE_URL: databaseUrl,
+    MIGRATION_DATABASE_URL: databaseUrl,
     INITIAL_ADMIN_EMAIL: process.env.INITIAL_ADMIN_EMAIL ?? "admin@example.com",
     INITIAL_ADMIN_PASSWORD:
       process.env.INITIAL_ADMIN_PASSWORD ?? "ChangeMe123!",

--- a/webapp/tests/e2e/global.setup.ts
+++ b/webapp/tests/e2e/global.setup.ts
@@ -1,14 +1,9 @@
 import "dotenv/config";
 import { spawnSync } from "node:child_process";
-
-const defaultE2eDatabaseUrl =
-  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+import { resolveE2eDatabaseUrl } from "../../scripts/e2e-database-url.mjs";
 
 export default async function globalSetup() {
-  const databaseUrl =
-    process.env.E2E_DATABASE_URL ??
-    process.env.DATABASE_URL ??
-    defaultE2eDatabaseUrl;
+  const databaseUrl = resolveE2eDatabaseUrl();
   const env = {
     ...process.env,
     APP_DATABASE_URL: databaseUrl,

--- a/webapp/tests/e2e/raster-generate.spec.ts
+++ b/webapp/tests/e2e/raster-generate.spec.ts
@@ -130,10 +130,13 @@ test("admin can generate and review a raster snapshot", async ({ page }) => {
     page.getByRole("heading", { name: "Run optimizer" }),
   ).toBeVisible();
   await page
-    .getByRole("button", { name: "Infer missing capacities" })
+    .getByRole("button", { name: "Recheck capacities" })
     .first()
     .click();
-  await expect(page.getByText(/Capacity rows inferred/)).toBeVisible();
+  await expect(page.getByText(/Inferred \d+; \d+ need review/)).toBeVisible();
+  await page.getByRole("button", { name: "Mark all reviewed" }).click();
+  await expect(page.getByText("Source matches (0 outstanding)")).toBeVisible();
+  await page.getByRole("link", { name: /^Run optimizer/ }).click();
   await page.getByRole("button", { name: "Validate" }).click();
   await expect(page.getByText(/Validation passed/)).toBeVisible();
   await page.getByRole("button", { name: "Queue run" }).click();

--- a/webapp/tests/e2e/raster-generate.spec.ts
+++ b/webapp/tests/e2e/raster-generate.spec.ts
@@ -123,11 +123,9 @@ test("admin can generate and review a raster snapshot", async ({ page }) => {
 
   // Address the step directly: /raster redirects to whatever step readiness
   // picks, which depends on state other tests leave behind.
-  await page.goto(`${appBasePath}/raster/run?${rasterQuery}`);
-  // The run step shows the scope's input set without naming it, so assert the
-  // step rather than the name the pre-005 single page used to render.
+  await page.goto(`${appBasePath}/raster/review?${rasterQuery}`);
   await expect(
-    page.getByRole("heading", { name: "Run optimizer" }),
+    page.getByText(`E2E generated ${suffix}`, { exact: true }),
   ).toBeVisible();
   await page
     .getByRole("button", { name: "Recheck capacities" })

--- a/webapp/tests/e2e/raster-roles.spec.ts
+++ b/webapp/tests/e2e/raster-roles.spec.ts
@@ -115,7 +115,7 @@ test("raster role matrix allows admin, scheduler, and viewer actions correctly",
       data: { scope: scopeCode, season, name: "blocked scheduler input set" },
     },
   );
-  expect(schedulerInputCreate.status()).toBe(403);
+  expect(schedulerInputCreate.status()).toBe(201);
 
   const schedulerWishesUpload = await schedulerRequest.post(
     `${appBasePath}/api/raster/input-sets/${inputSetBody.inputSet.id}/wishes/json`,
@@ -123,7 +123,7 @@ test("raster role matrix allows admin, scheduler, and viewer actions correctly",
       data: { wishes: [] },
     },
   );
-  expect(schedulerWishesUpload.status()).toBe(403);
+  expect(schedulerWishesUpload.status()).toBe(200);
 
   const schedulerRunStart = await schedulerRequest.post(
     `${appBasePath}/api/raster/input-sets/${inputSetBody.inputSet.id}/runs`,
@@ -131,7 +131,7 @@ test("raster role matrix allows admin, scheduler, and viewer actions correctly",
       data: {},
     },
   );
-  expect(schedulerRunStart.status()).toBe(403);
+  expect(schedulerRunStart.status()).not.toBe(403);
 
   const schedulerCapacityUpload = await schedulerRequest.post(
     `${appBasePath}/api/raster/capacity/upload`,

--- a/webapp/tests/integration/last-admin-guard.test.ts
+++ b/webapp/tests/integration/last-admin-guard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { ensureAdminUserCanChange } from "@/services/api/user-admin";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+describe("last admin guard", () => {
+  it("refuses demoting the last active platform admin", async () => {
+    const denied = await ensureAdminUserCanChange(
+      { role: Role.PLATFORM_ADMIN, status: UserStatus.ACTIVE },
+      {
+        role: Role.SCOPE_USER,
+        message: "Cannot change role of the last Admin user",
+      },
+      vi.fn().mockResolvedValue(1),
+    );
+
+    expect(denied?.status).toBe(400);
+  });
+
+  it("refuses deactivating the last active platform admin", async () => {
+    const denied = await ensureAdminUserCanChange(
+      { role: Role.PLATFORM_ADMIN, status: UserStatus.ACTIVE },
+      {
+        status: UserStatus.INACTIVE,
+        message: "Cannot deactivate the last Admin user",
+      },
+      vi.fn().mockResolvedValue(1),
+    );
+
+    expect(denied?.status).toBe(400);
+  });
+});

--- a/webapp/tests/integration/scope-access-review.test.tsx
+++ b/webapp/tests/integration/scope-access-review.test.tsx
@@ -1,0 +1,90 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const { requireSession } = vi.hoisted(() => ({ requireSession: vi.fn() }));
+const { prisma } = vi.hoisted(() => ({
+  prisma: {
+    user: { findMany: vi.fn() },
+    scope: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ requireSession }));
+vi.mock("@/lib/db", () => ({ prisma }));
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn(async () => (key: string) => key),
+}));
+vi.mock("@/components/auth/UserLookupPanel", () => ({
+  UserLookupPanel: () => null,
+}));
+
+import UsersPage from "@/app/(dashboard)/users/page";
+
+describe("scope access review", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a scope admin access review only for held scopes", async () => {
+    requireSession.mockResolvedValue({
+      id: "actor",
+      role: Role.SCOPE_ADMIN,
+      status: UserStatus.ACTIVE,
+    });
+    prisma.scope.findMany
+      .mockResolvedValueOnce([scope("OWL")])
+      .mockResolvedValueOnce([
+        {
+          ...scope("OWL"),
+          userAssignments: [
+            {
+              user: {
+                id: "u1",
+                name: "User 1",
+                email: "u1@example.com",
+                role: Role.SCOPE_USER,
+              },
+            },
+          ],
+        },
+      ]);
+
+    const result = await UsersPage();
+    const text = collectText(result).join(" ");
+
+    expect(text).toContain("OWL");
+    expect(text).toContain("User 1");
+    expect(text).not.toContain("KOELN");
+  });
+});
+
+function scope(code: string) {
+  return {
+    id: `scope-${code}`,
+    code,
+    name: code,
+    parent: {
+      code: "WTTV",
+      name: "WTTV",
+      parent: { code: "DE", name: "Germany" },
+    },
+  };
+}
+
+function collectText(node: ReactNode): string[] {
+  if (node === null || node === undefined || typeof node === "boolean")
+    return [];
+  if (typeof node === "string" || typeof node === "number")
+    return [String(node)];
+  if (Array.isArray(node)) return node.flatMap((child) => collectText(child));
+  if (isValidElement(node)) {
+    const element = node as ReactElement<{ children?: ReactNode }>;
+    if (typeof element.type === "function") {
+      const render = element.type as (props: typeof element.props) => ReactNode;
+      return collectText(render(element.props));
+    }
+    return collectText(element.props.children);
+  }
+  return [];
+}

--- a/webapp/tests/integration/scope-admin-escalation.test.ts
+++ b/webapp/tests/integration/scope-admin-escalation.test.ts
@@ -9,6 +9,11 @@ const auth = vi.hoisted(() => ({
 
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/audit", () => ({ safeLogAudit: vi.fn() }));
+vi.mock("@/services/notifications/service", () => ({
+  safeQueueRoleChangedNotifications: vi.fn(),
+  safeQueueUserCreatedNotifications: vi.fn(),
+  safeQueueUserStatusChangedNotifications: vi.fn(),
+}));
 vi.mock("@/services/api/route-context", () => ({
   requireRouteUserWithRoles: auth.requireRouteUserWithRoles,
 }));
@@ -75,6 +80,61 @@ describe("scope admin escalation", () => {
 
     expect(result.status).toBe(403);
     expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses demoting a platform admin", async () => {
+    // canAssignRole guards only the destination role, so a scope admin could
+    // otherwise strip a platform admin by moving them down to SCOPE_USER.
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "target",
+      role: Role.PLATFORM_ADMIN,
+      status: UserStatus.ACTIVE,
+    } as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_USER }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses a role change for a user outside the actor's scopes", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-owl" },
+    ] as never);
+    prismaMock.userScopeAssignment.findFirst.mockResolvedValue(null as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_ADMIN }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a role change for a user within the actor's scopes", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-owl" },
+    ] as never);
+    prismaMock.userScopeAssignment.findFirst.mockResolvedValue({
+      scopeId: "scope-owl",
+    } as never);
+    prismaMock.user.update.mockResolvedValue({
+      id: "target",
+      role: Role.SCOPE_ADMIN,
+    } as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_ADMIN }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { role: Role.SCOPE_ADMIN } }),
+    );
   });
 
   it("refuses listing users for scope admins", async () => {

--- a/webapp/tests/integration/scope-admin-escalation.test.ts
+++ b/webapp/tests/integration/scope-admin-escalation.test.ts
@@ -99,6 +99,23 @@ describe("scope admin escalation", () => {
     expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
+  it("refuses demoting a target promoted after the initial lookup", async () => {
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce(targetUser() as never)
+      .mockResolvedValueOnce({
+        id: "target",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      } as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_USER }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
   it("refuses a role change for a user outside the actor's scopes", async () => {
     prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
     prismaMock.userScopeAssignment.findMany.mockResolvedValue([

--- a/webapp/tests/integration/scope-admin-escalation.test.ts
+++ b/webapp/tests/integration/scope-admin-escalation.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const auth = vi.hoisted(() => ({
+  requireRouteUserWithRoles: vi.fn(),
+  requireApiUserWithRoles: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/audit", () => ({ safeLogAudit: vi.fn() }));
+vi.mock("@/services/api/route-context", () => ({
+  requireRouteUserWithRoles: auth.requireRouteUserWithRoles,
+}));
+vi.mock("@/lib/route-auth", () => ({
+  requireApiUserWithRoles: auth.requireApiUserWithRoles,
+}));
+
+import { POST as grantScope } from "@/app/api/users/[id]/scopes/route";
+import { PATCH as updateRole } from "@/app/api/users/[id]/role/route";
+import { GET as listUsers } from "@/app/api/users/route";
+
+describe("scope admin escalation", () => {
+  beforeEach(() => {
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (tx: typeof prismaMock) => Promise<unknown>) =>
+        callback(prismaMock),
+    );
+    auth.requireRouteUserWithRoles.mockResolvedValue({
+      user: { id: "actor", role: Role.SCOPE_ADMIN, status: UserStatus.ACTIVE },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuses granting a scope the actor does not hold", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
+    prismaMock.scope.findUnique.mockResolvedValue(scope("KOELN") as never);
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-OWL" },
+    ] as never);
+
+    const response = await grantScope(jsonRequest({ scopeId: "scope-KOELN" }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(prismaMock.userScopeAssignment.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses self assignment", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "actor",
+      role: Role.SCOPE_USER,
+    } as never);
+    prismaMock.scope.findUnique.mockResolvedValue(scope("OWL") as never);
+
+    const response = await grantScope(jsonRequest({ scopeId: "scope-OWL" }), {
+      params: Promise.resolve({ id: "actor" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(prismaMock.userScopeAssignment.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses platform admin role escalation", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
+
+    const result = await updateRole(
+      jsonRequest({ role: Role.PLATFORM_ADMIN }),
+      { params: Promise.resolve({ id: "target" }) },
+    );
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses listing users for scope admins", async () => {
+    auth.requireApiUserWithRoles.mockResolvedValue({
+      error: Response.json({ error: "Not authorized" }, { status: 403 }),
+    });
+
+    const response = await listUsers(new Request("http://localhost/api/users"));
+
+    if (!response) {
+      throw new Error("Expected response");
+    }
+    expect(response.status).toBe(403);
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+});
+
+function jsonRequest(body: unknown) {
+  return new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function targetUser() {
+  return { id: "target", role: Role.SCOPE_USER, status: UserStatus.ACTIVE };
+}
+
+function scope(code: string) {
+  return {
+    id: `scope-${code}`,
+    code,
+    name: code,
+    parent: {
+      code: "WTTV",
+      name: "WTTV",
+      parent: { code: "DE", name: "Germany" },
+    },
+  };
+}

--- a/webapp/tests/integration/scope-exact-match.test.ts
+++ b/webapp/tests/integration/scope-exact-match.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import {
+  canAccessRasterScope,
+  listAccessibleRasterScopes,
+} from "@/lib/raster/access";
+import { Role } from "../../generated/prisma/enums";
+
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+describe("scope exact-match access", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses exact scope assignments for scoped users", async () => {
+    prismaMock.scope.findMany.mockResolvedValue([scope("OWL")] as never);
+    prismaMock.scope.findFirst.mockResolvedValue(null);
+
+    await expect(
+      listAccessibleRasterScopes({ id: "user-1", role: Role.SCOPE_USER }),
+    ).resolves.toMatchObject([{ code: "OWL" }]);
+    await expect(
+      canAccessRasterScope({ id: "user-1", role: Role.SCOPE_USER }, "KOELN"),
+    ).resolves.toBe(false);
+
+    expect(prismaMock.scope.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userAssignments: { some: { userId: "user-1" } } },
+      }),
+    );
+    expect(prismaMock.scope.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          code: "KOELN",
+          userAssignments: { some: { userId: "user-1" } },
+        },
+      }),
+    );
+  });
+
+  it("lets platform admins list every selectable scope without assignments", async () => {
+    prismaMock.scope.findMany.mockResolvedValue([scope("OWL")] as never);
+
+    await expect(
+      listAccessibleRasterScopes({ id: "admin-1", role: Role.PLATFORM_ADMIN }),
+    ).resolves.toMatchObject([{ code: "OWL" }]);
+
+    expect(prismaMock.scope.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined }),
+    );
+  });
+});
+
+function scope(code: string) {
+  return {
+    id: `scope-${code}`,
+    code,
+    name: code,
+    parent: {
+      code: "WTTV",
+      name: "WTTV",
+      parent: { code: "DE", name: "Germany" },
+    },
+  };
+}

--- a/webapp/tests/integration/scope-scheduler-access.test.ts
+++ b/webapp/tests/integration/scope-scheduler-access.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { assertRasterAccess } from "@/lib/raster/access";
+import { Role } from "../../generated/prisma/enums";
+
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+describe("scope scheduler access", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows a scope admin to schedule in a held scope", async () => {
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "scope-OWL" } as never);
+
+    await expect(
+      assertRasterAccess(
+        { id: "actor", role: Role.SCOPE_ADMIN },
+        "OWL",
+        "scheduler",
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses a scope admin outside held scopes", async () => {
+    prismaMock.scope.findFirst.mockResolvedValue(null);
+
+    const result = await assertRasterAccess(
+      { id: "actor", role: Role.SCOPE_ADMIN },
+      "KOELN",
+      "scheduler",
+    );
+
+    expect(result).not.toBe(true);
+  });
+
+  it("keeps scope users at viewer", async () => {
+    const result = await assertRasterAccess(
+      { id: "viewer", role: Role.SCOPE_USER },
+      "OWL",
+      "scheduler",
+    );
+
+    expect(result).not.toBe(true);
+    expect(prismaMock.scope.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("leaves platform admins unaffected", async () => {
+    await expect(
+      assertRasterAccess(
+        { id: "admin", role: Role.PLATFORM_ADMIN },
+        "KOELN",
+        "scheduler",
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/webapp/tests/integration/user-lookup.test.ts
+++ b/webapp/tests/integration/user-lookup.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+import { Role, UserStatus } from "../../generated/prisma/enums";
+
+const { requireRouteUserWithRoles } = vi.hoisted(() => ({
+  requireRouteUserWithRoles: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/services/api/route-context", () => ({ requireRouteUserWithRoles }));
+
+import { GET as lookupUser } from "@/app/api/users/lookup/route";
+
+describe("user lookup", () => {
+  beforeEach(() => {
+    requireRouteUserWithRoles.mockResolvedValue({
+      user: { id: "actor", role: Role.SCOPE_ADMIN, status: UserStatus.ACTIVE },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns one exact email match", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(
+      user("target@example.com") as never,
+    );
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=target@example.com"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      user: { email: "target@example.com" },
+    });
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { email: "target@example.com" } }),
+    );
+  });
+
+  it("does not do prefix lookup", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=target"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ user: null });
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { email: "target" } }),
+    );
+  });
+
+  it("returns the same empty result for users the actor may not act on", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(
+      user("admin@example.com", Role.PLATFORM_ADMIN) as never,
+    );
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=admin@example.com"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ user: null });
+  });
+});
+
+function user(email: string, role: Role = Role.SCOPE_USER) {
+  return {
+    id: "target",
+    email,
+    name: "Target",
+    role,
+    status: UserStatus.ACTIVE,
+    authMethod: "LOCAL",
+    scopeAssignments: [],
+  };
+}

--- a/webapp/tests/integration/user-lookup.test.ts
+++ b/webapp/tests/integration/user-lookup.test.ts
@@ -66,9 +66,75 @@ describe("user lookup", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ user: null });
   });
+
+  it("shows a scope admin only the target's scopes they hold (FR-042)", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(
+      user("target@example.com", Role.SCOPE_USER, [
+        assignment("scope-owl", "OWL"),
+        assignment("scope-koeln", "KOELN"),
+      ]) as never,
+    );
+    // The actor holds OWL only.
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-owl" },
+    ] as never);
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=target@example.com"),
+    );
+
+    const body = await response.json();
+    expect(body.user.scopes.map((scope: { code: string }) => scope.code)).toEqual([
+      "OWL",
+    ]);
+  });
+
+  it("shows a platform admin every scope the target holds", async () => {
+    requireRouteUserWithRoles.mockResolvedValue({
+      user: { id: "actor", role: Role.PLATFORM_ADMIN, status: UserStatus.ACTIVE },
+    });
+    prismaMock.user.findUnique.mockResolvedValue(
+      user("target@example.com", Role.SCOPE_USER, [
+        assignment("scope-owl", "OWL"),
+        assignment("scope-koeln", "KOELN"),
+      ]) as never,
+    );
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=target@example.com"),
+    );
+
+    const body = await response.json();
+    expect(body.user.scopes.map((scope: { code: string }) => scope.code)).toEqual([
+      "OWL",
+      "KOELN",
+    ]);
+    // No per-actor scope filtering query for a platform admin.
+    expect(prismaMock.userScopeAssignment.findMany).not.toHaveBeenCalled();
+  });
 });
 
-function user(email: string, role: Role = Role.SCOPE_USER) {
+function assignment(scopeId: string, code: string) {
+  return {
+    scopeId,
+    scope: {
+      id: scopeId,
+      code,
+      name: code,
+      parent: {
+        code: "WTTV",
+        name: "WTTV",
+        parent: { code: "DE", name: "Germany" },
+      },
+    },
+  };
+}
+
+function user(
+  email: string,
+  role: Role = Role.SCOPE_USER,
+  scopeAssignments: ReturnType<typeof assignment>[] = [],
+) {
   return {
     id: "target",
     email,
@@ -76,6 +142,6 @@ function user(email: string, role: Role = Role.SCOPE_USER) {
     role,
     status: UserStatus.ACTIVE,
     authMethod: "LOCAL",
-    scopeAssignments: [],
+    scopeAssignments,
   };
 }

--- a/webapp/tests/unit/auth/last-admin.test.ts
+++ b/webapp/tests/unit/auth/last-admin.test.ts
@@ -177,7 +177,7 @@ describe("last admin protection", () => {
 
     expect(response?.status).toBe(401);
     expect(requireRouteUserWithRoles).toHaveBeenCalledWith(
-      [Role.PLATFORM_ADMIN],
+      [Role.PLATFORM_ADMIN, Role.SCOPE_ADMIN],
       request,
     );
   });

--- a/webapp/tests/unit/auth/scope-grant-authorization.test.ts
+++ b/webapp/tests/unit/auth/scope-grant-authorization.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { canAssignRole, mayManageScopeAssignment } from "@/lib/rbac";
+import { Role } from "../../../generated/prisma/enums";
+
+const owl = "scope-owl";
+const koeln = "scope-koeln";
+const germany = "scope-de";
+
+describe("scope assignment authorization", () => {
+  it("allows a scope admin to grant a held scope", async () => {
+    await expect(
+      mayManageScopeAssignment(
+        { id: "actor", role: Role.SCOPE_ADMIN },
+        { id: "target", role: Role.SCOPE_USER },
+        owl,
+        async () => [owl],
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses scopes the actor does not hold", async () => {
+    await expect(
+      mayManageScopeAssignment(
+        { id: "actor", role: Role.SCOPE_ADMIN },
+        { id: "target", role: Role.SCOPE_USER },
+        koeln,
+        async () => [owl],
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses platform-admin targets for scope admins", () => {
+    expect(canAssignRole({ role: Role.SCOPE_ADMIN }, Role.PLATFORM_ADMIN)).toBe(
+      false,
+    );
+  });
+
+  it("refuses self-assignment", async () => {
+    await expect(
+      mayManageScopeAssignment(
+        { id: "actor", role: Role.SCOPE_ADMIN },
+        { id: "actor", role: Role.SCOPE_USER },
+        owl,
+        async () => [owl],
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("allows platform admins to manage any assignable scope", async () => {
+    await expect(
+      mayManageScopeAssignment(
+        { id: "actor", role: Role.PLATFORM_ADMIN },
+        { id: "target", role: Role.SCOPE_USER },
+        koeln,
+        async () => [],
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses unassignable scopes for everyone", async () => {
+    await expect(
+      mayManageScopeAssignment(
+        { id: "actor", role: Role.PLATFORM_ADMIN },
+        { id: "target", role: Role.SCOPE_USER },
+        germany,
+        async () => [],
+        async () => false,
+      ),
+    ).resolves.toBe(false);
+  });
+});

--- a/webapp/tests/unit/auth/scope-grant-authorization.test.ts
+++ b/webapp/tests/unit/auth/scope-grant-authorization.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { canAssignRole, mayManageScopeAssignment } from "@/lib/rbac";
+import {
+  canAssignRole,
+  mayManageScopeAssignment,
+  mayManageUserRole,
+} from "@/lib/rbac";
 import { Role } from "../../../generated/prisma/enums";
 
 const owl = "scope-owl";
 const koeln = "scope-koeln";
 const germany = "scope-de";
+
+const shareScopes = async () => true;
+const shareNoScopes = async () => false;
 
 describe("scope assignment authorization", () => {
   it("allows a scope admin to grant a held scope", async () => {
@@ -67,5 +74,77 @@ describe("scope assignment authorization", () => {
         async () => false,
       ),
     ).resolves.toBe(false);
+  });
+});
+
+describe("user role management authorization", () => {
+  const scopeAdmin = { id: "actor", role: Role.SCOPE_ADMIN };
+
+  it("lets a scope admin set a shared-scope user's role within their rank", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.SCOPE_USER },
+        Role.SCOPE_ADMIN,
+        shareScopes,
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses raising a role above the actor's own", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.SCOPE_USER },
+        Role.PLATFORM_ADMIN,
+        shareScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses demoting a user ranked above the actor", async () => {
+    // The exploit: canAssignRole guards only the destination role, so without
+    // the target-rank check a scope admin could strip a platform admin.
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.PLATFORM_ADMIN },
+        Role.SCOPE_USER,
+        shareScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses acting on a user outside the actor's scopes", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.SCOPE_USER },
+        Role.SCOPE_USER,
+        shareNoScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses a scope admin rerolling themselves", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "actor", role: Role.SCOPE_ADMIN },
+        Role.SCOPE_USER,
+        shareScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("lets a platform admin set any role", async () => {
+    await expect(
+      mayManageUserRole(
+        { id: "actor", role: Role.PLATFORM_ADMIN },
+        { id: "target", role: Role.SCOPE_ADMIN },
+        Role.PLATFORM_ADMIN,
+        shareNoScopes,
+      ),
+    ).resolves.toBe(true);
   });
 });

--- a/webapp/tests/unit/e2e-database-url.test.ts
+++ b/webapp/tests/unit/e2e-database-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_E2E_DATABASE_URL,
+  resolveE2eDatabaseUrl,
+} from "../../scripts/e2e-database-url.mjs";
+
+describe("resolveE2eDatabaseUrl", () => {
+  // The whole point: E2E resets its database, so it must never inherit
+  // DATABASE_URL, which may be a real or production database.
+  it("ignores DATABASE_URL", () => {
+    expect(
+      resolveE2eDatabaseUrl({
+        DATABASE_URL: "postgresql://prod-host:5432/production",
+      }),
+    ).toBe(DEFAULT_E2E_DATABASE_URL);
+  });
+
+  it("uses E2E_DATABASE_URL when set, even alongside DATABASE_URL", () => {
+    expect(
+      resolveE2eDatabaseUrl({
+        E2E_DATABASE_URL: "postgresql://e2e-host:5432/e2e",
+        DATABASE_URL: "postgresql://prod-host:5432/production",
+      }),
+    ).toBe("postgresql://e2e-host:5432/e2e");
+  });
+
+  it("falls back to the throwaway local default", () => {
+    expect(resolveE2eDatabaseUrl({})).toBe(DEFAULT_E2E_DATABASE_URL);
+  });
+
+  it("treats a blank E2E_DATABASE_URL as unset", () => {
+    expect(
+      resolveE2eDatabaseUrl({
+        E2E_DATABASE_URL: "   ",
+        DATABASE_URL: "postgresql://prod-host:5432/production",
+      }),
+    ).toBe(DEFAULT_E2E_DATABASE_URL);
+  });
+});

--- a/webapp/tests/unit/raster-access.test.ts
+++ b/webapp/tests/unit/raster-access.test.ts
@@ -15,7 +15,7 @@ describe("raster access", () => {
     vi.clearAllMocks();
   });
 
-  it("allows scoped users through assigned parent scopes", async () => {
+  it("checks only the exact assigned scope", async () => {
     prismaMock.scope.findFirst.mockResolvedValue({ id: "owl" } as never);
 
     await expect(
@@ -24,24 +24,8 @@ describe("raster access", () => {
 
     expect(prismaMock.scope.findFirst).toHaveBeenCalledWith({
       where: {
-        AND: [
-          { code: "OWL" },
-          {
-            OR: [
-              { userAssignments: { some: { userId: "user-1" } } },
-              {
-                parent: { userAssignments: { some: { userId: "user-1" } } },
-              },
-              {
-                parent: {
-                  parent: {
-                    userAssignments: { some: { userId: "user-1" } },
-                  },
-                },
-              },
-            ],
-          },
-        ],
+        code: "OWL",
+        userAssignments: { some: { userId: "user-1" } },
       },
       select: { id: true },
     });
@@ -75,17 +59,7 @@ describe("raster access", () => {
     ]);
 
     expect(prismaMock.scope.findMany).toHaveBeenCalledWith({
-      where: {
-        OR: [
-          { userAssignments: { some: { userId: "user-1" } } },
-          { parent: { userAssignments: { some: { userId: "user-1" } } } },
-          {
-            parent: {
-              parent: { userAssignments: { some: { userId: "user-1" } } },
-            },
-          },
-        ],
-      },
+      where: { userAssignments: { some: { userId: "user-1" } } },
       select: {
         code: true,
         id: true,

--- a/webapp/tests/unit/raster-scenarios-route.test.ts
+++ b/webapp/tests/unit/raster-scenarios-route.test.ts
@@ -108,9 +108,8 @@ describe("raster scenarios route", () => {
     // an unconsumed one would leak into the next test.
     prismaMock.scope.findFirst.mockReset();
     prismaMock.scope.findFirst.mockImplementation((async (args: {
-      where: { AND: [{ code: string }, unknown] };
-    }) =>
-      args.where.AND[0].code === "OWL" ? { id: "scope-owl" } : null) as never);
+      where: { code: string };
+    }) => (args.where.code === "OWL" ? { id: "scope-owl" } : null)) as never);
 
     const response = await POST(
       new Request("http://localhost/api/raster/scenarios/compare", {

--- a/webapp/worker/src/starter_worker/db.py
+++ b/webapp/worker/src/starter_worker/db.py
@@ -207,18 +207,24 @@ class JobStore:
             with connection.cursor() as cursor:
                 cursor.execute(
                     """
-                    SELECT run.id, run.status, run.settings, input.id AS "inputSetId",
+                    SELECT run.id, run.status, run.settings,
+                           scope_main.code AS district,
+                           input.id AS "inputSetId",
                            input."scopeId", input.season, input."seasonModelJson",
                            COALESCE(
-                             ARRAY_AGG(scope."scopeId") FILTER (WHERE scope."scopeId" IS NOT NULL),
+                             ARRAY_AGG(input_scope."scopeId") FILTER (
+                               WHERE input_scope."scopeId" IS NOT NULL
+                             ),
                              ARRAY[]::text[]
                            ) AS "scopeIds"
                     FROM "RasterOptimizationRun" run
                     JOIN "RasterInputSet" input ON input.id = run."inputSetId"
-                    LEFT JOIN "RasterInputSetScope" scope ON scope."inputSetId" = input.id
+                    JOIN "Scope" scope_main ON scope_main.id = input."scopeId"
+                    LEFT JOIN "RasterInputSetScope" input_scope
+                      ON input_scope."inputSetId" = input.id
                     WHERE run.id = %s
                     GROUP BY run.id, run.status, run.settings, input.id, input."scopeId",
-                             input.season, input."seasonModelJson"
+                             input.season, input."seasonModelJson", scope_main.code
                     """,
                     (run_id,),
                 )
@@ -370,7 +376,10 @@ class JobStore:
                         run_id,
                     ),
                 )
-                scope_rows = [( _new_id(), snapshot_id, scope_id_value) for scope_id_value in (spanned_scope_ids or [str(scope_id or district)])]
+                scope_rows = [
+                    (_new_id(), snapshot_id, scope_id_value)
+                    for scope_id_value in (spanned_scope_ids or [str(scope_id or district)])
+                ]
                 cursor.executemany(
                     """
                     INSERT INTO "RasterSnapshotScope" (id, "snapshotId", "scopeId")
@@ -680,7 +689,6 @@ class JobStore:
                 "intakeEnabled": bool(row["intakeEnabled"]),
             }
 
-
     def _claim_postgres_job(self) -> BackgroundJob | None:
         with psycopg.connect(self._postgres_database_url, row_factory=dict_row) as connection:
             with connection.cursor() as cursor:
@@ -721,7 +729,6 @@ class JobStore:
             attempt_count=row["attemptCount"],
         )
 
-
     def _requeue_stale_postgres_jobs(self) -> int:
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
@@ -746,7 +753,6 @@ class JobStore:
                 row_count = int(cursor.rowcount or 0)
             connection.commit()
             return row_count
-
 
     def _fail_postgres_job(self, job_id: str, error: str, *, retry: bool) -> None:
         with psycopg.connect(self._postgres_database_url) as connection:
@@ -811,8 +817,6 @@ def _parse_payload(value: str | None) -> dict[str, Any]:
         return {"raw": value}
 
     return parsed if isinstance(parsed, dict) else {"value": parsed}
-
-
 
 
 def _new_id() -> str:
@@ -1139,9 +1143,7 @@ def _home_weeks(group: dict[str, Any], rasterzahl: int, bye: int | None = None) 
     return weeks
 
 
-def _unique_home_weeks(
-    group: dict[str, Any], rasterzahl: int, bye: int | None = None
-) -> list[int]:
+def _unique_home_weeks(group: dict[str, Any], rasterzahl: int, bye: int | None = None) -> list[int]:
     return list(dict.fromkeys(_home_weeks(group, rasterzahl, bye)))
 
 
@@ -1184,8 +1186,27 @@ def _circle_pairs(size: int | str) -> list[list[dict[str, int]]]:
 
 _HOME_ROWS = {
     6: [[1, 2, 3], [6, 5, 1], [2, 3, 4], [6, 1, 2], [3, 4, 5]],
-    "6d": [[1, 2, 3], [6, 5, 1], [2, 3, 4], [6, 1, 2], [3, 4, 5], [6, 5, 4], [4, 3, 2], [6, 1, 5], [5, 4, 3], [6, 2, 1]],
-    8: [[1, 2, 3, 4], [8, 6, 7, 1], [2, 3, 4, 5], [8, 7, 1, 2], [3, 4, 5, 6], [8, 1, 2, 3], [4, 5, 6, 7]],
+    "6d": [
+        [1, 2, 3],
+        [6, 5, 1],
+        [2, 3, 4],
+        [6, 1, 2],
+        [3, 4, 5],
+        [6, 5, 4],
+        [4, 3, 2],
+        [6, 1, 5],
+        [5, 4, 3],
+        [6, 2, 1],
+    ],
+    8: [
+        [1, 2, 3, 4],
+        [8, 6, 7, 1],
+        [2, 3, 4, 5],
+        [8, 7, 1, 2],
+        [3, 4, 5, 6],
+        [8, 1, 2, 3],
+        [4, 5, 6, 7],
+    ],
     10: [
         [1, 2, 3, 4, 5],
         [10, 7, 8, 9, 1],
@@ -1248,8 +1269,35 @@ _SPIELWOCHEN = {
     8: [1, 2, 3, 4, 5, 6, 7, 11, 12, 15, 16, 17, 18, 19],
     10: [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19],
     12: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21],
-    14: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
-    }
+    14: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+    ],
+}
 
 
 def _weekday_to_db(value: str) -> str:

--- a/webapp/worker/src/starter_worker/main.py
+++ b/webapp/worker/src/starter_worker/main.py
@@ -126,7 +126,7 @@ def process_raster_run(store: JobStore, job: BackgroundJob) -> dict[str, object]
     snapshot_id = store.persist_raster_run_result(
         run_id=run_id,
         district=str(context.get("district") or context.get("scopeId") or ""),
-        scope_id=context.get("scopeId"),
+        scope_id=str(context.get("scopeId") or ""),
         spanned_scope_ids=context.get("scopeIds") or [],
         model=model,
         solver_output=solver_output,
@@ -220,9 +220,7 @@ def _raster_run_model(context: dict[str, Any]) -> dict[str, object]:
     return cast(dict[str, object], {"clubs": list(clubs.values()), **merged})
 
 
-def _with_supplied_fixed_numbers(
-    teams: list[object], fixed_rows: object
-) -> list[object]:
+def _with_supplied_fixed_numbers(teams: list[object], fixed_rows: object) -> list[object]:
     """Apply Rasterzahlen supplied for the combined input set itself (FR-014).
 
     _combined_team() unfixes the numbers inherited from each scope, since the
@@ -304,9 +302,7 @@ def _merge_club(clubs: dict[str, dict[str, object]], club: dict[str, object]) ->
         clubs[club_id] = dict(club)
         return
     venues = list(_json_list(existing, "venues"))
-    known = {
-        str(venue.get("hall")) for venue in venues if isinstance(venue, dict)
-    }
+    known = {str(venue.get("hall")) for venue in venues if isinstance(venue, dict)}
     for venue in _json_list(club, "venues"):
         if isinstance(venue, dict) and str(venue.get("hall")) not in known:
             venues.append(venue)
@@ -337,10 +333,7 @@ def _exclude_unplanned_groups(model: dict[str, object]) -> dict[str, object]:
     kept_groups = [
         group
         for group in groups
-        if not (
-            isinstance(group, dict)
-            and str(group.get("planningStatus") or "") == "exclude"
-        )
+        if not (isinstance(group, dict) and str(group.get("planningStatus") or "") == "exclude")
     ]
     kept_team_ids = {
         str(team_id)


### PR DESCRIPTION
## Summary
- Implement scope assignment management for platform admins and scope admins.
- Enforce exact-match raster scope access and allow scope admins to do scheduler work only in assigned scopes.
- Add user lookup, grant/revoke APIs, scope assignment UI, and role/access tests.
- Make E2E setup honor E2E_DATABASE_URL for NAS runs while keeping local/GitHub Docker Postgres fallback.
- Update raster E2E flows and worker SQL for the scope-based schema.

## Validation
- validate.ps1 full against NAS E2E DB (192.168.178.19 / click_tt_automation_e2e): all repo gates passed except Docker-dependent supply-chain audit because local Docker daemon was unavailable.
- Full Playwright E2E against NAS DB: 26 passed, 1 skipped.
- Rebase conflict checks: pnpm run typecheck passed; focused Vitest scope/raster tests passed (13 tests); worker ruff check and py_compile passed.
- Worker DB-backed pytest could not complete from this machine after hibernate because 192.168.178.19:5432 timed out; pure combined worker model subset passed before the DB-backed test attempted connection.
- Supply-chain audit failure is environmental: Trivy/image scans could not connect to Docker at npipe:////./pipe/docker_engine.

## Merge Status
- Rebased onto origin/main and force-pushed; GitHub no longer reports merge conflicts.
- Current GitHub mergeStateStatus: UNSTABLE. PR is still draft, so do not merge until required checks settle and the PR is marked ready.