### PR TITLE
Slim the worker runtime image

### DIFF
--- a/webapp/Dockerfile.worker
+++ b/webapp/Dockerfile.worker
@@ -13,6 +13,24 @@ COPY webapp/worker/uv.lock ./uv.lock
 
 CMD ["uv", "audit", "--frozen", "--no-dev"]
 
+FROM python:3.12-slim AS builder
+
+WORKDIR /worker
+
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+COPY webapp/worker/pyproject.toml ./pyproject.toml
+COPY webapp/worker/uv.lock ./uv.lock
+COPY webapp/worker/README.md ./README.md
+COPY webapp/worker/src ./src
+
+RUN uv sync --frozen --no-dev \
+    && rm -rf /root/.cache/uv
+
 FROM python:3.12-slim
 
 WORKDIR /worker
@@ -33,16 +51,10 @@ RUN apt-get update -y \
     && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir uv
-
-COPY webapp/worker/pyproject.toml ./pyproject.toml
-COPY webapp/worker/uv.lock ./uv.lock
-COPY webapp/worker/README.md ./README.md
+COPY --from=builder /worker/.venv ./.venv
 COPY webapp/worker/src ./src
 COPY scripts /app/scripts
 COPY src/raster /app/src/raster
-
-RUN uv sync --frozen --no-dev
 
 RUN groupadd --system --gid 1001 worker \
     && useradd --system --uid 1001 --gid worker starter-worker \

--- a/webapp/worker/pyproject.toml
+++ b/webapp/worker/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 ]
 
 [project.scripts]
+starter-worker = "starter_worker.main:main"
 raster-review-worker = "starter_worker.main:main"
 
 [build-system]


### PR DESCRIPTION
## Summary
- build the Python worker virtualenv in a builder stage
- copy only the runtime venv and worker/source files into the final image
- keep uv out of the runtime layer

## Verification
- `docker build -f webapp/Dockerfile.worker -t business-app-starter-worker:slim-test .`
- `docker run --rm --entrypoint .venv/bin/python business-app-starter-worker:slim-test -c "import starter_worker.main; print('ok')"`

## Size
- before: `business-app-starter-worker:latest` 837MB
- after: `business-app-starter-worker:slim-test` 724MB
