### PR TITLE
Authorize every scenario's district before comparing

### DIFF
--- a/webapp/src/app/api/raster/scenarios/compare/route.ts
+++ b/webapp/src/app/api/raster/scenarios/compare/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireApiUser } from "@/lib/route-auth";
 import { assertRasterAccess } from "@/lib/raster/access";
-import { compareScenarioIds } from "@/services/raster/scenarioComparison";
+import { compareScenarios } from "@/services/raster/scenarioComparison";
+import { getScenariosByIds } from "@/services/raster/scenarios";
 
 const compareBodySchema = z.object({
   scenarioIds: z.array(z.string().trim().min(1)).min(2),
@@ -23,25 +24,28 @@ export async function POST(request: Request) {
     );
   }
 
+  const scenarios = await getScenariosByIds([...new Set(parsed.data.scenarioIds)]);
+
+  // Authorize every scenario's district before comparing, rather than checking
+  // the first one afterwards. Comparable scenarios do share a district today,
+  // so one check happened to cover them all -- but that is isComparableScenario
+  // enforcing a compatibility rule, not an access rule. Relaxing compatibility
+  // later (say, to compare across seasons) would silently widen access with no
+  // test failing. Checking each district keeps this correct on its own terms.
+  for (const district of new Set(scenarios.map((scenario) => scenario.district))) {
+    const access = await assertRasterAccess(auth.user, district, "viewer");
+    if (access !== true) return access.error;
+  }
+
   let comparison;
   try {
-    comparison = await compareScenarioIds(
-      parsed.data.scenarioIds,
-      parsed.data.baselineScenarioId,
-    );
+    comparison = compareScenarios(scenarios, parsed.data.baselineScenarioId);
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Invalid comparison" },
       { status: 422 },
     );
   }
-
-  const access = await assertRasterAccess(
-    auth.user,
-    comparison.scenarios[0]!.district,
-    "viewer",
-  );
-  if (access !== true) return access.error;
 
   return NextResponse.json(comparison);
 }

--- a/webapp/src/services/raster/scenarioComparison.ts
+++ b/webapp/src/services/raster/scenarioComparison.ts
@@ -2,7 +2,6 @@ import {
   isComparableScenario,
   type RasterScenario,
 } from "@/lib/raster/scenarios";
-import { getScenariosByIds } from "@/services/raster/scenarios";
 
 export type ScenarioComparison = {
   scenarios: RasterScenario[];
@@ -19,14 +18,10 @@ const kpiKeys = [
   "sameClubDerbyIssues",
 ] as const;
 
-export async function compareScenarioIds(
-  scenarioIds: string[],
-  baselineScenarioId?: string | null,
-) {
-  const scenarios = await getScenariosByIds([...new Set(scenarioIds)]);
-  return compareScenarios(scenarios, baselineScenarioId);
-}
-
+// compareScenarioIds used to live here: it fetched scenarios by id and compared
+// them in one call, which left callers no point at which to authorize the
+// districts it had just loaded. Its only caller did the access check afterwards,
+// on the first scenario alone. Fetch and authorize in the route, then call this.
 export function compareScenarios(
   scenarios: RasterScenario[],
   baselineScenarioId?: string | null,

--- a/webapp/tests/unit/raster-scenarios-route.test.ts
+++ b/webapp/tests/unit/raster-scenarios-route.test.ts
@@ -81,7 +81,77 @@ describe("raster scenarios route", () => {
 
     expect(response.status).toBe(422);
   });
+
+  // Every scenario's district is authorized, not just the first one's, and the
+  // check runs before the comparison. Comparable scenarios do share a district,
+  // so checking the first happened to cover them all -- but that relied on
+  // isComparableScenario, a compatibility rule, to enforce an access rule.
+  // Here the districts differ and the user holds only the first: the access
+  // check must reject before the incompatibility is ever evaluated. Checking
+  // scenarios[0] alone, or comparing first, returns 422 instead of 403 and
+  // tells an unauthorized caller that both ids exist.
+  it("refuses a scenario whose district the caller cannot access, before comparing", async () => {
+    mockScopedUser();
+    prismaMock.rasterOptimizationRun.findMany.mockResolvedValue([
+      runFixture({ id: "run-1", inputSet: { district: "OWL", season: "2026/27" } }),
+      runFixture({
+        id: "run-2",
+        inputSet: { district: "WESTFALEN_MITTE", season: "2026/27" },
+      }),
+    ] as never);
+    // Authorized for OWL, not for WESTFALEN_MITTE. mockReset because
+    // vi.clearAllMocks() clears recorded calls but not queued *Once values, so
+    // an unconsumed one would leak into the next test.
+    prismaMock.scope.findFirst.mockReset();
+    prismaMock.scope.findFirst.mockImplementation((async (args: {
+      where: { AND: [{ OR: [{ code: string }] }] };
+    }) =>
+      args.where.AND[0].OR[0].code === "OWL"
+        ? { id: "scope-owl" }
+        : null) as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/scenarios/compare", {
+        method: "POST",
+        body: JSON.stringify({ scenarioIds: ["run-1", "run-2"] }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("compares when the caller can access every scenario's district", async () => {
+    mockScopedUser();
+    prismaMock.rasterOptimizationRun.findMany.mockResolvedValue([
+      runFixture({ id: "run-1", objectiveValue: 10 }),
+      runFixture({ id: "run-2", objectiveValue: 13 }),
+    ] as never);
+    prismaMock.scope.findFirst.mockReset();
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "scope-owl" } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/scenarios/compare", {
+        method: "POST",
+        body: JSON.stringify({
+          scenarioIds: ["run-1", "run-2"],
+          baselineScenarioId: "run-1",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
 });
+
+function mockScopedUser() {
+  requireApiUser.mockResolvedValue({
+    user: {
+      id: "scoped-1",
+      role: Role.SCOPE_USER,
+      status: UserStatus.ACTIVE,
+    },
+  });
+}
 
 function mockUser() {
   requireApiUser.mockResolvedValue({


### PR DESCRIPTION
Follow-up to the review on #9. Fixes finding 2. Independent of #10 — different files, either can merge first.

## The problem

`webapp/src/app/api/raster/scenarios/compare/route.ts` ran `compareScenarioIds` first and checked access **afterwards**, on `scenarios[0]` alone.

That was sound only by accident. Comparable scenarios do share a district, so one check covered them all — but it's `isComparableScenario` that guarantees that, and **that's a compatibility rule doing an access rule's job**. Relax compatibility later (say, to compare across seasons) and access silently widens with no test failing. An authorization check shouldn't depend on an unrelated business rule happening to hold.

Checking afterwards also let the 422s discriminate before authorization — `"At least two scenarios are required"` vs `"Scenarios are not compatible"` told an unauthorized caller whether two ids existed and whether they shared a district. Minor on its own (cuids aren't guessable), but it costs nothing to remove once the order is right.

## The fix

Fetch → authorize each distinct district → compare.

Also **removes `compareScenarioIds`**. It fetched and compared in one call, leaving callers no point at which to authorize what it had just loaded — which is precisely how its only caller ended up checking afterwards. The next route to call it would have repeated the bug. Fetch and authorize in the route, then call `compareScenarios`.

## The test

Every existing test used `PLATFORM_ADMIN`, which is authorized for every district — so **none of them exercised this path at all**. That's why the coupling was invisible.

Two new ones:

- **scenarios in different districts, caller holds only the first** → must be refused *before* the incompatibility is evaluated. Old code: `422`. Fixed: `403`.
- **caller holds both districts** → gets the comparison.

Verified by narrowing the check back to `scenarios[0]`: exactly one test fails, with `expected 422 to be 403`. That 422 *is* the leak.

One thing worth flagging in the test file itself: `vi.clearAllMocks()` clears recorded calls but **not** queued `mockResolvedValueOnce` values. My first draft passed only because the fixed code happened to consume both queued values — under the mutation an unconsumed `null` leaked into the next test and failed it spuriously. The tests now `mockReset()` and use an explicit `mockImplementation`, so they're order-independent. Worth knowing for any future test that queues `*Once` against this mock.

## Validation

- `pnpm exec vitest run tests/unit/` → **226 passed**
- `pnpm run lint`, `pnpm run typecheck` → clean
- 8 suites fail to *collect* in a bare worktree for want of `APP_DATABASE_URL`. Pre-existing and unrelated — identical without this change.

## Not addressed

Findings 3–6 from the review stand. 3 and 4 (capacity no longer hard-constrained anywhere; `spielwocheMisses` changed meaning) are description fixes for #9 rather than code changes — but #9 is the base of a five-PR stack, so what it says it does matters.
