### PR TITLE
Fix E2E Postgres port Windows can reserve out from under the harness

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,9 +44,9 @@ jobs:
       E2E_BASE_PATH: /app-starter
       AUTH_BASE_URL: http://localhost:3290/app-starter
       BETTERAUTH_SECRET: ci-betterauth-secret-for-playwright-tests-only
-      DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test
-      MIGRATION_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test
-      WORKER_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test
+      DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
+      MIGRATION_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
+      WORKER_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       E2E_POSTGRES_CONTAINER: click-tt-e2e-postgres
 
     steps:

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -106,7 +106,7 @@ Guidelines:
 ```
 
 Playwright E2E defaults to a local PostgreSQL container named
-`click-tt-e2e-postgres` on host port `55432`. The E2E setup script
+`click-tt-e2e-postgres` on host port `45432`. The E2E setup script
 creates or starts that container, ensures the `business_app_starter_e2e_test`
 database exists, resets that database, seeds the initial admin, and runs the app
 with the Postgres Prisma schema. Use a separate database such as

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -5,7 +5,7 @@ const normalizedBasePath = process.env.E2E_BASE_PATH ?? "/app-starter";
 const authBaseUrl = `http://localhost:${port}${normalizedBasePath}`;
 const databaseUrl =
   process.env.DATABASE_URL ??
-  "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test";
+  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
 const reuseExistingServer = process.env.E2E_REUSE_SERVER === "1";
 
 process.env.E2E_PORT = String(port);

--- a/webapp/scripts/ensure-e2e-db.mjs
+++ b/webapp/scripts/ensure-e2e-db.mjs
@@ -1,7 +1,11 @@
 import { spawnSync } from "node:child_process";
+import net from "node:net";
 
+// Port 45432 sits below the Windows dynamic port range (49152+), where Hyper-V
+// reserves blocks at boot. A published port inside that range can become
+// unbindable after a reboot: see waitForPublishedPort.
 const DEFAULT_E2E_DATABASE_URL =
-  "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test";
+  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
 
 const databaseUrl =
   process.env.DATABASE_URL?.trim() || DEFAULT_E2E_DATABASE_URL;
@@ -22,9 +26,9 @@ const postgresPassword = decodeURIComponent(
 );
 const postgresDb =
   parsed.pathname.replace(/^\//, "") || "business_app_starter_e2e_test";
-const hostPort = parsed.port || "55432";
+const hostPort = parsed.port || "45432";
 
-ensureDockerPostgres();
+await ensureDockerPostgres();
 ensureTargetDatabase();
 
 const env = {
@@ -42,7 +46,7 @@ runStep(
 );
 runStep("Seed PostgreSQL E2E data", "pnpm exec tsx prisma/seed.ts", env);
 
-function ensureDockerPostgres() {
+async function ensureDockerPostgres() {
   const existing = runDockerCaptured([
     "ps",
     "-a",
@@ -75,6 +79,55 @@ function ensureDockerPostgres() {
   }
 
   waitForPostgres();
+  await waitForPublishedPort();
+}
+
+// pg_isready only proves PostgreSQL is up *inside* the container. The published
+// port can still be unreachable from the host, which surfaces later as an
+// unexplained Prisma P1001. Fail here instead, where the cause is knowable.
+async function waitForPublishedPort() {
+  const deadline = Date.now() + 30_000;
+  let lastError = "";
+
+  while (Date.now() < deadline) {
+    lastError = await probeHostPort();
+    if (!lastError) return;
+    await delay(500);
+  }
+
+  throw new Error(
+    [
+      `PostgreSQL is running inside ${containerName}, but ${parsed.hostname}:${hostPort} is not reachable from this host (${lastError}).`,
+      process.platform === "win32"
+        ? [
+            "On Windows this usually means the port falls inside a reserved range. Check:",
+            "  netsh interface ipv4 show excludedportrange protocol=tcp",
+            `If ${hostPort} falls inside a listed range, set DATABASE_URL to a free port below 49152.`,
+          ].join("\n")
+        : "Check that the container's published port is not blocked by the host.",
+    ].join("\n"),
+  );
+}
+
+function probeHostPort() {
+  return new Promise((resolve) => {
+    const socket = net.connect({
+      host: parsed.hostname,
+      port: Number(hostPort),
+    });
+    const finish = (result) => {
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(2000);
+    socket.on("connect", () => finish(""));
+    socket.on("timeout", () => finish("timed out"));
+    socket.on("error", (error) => finish(error.code ?? String(error)));
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function waitForPostgres() {

--- a/webapp/tests/e2e/global.setup.ts
+++ b/webapp/tests/e2e/global.setup.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 
 const defaultE2eDatabaseUrl =
-  "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test";
+  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
 
 export default async function globalSetup() {
   const env = {

--- a/webapp/tests/e2e/global.teardown.ts
+++ b/webapp/tests/e2e/global.teardown.ts
@@ -1,7 +1,7 @@
 export default async function globalTeardown() {
   const databaseUrl =
     process.env.DATABASE_URL ??
-    "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test";
+    "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
   if (!databaseUrl.startsWith("file:")) {
     return;
   }

--- a/webapp/tests/e2e/helpers/db.ts
+++ b/webapp/tests/e2e/helpers/db.ts
@@ -25,7 +25,7 @@ function runDbWorker<TInput, TResult>(
 ): TResult {
   const databaseUrl =
     process.env.DATABASE_URL ??
-    "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test";
+    "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
   const output = runDbWorkerWithRetry(operation, payload, databaseUrl).trim();
 
   return output ? (JSON.parse(output) as TResult) : (null as TResult);

--- a/webapp/tests/e2e/raster-generate.spec.ts
+++ b/webapp/tests/e2e/raster-generate.spec.ts
@@ -389,7 +389,7 @@ function processRasterWorkerJob(runId: string) {
   const databaseUrl =
     process.env.WORKER_DATABASE_URL ??
     process.env.DATABASE_URL ??
-    "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test";
+    "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
   execFileSync(
     "uv",
     [

--- a/webapp/validate.ps1
+++ b/webapp/validate.ps1
@@ -1244,7 +1244,7 @@ if ($Phase -in "all", "full", "test", "commit") {
     try {
         $previousDatabaseUrl = $env:DATABASE_URL
         if ([string]::IsNullOrWhiteSpace($env:APP_DATABASE_URL) -and [string]::IsNullOrWhiteSpace($env:DATABASE_URL)) {
-            $env:DATABASE_URL = "postgresql://starter:starter_e2e_password@localhost:55432/business_app_starter_e2e_test"
+            $env:DATABASE_URL = "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test"
         }
 
         $generateResult = Invoke-NativeCommandCaptured "pnpm run prisma:generate"


### PR DESCRIPTION
The E2E harness publishes Postgres on **55432**, which sits inside the Windows **dynamic port range** (49152+). Hyper-V reserves blocks in that range **at boot**, so the port can become unbindable from one reboot to the next:

```
netsh interface ipv4 show excludedportrange protocol=tcp

Start Port    End Port
----------    --------
     55352       55451     <-- 55432 lives here
```

When that happens, Rancher Desktop's forwarder fails to bind the host side with `WSAEACCES`:

```
[ERROR] exposing {HostIP:0.0.0.0 HostPort:55432} failed: error from API:
        listen tcp 0.0.0.0:55432: bind: An attempt was made to access a socket
        in a way forbidden by its access permissions.
```

The result is genuinely misleading. The container is healthy, `docker ps` reports `0.0.0.0:55432->5432/tcp`, and `pg_isready` inside the container says `accepting connections` — but the port only exists in the VM's network namespace, and the harness dies with a bare `P1001: Can't reach database server` that points at nothing. Because the reservation is assigned dynamically at boot, it also **works until it suddenly doesn't**, which makes it look like flakiness rather than a fixed cause.

## Changes

**Move the default to 45432** — below the dynamic range, where Windows never reserves. This is structural rather than a luckier guess: any port ≥49152 can be reserved on the next boot.

The port default was copy-pasted across **eight** files (`playwright.config.ts`, `global.setup.ts`, `global.teardown.ts`, `helpers/db.ts`, `raster-generate.spec.ts`, `ensure-e2e-db.mjs`, `validate.ps1`, and the CI workflow). All now agree. `DATABASE_URL` still overrides, as before.

**Check the port that actually matters.** `waitForPostgres()` only ran `docker exec … pg_isready`, which proves Postgres is up *inside* the container — true throughout the failure above, since inside was never the problem. `waitForPublishedPort()` probes from the host and, on failure, explains itself:

```
Error: PostgreSQL is running inside click-tt-e2e-postgres, but localhost:55432
is not reachable from this host (ECONNREFUSED).
On Windows this usually means the port falls inside a reserved range. Check:
  netsh interface ipv4 show excludedportrange protocol=tcp
If 55432 falls inside a listed range, set DATABASE_URL to a free port below 49152.
```

## Verification

- `pnpm exec playwright test` on the new default: **24 passed, 3 failed, 1 skipped** — identical to before this change, so the port move regresses nothing.
- The 3 failures (`raster-generate` ×2, `raster-roles`) are **pre-existing on `main`** and unrelated: `POST /api/raster/roster/input-sets` returns 400 instead of 201. Confirmed by running them on `main` untouched. Being investigated separately.
- Forced the failure path by pointing `DATABASE_URL` at 55432 on purpose: the new diagnostic fires instead of `P1001`.
- `pnpm run typecheck` and `pnpm run lint` clean.

## Notes

CI runs on Linux, where excluded ranges don't apply — 55432 was never broken there. This is a local-developer fix on Windows; the CI workflow is updated only to keep the port consistent everywhere.

`webapp/specs/017-deepsec-remediation/remediation-evidence.md` still mentions 55432 and is deliberately left alone: it records what was done at the time.

Found while reviewing #13.
