### PR TITLE
Worker: run on PostgreSQL only, drop SQLite

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,6 +50,9 @@ jobs:
       DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       MIGRATION_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       WORKER_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
+      # The worker suite gets its own database on the same container so a pytest
+      # run and a Playwright run cannot truncate each other's rows.
+      WORKER_TEST_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_worker_test
       E2E_POSTGRES_CONTAINER: click-tt-e2e-postgres
 
     steps:
@@ -120,6 +123,14 @@ jobs:
       - name: Test
         working-directory: webapp
         run: pnpm test
+
+      - name: Provision PostgreSQL
+        working-directory: webapp
+        run: node scripts/ensure-e2e-db.mjs
+
+      - name: Worker tests
+        working-directory: webapp/worker
+        run: uv run pytest -q
 
       - name: Install Playwright browsers
         working-directory: webapp

--- a/webapp/.specify/memory/constitution.md
+++ b/webapp/.specify/memory/constitution.md
@@ -1,7 +1,7 @@
 # Business App Starter Constitution
 
 > Project constitution for the Business App Starter web application.
-> Version: 1.1.0
+> Version: 2.0.0
 > Last updated: 2026-07-17
 
 ## Core Principles
@@ -194,11 +194,16 @@ approved before merge.
 
 ## Amendment History
 
-### 1.1.0 -- 2026-07-17
+### 2.0.0 -- 2026-07-17
 
 **Changed**: Technology Constraints / Database. SQLite is no longer
 an accepted local-development database; PostgreSQL is required in
 every environment.
+
+**Why MAJOR**: This is an incompatible redefinition, not a
+clarification. The previous constraint permitted SQLite locally; this
+one forbids it, and any environment or contributor depending on the
+old rule must change. Per the Amendments rule above, that is MAJOR.
 
 **Rationale**: The webapp became PostgreSQL-only on 2026-07-10, but
 the worker kept a parallel SQLite implementation that survived only
@@ -208,6 +213,6 @@ branch production never ran, and missed at least one defect in the
 PostgreSQL path as a result. The constraint is amended to match both
 the deployed reality and the reason it went wrong.
 
-> Versions before 1.1.0 were unnumbered. The text as it stood on
+> Versions before 2.0.0 were unnumbered. The text as it stood on
 > 2026-03-19 is treated as 1.0.0 so this amendment has a baseline to
 > bump from.

--- a/webapp/.specify/memory/constitution.md
+++ b/webapp/.specify/memory/constitution.md
@@ -1,7 +1,8 @@
 # Business App Starter Constitution
 
 > Project constitution for the Business App Starter web application.
-> Last updated: 2026-03-19
+> Version: 1.1.0
+> Last updated: 2026-07-17
 
 ## Core Principles
 
@@ -123,8 +124,10 @@ visually before merge.
   (user-selectable, persisted per user). Dark mode via
   `[data-theme="dark"]` selector and Tailwind `dark:` variants.
 - **ORM**: Prisma 7 for database access and schema management.
-- **Database**: SQLite for local development. Docker and shared
-  deployments use PostgreSQL.
+- **Database**: PostgreSQL everywhere -- local development, Docker,
+  and shared deployments. Local development runs it in a container.
+  SQLite is not supported: a database that only runs locally means
+  local tests exercise a code path production never takes.
 - **Authentication**: Dual auth support -- Azure SSO and local
   username/password. Email is the unique user identifier across
   both methods. Azure SSO via BetterAuth (with Admin + SSO plugins).
@@ -188,3 +191,23 @@ semantic versioning:
 **Compliance**: All PRs and code reviews MUST verify adherence to
 these principles. Deviations MUST be justified in writing and
 approved before merge.
+
+## Amendment History
+
+### 1.1.0 -- 2026-07-17
+
+**Changed**: Technology Constraints / Database. SQLite is no longer
+an accepted local-development database; PostgreSQL is required in
+every environment.
+
+**Rationale**: The webapp became PostgreSQL-only on 2026-07-10, but
+the worker kept a parallel SQLite implementation that survived only
+as its test fixture, with a hand-maintained schema of 13 tables
+against the real migrations' 37. Its tests passed while exercising a
+branch production never ran, and missed at least one defect in the
+PostgreSQL path as a result. The constraint is amended to match both
+the deployed reality and the reason it went wrong.
+
+> Versions before 1.1.0 were unnumbered. The text as it stood on
+> 2026-03-19 is treated as 1.0.0 so this amendment has a baseline to
+> bump from.

--- a/webapp/AUTH_FLOWS.md
+++ b/webapp/AUTH_FLOWS.md
@@ -26,8 +26,7 @@ Self-service signup is disabled. Users are either created by admins or provision
 | `src/app/api/auth/sso/azure/route.ts`          | Azure SSO initiation and test-only mock path               |
 | `src/app/api/auth/sso/azure/callback/route.ts` | Azure SSO callback handler                                 |
 | `src/app/(dashboard)/layout.tsx`               | Dashboard layout with auth enforcement                     |
-| `prisma/schema.prisma`                         | SQLite schema for local development                        |
-| `prisma/schema.postgres.prisma`                | PostgreSQL schema for Docker / production-style deployment |
+| `prisma/schema.postgres.prisma`                | PostgreSQL schema (local development, Docker, production)  |
 
 ## 1. Email/Password Login
 

--- a/webapp/CLAUDE.md
+++ b/webapp/CLAUDE.md
@@ -10,7 +10,7 @@
 
 - TypeScript with Next.js 16 (App Router)
 - BetterAuth for authentication (email/password + Azure AD SSO)
-- Prisma 7 ORM with SQLite locally and PostgreSQL in Docker
+- Prisma 7 ORM on PostgreSQL (local, Docker, and production)
 - Tailwind CSS 4
 - next-intl for internationalization (en, de, es, fr, pt)
 - bcryptjs for password hashing

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -51,7 +51,7 @@ These files are intentionally committed into the template so copied repos still 
 ## Includes
 
 - Next.js 16 app router
-- Prisma starter data model with SQLite for local development
+- Prisma starter data model on PostgreSQL
 - PostgreSQL-backed Docker deployment
 - Go-based `starterctl` CLI with PAT-backed API access and GoReleaser packaging
 - uv-managed Python worker skeleton for background jobs
@@ -111,9 +111,8 @@ creates or starts that container, ensures the `business_app_starter_e2e_test`
 database exists, resets that database, seeds the initial admin, and runs the app
 with the Postgres Prisma schema. Use a separate database such as
 `business_app_starter_manual` in the same container for manual exploratory
-testing. Set an explicit `DATABASE_URL=file:./e2e.db` only when you intentionally
-need the legacy SQLite E2E path. Set `E2E_REUSE_SERVER=1` only when you are not
-resetting the database between runs.
+testing. Set `E2E_REUSE_SERVER=1` only when you are not resetting the database
+between runs.
 
 `precommit` is the fast local hook phase: TypeScript typecheck,
 dependency-cruiser architecture, and jscpd duplication.
@@ -188,7 +187,7 @@ pnpm run cli:install-releases
 
 ## Docker Deployment
 
-- Local `pnpm run dev` uses SQLite via `DATABASE_URL=file:./dev.db`.
+- Local `pnpm run dev` uses PostgreSQL via `DATABASE_URL`; there is no SQLite fallback.
 - Put Docker-only PostgreSQL and initial admin values in `.env.docker` using `.env.docker.example` as the template, then start Docker with `pnpm docker up`.
 - Production-style Docker uses separate database URL names by runtime: `APP_DATABASE_URL`, `WORKER_DATABASE_URL`, and `MIGRATION_DATABASE_URL`.
 - Docker services receive explicit allowlisted environment variables; the Postgres container only receives `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.

--- a/webapp/cli/README.md
+++ b/webapp/cli/README.md
@@ -95,7 +95,7 @@ This is the fastest local verification path on Windows PowerShell.
 1. Create a local `.env` if you do not already have one.
 
 ```dotenv
-DATABASE_URL="file:./dev.db"
+DATABASE_URL="postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test"
 PORT=3270
 AUTH_BASE_URL=http://localhost:3270
 BETTER_AUTH_SECRET=dev-secret-change-me-in-production
@@ -104,10 +104,10 @@ INITIAL_ADMIN_PASSWORD=ChangeMe123!
 PAT_TOKEN_PREFIX=starter_pat
 ```
 
-2. Bootstrap the local SQLite database and seed the admin user.
+2. Start the PostgreSQL container, apply migrations, and seed the admin user.
 
 ```powershell
-node scripts/ensure-local-db.mjs
+node scripts/ensure-e2e-db.mjs
 ```
 
 3. Start the app.

--- a/webapp/docs/best-practices-review.md
+++ b/webapp/docs/best-practices-review.md
@@ -744,6 +744,7 @@ Double cast (`as unknown as`) bypasses all type safety. If the model is renamed,
 ### PR6: Dual schema files must be kept in sync manually
 
 **Severity:** Medium
+**Status:** Resolved 2026-07-17
 **Files:** `prisma/schema.prisma`, `prisma/schema.postgres.prisma`
 
 Two schema files are identical except for `datasource.provider` (`sqlite` vs `postgresql`). Any model, enum, or index change must be applied to both files manually. No CI check or script validates they stay in sync.
@@ -753,6 +754,8 @@ Options:
 1. Script that generates one from the other (swap the datasource line)
 2. CI step that diffs the two files (ignoring the datasource block)
 3. Single schema with environment-driven provider selection (Prisma 7 may support this via config)
+
+**Resolution:** Taken further than any of the three options — the second schema is gone. `schema.prisma` was deleted when the webapp became PostgreSQL-only (2026-07-10), leaving `schema.postgres.prisma` as the single source. The drift this finding predicted did happen before then, in the worker's hand-written SQLite test schema, which fell to 13 tables against the real migrations' 37; the worker was moved onto PostgreSQL and that fixture deleted (2026-07-17).
 
 ### PR7: AuditEntry `details` stored as String instead of Json
 
@@ -765,7 +768,9 @@ Options:
 - Cannot use Prisma's JSON filtering (`path`, `array_contains`, etc.) on PostgreSQL
 - Query code must parse manually
 
-SQLite doesn't support `Json` type, which explains the choice. But `schema.postgres.prisma` could use `Json` for the PostgreSQL deployment while keeping `String` in the SQLite schema.
+SQLite doesn't support `Json` type, which explained the choice at the time.
+
+**Update 2026-07-17:** SQLite is gone, so nothing forces `String` any more. `Json` is now available for the audit `details` column without a second schema to keep in step. Still open — the change needs a migration and a pass over the query code that parses `details` by hand.
 
 ### PR8: Hard deletes cascade — no soft delete pattern
 
@@ -1125,7 +1130,7 @@ Works functionally, but `opacity-35` on the entire container dims the text and l
 - **Cascade design**: Thoughtful `onDelete` choices — Cascade for owned data, Restrict for audit integrity, SetNull for optional references
 - **Enum usage**: All status/type fields use Prisma enums, no magic strings
 - **cuid() IDs**: URL-safe, sortable, no sequential enumeration risk
-- **Dual-database support**: Clean separation of SQLite (local dev) and PostgreSQL (production)
+- **Single database everywhere**: One PostgreSQL schema for local, Docker, and production, so tests exercise the engine production runs. (This bullet previously praised the SQLite/PostgreSQL split as clean separation; see PR6 — the split was the drift risk, not a strength, and was removed on 2026-07-10 and 2026-07-17.)
 - **Transaction usage**: Notification creation and password changes correctly use `$transaction`
 - **No raw SQL in app code**: Single `$queryRaw` for health check only; all queries use typed client
 - **Select scoping in services**: Service layer (`user-admin.ts`, `admin.ts`) maps query results to safe subsets before returning

--- a/webapp/docs/runtime-credentials.md
+++ b/webapp/docs/runtime-credentials.md
@@ -19,7 +19,7 @@ This document maps sensitive runtime settings to the process that should receive
 | `APP_DATABASE_URL`              | app               | Runtime app database access                                 | Docker/prod app runtime                           |           |
 | `WORKER_DATABASE_URL`           | worker            | Worker job queue and background integration database access | Docker/prod worker runtime                        |           |
 | `MIGRATION_DATABASE_URL`        | migration         | Prisma migration and initial-admin seed database access     | Docker/prod migration runtime                     |           |
-| `DATABASE_URL`                  | local-development | SQLite local fallback and legacy Prisma compatibility       | Local development, internal service compatibility |           |
+| `DATABASE_URL`                  | local-development | PostgreSQL access for local development and Prisma tooling   | Local development, internal service compatibility |           |
 | `BETTER_AUTH_SECRET`            | app               | Session signing and Better Auth runtime secret              | App runtime                                       |           |
 | `AUTH_BASE_URL`                 | app               | Public origin for auth callbacks and cookie behavior        | App runtime                                       |           |
 | `AZURE_AD_CLIENT_ID`            | shared-exception  | Microsoft Entra SSO and current Teams Graph flows           | App and worker runtimes                           | EX-001    |

--- a/webapp/specs/base/README.md
+++ b/webapp/specs/base/README.md
@@ -18,8 +18,7 @@ that new feature specs should build on.
 
 - Next.js 16 App Router frontend and API routes
 - Prisma data layer
-- SQLite for local development
-- PostgreSQL for Docker and production-style deployment
+- PostgreSQL for local development, Docker, and production-style deployment
 - Python worker skeleton managed with `uv`
 - Better Auth with local login plus Azure SSO
 - RBAC, user management, audit trail, and background jobs

--- a/webapp/specs/base/architecture.md
+++ b/webapp/specs/base/architecture.md
@@ -8,7 +8,7 @@ This starter provides a reusable internal business app foundation with:
 - role-based access control
 - operational auditability
 - background job processing
-- local SQLite development and Docker/PostgreSQL deployment
+- PostgreSQL in every environment, local through deployment
 
 ## System Overview
 
@@ -59,13 +59,9 @@ flowchart LR
 ### Data Layer
 
 - ORM/client: Prisma
-- Local mode:
-  - SQLite
-  - `prisma/schema.prisma`
-- Docker / production-style mode:
-  - PostgreSQL
-  - `prisma/schema.postgres.prisma`
-- Runtime DB adapter selection happens from `DATABASE_URL`
+- PostgreSQL in every mode -- local, Docker, and production-style
+- Single schema: `prisma/schema.postgres.prisma`
+- `DATABASE_URL` selects the instance, not the engine
 
 ### Background Jobs
 

--- a/webapp/specs/base/auth-and-rbac.md
+++ b/webapp/specs/base/auth-and-rbac.md
@@ -116,6 +116,6 @@ flowchart TD
 
 ## Important Constraints
 
-- auth must work in both SQLite local mode and PostgreSQL deployment mode
+- auth runs on PostgreSQL in every environment; there is no second database mode to support
 - login pages should remain resilient to browser autofill and extension interference
 - account status and role checks must be enforced server-side

--- a/webapp/specs/base/data-model.md
+++ b/webapp/specs/base/data-model.md
@@ -157,14 +157,13 @@ Includes key user-admin and auth events, such as:
 - `COMPLETED`
 - `FAILED`
 
-## Dual Database Model
+## Database Model
 
-- SQLite schema:
-  - `prisma/schema.prisma`
-- PostgreSQL schema:
-  - `prisma/schema.postgres.prisma`
+- Single PostgreSQL schema: `prisma/schema.postgres.prisma`
+- Migrations: `prisma/migrations-postgres/`
 
-The structural intent should remain aligned across both.
+There is one schema, so there is no cross-schema alignment to maintain. The
+earlier SQLite/PostgreSQL pair had to be kept in step by hand and drifted.
 
 ## Design Expectations
 

--- a/webapp/specs/base/runtime-and-ops.md
+++ b/webapp/specs/base/runtime-and-ops.md
@@ -4,10 +4,10 @@
 
 ### Local Development
 
-- `DATABASE_URL="file:./dev.db"`
-- app runs with SQLite
-- `pnpm run dev` prepares the local database before startup
-- Prisma uses the SQLite schema by default
+- `DATABASE_URL="postgresql://..."` pointing at the local PostgreSQL container
+- app runs with PostgreSQL, the same engine as every other environment
+- `node scripts/ensure-e2e-db.mjs` starts the container, applies migrations, and seeds
+- Prisma uses `prisma/schema.postgres.prisma`, the only schema
 
 ### Docker / Production-Style Deployment
 
@@ -17,8 +17,8 @@
   - `WORKER_DATABASE_URL`
   - `MIGRATION_DATABASE_URL`
 - each service maps its runtime-specific URL into `DATABASE_URL` for Prisma or compatibility paths
-- Prisma migrations run through `prisma.config.postgres.ts`
-- local development can continue using `DATABASE_URL="file:./dev.db"` without defining every runtime-specific URL
+- Prisma migrations run through `prisma.config.ts`
+- local development can point `DATABASE_URL` at the local PostgreSQL container without defining every runtime-specific URL
 
 ## Database Behavior
 
@@ -26,13 +26,13 @@
 sequenceDiagram
     participant Dev as Developer
     participant App as Next.js
-    participant DB as SQLite dev.db
+    participant DB as Local PostgreSQL
 
-    Dev->>App: pnpm run dev
-    App->>DB: ensure local DB exists
-    App->>DB: db push if empty
-    App->>DB: migrate dev if non-empty
+    Dev->>App: node scripts/ensure-e2e-db.mjs
+    App->>DB: ensure container and database exist
+    App->>DB: prisma migrate
     App->>DB: seed initial admin if needed
+    Dev->>App: pnpm run dev
 ```
 
 ```mermaid

--- a/webapp/specs/base/testing-and-quality.md
+++ b/webapp/specs/base/testing-and-quality.md
@@ -48,7 +48,8 @@ Tooling:
 Coverage focus:
 
 - worker job processing
-- SQLite claim / complete / fail transitions
+- PostgreSQL claim / complete / fail transitions, run against a real database
+  built from the Prisma migrations (`WORKER_TEST_DATABASE_URL`)
 
 ## Validation Pipeline
 

--- a/webapp/validate.ps1
+++ b/webapp/validate.ps1
@@ -1210,6 +1210,14 @@ if ($Phase -in "all", "full", "quality", "commit") {
 if ($Phase -in "all", "full", "test", "commit") {
     Write-Step "Tests - Python (pytest)"
     try {
+        # The worker runs on PostgreSQL everywhere, so its tests need the E2E
+        # container up before they can create their own database on it.
+        $provisionResult = Invoke-NativeCommandCaptured "node scripts/ensure-e2e-db.mjs"
+        if ($provisionResult.ExitCode -ne 0) {
+            $provisionResult.Output | Out-Host
+            throw "could not provision PostgreSQL for the worker tests"
+        }
+
         Push-Location "worker"
         try {
             $pytestVersion = Invoke-NativeCommandCaptured "uv run pytest --version"

--- a/webapp/worker/README.md
+++ b/webapp/worker/README.md
@@ -16,14 +16,24 @@ uv run starter-worker
 ```
 
 The worker automatically loads the shared repo-root `.env` file when started
-from the `worker/` subdirectory. Production-style runs should set
-`WORKER_DATABASE_URL`; local development can still fall back to
-`DATABASE_URL=file:./dev.db`.
+from the `worker/` subdirectory. Set `WORKER_DATABASE_URL` (preferred) or
+`DATABASE_URL` to a PostgreSQL connection string. There is no default: the
+worker refuses to start without one.
 
-The worker supports both:
+PostgreSQL is the only supported database. A `file:` SQLite URL is rejected at
+startup rather than silently accepted.
 
-- `file:` SQLite URLs for local development
-- PostgreSQL URLs for Docker/shared deployments
+## Tests
+
+```powershell
+node ../scripts/ensure-e2e-db.mjs   # from webapp/, starts the PostgreSQL container
+cd worker
+uv run pytest
+```
+
+The tests run against their own `business_app_starter_worker_test` database on
+the E2E PostgreSQL container, built from the real Prisma migrations. Override the
+target with `WORKER_TEST_DATABASE_URL`.
 
 ## Reliability Settings
 

--- a/webapp/worker/src/starter_worker/config.py
+++ b/webapp/worker/src/starter_worker/config.py
@@ -27,9 +27,12 @@ def load_shared_env(env_path: Path | None = None) -> None:
 
 def load_config(env_path: Path | None = None) -> WorkerConfig:
     load_shared_env(env_path)
-    database_url = os.environ.get("WORKER_DATABASE_URL") or os.environ.get(
-        "DATABASE_URL", "file:./dev.db"
-    )
+    database_url = os.environ.get("WORKER_DATABASE_URL") or os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError(
+            "No database URL configured. Set WORKER_DATABASE_URL or DATABASE_URL "
+            "to a PostgreSQL connection string."
+        )
 
     return WorkerConfig(
         database_url=database_url,

--- a/webapp/worker/src/starter_worker/db.py
+++ b/webapp/worker/src/starter_worker/db.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import json
 import re
-import sqlite3
 import uuid
-from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -17,11 +14,16 @@ from psycopg.rows import dict_row
 from .config import WorkerConfig
 
 PRISMA_ONLY_QUERY_PARAMS = frozenset({"connection_limit"})
+POSTGRES_URL_SCHEMES = ("postgresql://", "postgres://")
 
 
 def normalize_postgres_database_url(database_url: str) -> str:
-    if database_url.startswith("file:"):
-        return database_url
+    if not database_url.startswith(POSTGRES_URL_SCHEMES):
+        raise ValueError(
+            "The worker requires a PostgreSQL database URL "
+            f"(postgresql:// or postgres://), got: {database_url!r}. "
+            "SQLite support was removed; set WORKER_DATABASE_URL or DATABASE_URL."
+        )
 
     parsed = urlsplit(database_url)
     query = urlencode(
@@ -45,50 +47,18 @@ class BackgroundJob:
 class JobStore:
     def __init__(self, config: WorkerConfig) -> None:
         self._config = config
-        self._is_sqlite = config.database_url.startswith("file:")
-        self._sqlite_path: Path | None = None
         self._postgres_database_url = normalize_postgres_database_url(
             config.database_url,
         )
-        if self._is_sqlite:
-            self._sqlite_path = Path(config.database_url.removeprefix("file:")).resolve()
-
-    def _sqlite_conn(self) -> sqlite3.Connection:
-        assert self._sqlite_path is not None
-        return sqlite3.connect(self._sqlite_path)
 
     def claim_next_job(self) -> BackgroundJob | None:
-        if self._is_sqlite:
-            return self._claim_sqlite_job()
-
         return self._claim_postgres_job()
 
     def requeue_stale_jobs(self) -> int:
-        if self._is_sqlite:
-            return self._requeue_stale_sqlite_jobs()
-
         return self._requeue_stale_postgres_jobs()
 
     def complete_job(self, job_id: str, result: dict[str, Any]) -> None:
         payload = json.dumps(result)
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE BackgroundJob
-                    SET status = 'COMPLETED',
-                        result = ?,
-                        error = NULL,
-                        lockedAt = NULL,
-                        finishedAt = CURRENT_TIMESTAMP,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (payload, job_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -107,29 +77,10 @@ class JobStore:
             connection.commit()
 
     def fail_job(self, job_id: str, error: str, *, retry: bool = True) -> None:
-        if self._is_sqlite:
-            self._fail_sqlite_job(job_id, error, retry=retry)
-            return
-
         self._fail_postgres_job(job_id, error, retry=retry)
 
     def mark_notification_processing(self, notification_id: str, attempt_count: int) -> None:
         retry_count = max(attempt_count - 1, 0)
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE Notification
-                    SET status = 'SENDING',
-                        retryCount = ?,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (retry_count, notification_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -146,23 +97,6 @@ class JobStore:
 
     def mark_notification_sent(self, notification_id: str, attempt_count: int) -> None:
         retry_count = max(attempt_count - 1, 0)
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE Notification
-                    SET status = 'SENT',
-                        retryCount = ?,
-                        lastError = NULL,
-                        sentAt = CURRENT_TIMESTAMP,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (retry_count, notification_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -189,22 +123,6 @@ class JobStore:
     ) -> None:
         retry_count = max(attempt_count - 1, 0)
         status = "RETRYING" if will_retry else "FAILED"
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE Notification
-                    SET status = ?,
-                        retryCount = ?,
-                        lastError = ?,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (status, retry_count, error, notification_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -221,24 +139,6 @@ class JobStore:
             connection.commit()
 
     def mark_raster_run_running(self, run_id: str, job_id: str) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE RasterOptimizationRun
-                    SET status = 'RUNNING',
-                        outcome = NULL,
-                        solverStatus = NULL,
-                        finishedAt = NULL,
-                        jobId = ?
-                    WHERE id = ?
-                      AND status != 'CANCELLED'
-                    """,
-                    (job_id, run_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -257,20 +157,6 @@ class JobStore:
             connection.commit()
 
     def mark_raster_run_succeeded(self, run_id: str) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE RasterOptimizationRun
-                    SET status = 'SUCCEEDED',
-                        finishedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (run_id,),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -285,22 +171,6 @@ class JobStore:
             connection.commit()
 
     def mark_raster_run_failed(self, run_id: str, error: str) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE RasterOptimizationRun
-                    SET status = 'FAILED',
-                        outcome = 'FAILED',
-                        solverStatus = ?,
-                        finishedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (error, run_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -317,22 +187,6 @@ class JobStore:
             connection.commit()
 
     def mark_raster_run_infeasible(self, run_id: str, reason: str) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE RasterOptimizationRun
-                    SET status = 'FAILED',
-                        outcome = 'INFEASIBLE',
-                        solverStatus = ?,
-                        finishedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (reason, run_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -349,26 +203,6 @@ class JobStore:
             connection.commit()
 
     def get_raster_run_context(self, run_id: str) -> dict[str, Any]:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.row_factory = sqlite3.Row
-                row = connection.execute(
-                    """
-                    SELECT run.id, run.status, run.settings, input.scopeId, input.seasonModelJson
-                    FROM RasterOptimizationRun run
-                    JOIN RasterInputSet input ON input.id = run.inputSetId
-                    WHERE run.id = ?
-                    """,
-                    (run_id,),
-                ).fetchone()
-                if row is None:
-                    raise ValueError(f"Raster run {run_id} not found")
-                result = dict(row)
-                result["seasonModels"] = [
-                    {"scopeId": result["scopeId"], "seasonModelJson": result["seasonModelJson"]}
-                ]
-                return result
-
         with psycopg.connect(self._postgres_database_url, row_factory=dict_row) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -430,16 +264,6 @@ class JobStore:
             return dict(row)
 
     def get_raster_run_status(self, run_id: str) -> str:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                row = connection.execute(
-                    "SELECT status FROM RasterOptimizationRun WHERE id = ?",
-                    (run_id,),
-                ).fetchone()
-                if row is None:
-                    raise ValueError(f"Raster run {run_id} not found")
-                return str(row[0])
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -453,20 +277,6 @@ class JobStore:
             return str(row[0])
 
     def list_raster_hall_capacities(self, scope: object) -> list[dict[str, Any]]:
-        if self._is_sqlite:
-            scope_id = str(scope[0] if isinstance(scope, list) and scope else scope)
-            with closing(self._sqlite_conn()) as connection:
-                connection.row_factory = sqlite3.Row
-                rows = connection.execute(
-                    """
-                    SELECT clubId, hall, weekday, capacity
-                    FROM RasterHallCapacity
-                    WHERE scopeId = ?
-                    """,
-                    (scope_id,),
-                ).fetchall()
-                return [dict(row) for row in rows]
-
         with psycopg.connect(self._postgres_database_url, row_factory=dict_row) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -505,64 +315,6 @@ class JobStore:
             metadata.get("objectiveBreakdown")
             or _objective_breakdown(overages, metadata.get("weights"))
         )
-
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute("BEGIN")
-                connection.execute(
-                    """
-                    INSERT INTO RasterSnapshot (
-                        id, runId, scopeId, origin, optimality, stale, totalConflicts,
-                        totalExcess, maxExcess, affectedClubs, objectiveBreakdown, createdAt
-                    ) VALUES (?, ?, ?, 'GENERATED', ?, 0, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-                    """,
-                    (
-                        snapshot_id,
-                        run_id,
-                        scope_id,
-                        optimality,
-                        len(overages),
-                        total_excess,
-                        max_excess,
-                        affected_clubs,
-                        objective_breakdown,
-                    ),
-                )
-                connection.executemany(
-                    """
-                    INSERT INTO RasterAssignment (
-                        id, snapshotId, league, "group", clubId, clubName, team, rasterzahl,
-                        status, weekday, hall, startTime, weekSlot
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    assignments,
-                )
-                connection.executemany(
-                    """
-                    INSERT INTO RasterConflict (
-                        id, snapshotId, matchWeek, clubId, clubName, weekday, hall,
-                        capacity, actualCount, excess, teams
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    _conflict_rows(snapshot_id, model, overages),
-                )
-                connection.execute(
-                    """
-                    UPDATE RasterOptimizationRun
-                    SET status = 'SUCCEEDED', outcome = ?, objectiveValue = ?,
-                        objectiveBreakdown = ?, solverStatus = ?, finishedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (
-                        outcome,
-                        metadata.get("objective"),
-                        objective_breakdown,
-                        metadata.get("status"),
-                        run_id,
-                    ),
-                )
-                connection.commit()
-                return snapshot_id
 
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
@@ -631,14 +383,6 @@ class JobStore:
             return snapshot_id
 
     def has_inbound_email(self, provider_message_id: str) -> bool:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                row = connection.execute(
-                    "SELECT 1 FROM InboundEmail WHERE providerMessageId = ? LIMIT 1",
-                    (provider_message_id,),
-                ).fetchone()
-                return row is not None
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -651,38 +395,6 @@ class JobStore:
 
     def create_inbound_email(self, payload: dict[str, Any]) -> str:
         reference_ids = json.dumps(payload.get("referenceIds") or [])
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                cursor = connection.execute(
-                    """
-                    INSERT INTO InboundEmail (
-                        id, providerMessageId, mailbox, internetMessageId, conversationId,
-                        senderEmail, senderName, subject, bodyPreview, bodyText, bodyHtml,
-                        inReplyTo, referenceIds, receivedAt, processingStatus, createdAt, updatedAt
-                    ) VALUES (
-                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'RECEIVED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-                    )
-                    """,
-                    (
-                        payload["id"],
-                        payload["providerMessageId"],
-                        payload["mailbox"],
-                        payload.get("internetMessageId"),
-                        payload.get("conversationId"),
-                        payload.get("senderEmail"),
-                        payload.get("senderName"),
-                        payload.get("subject") or "",
-                        payload.get("bodyPreview"),
-                        payload.get("bodyText"),
-                        payload.get("bodyHtml"),
-                        payload.get("inReplyTo"),
-                        reference_ids,
-                        payload["receivedAt"],
-                    ),
-                )
-                connection.commit()
-                return str(payload["id"] if cursor.rowcount else payload["id"])
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as pg_cursor:
                 pg_cursor.execute(
@@ -725,31 +437,6 @@ class JobStore:
         linked_entity_type: str | None = None,
         linked_entity_id: str | None = None,
     ) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE InboundEmail
-                    SET processingStatus = ?,
-                        processingNotes = ?,
-                        correlatedNotificationId = ?,
-                        linkedEntityType = ?,
-                        linkedEntityId = ?,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (
-                        processing_status,
-                        processing_notes,
-                        correlated_notification_id,
-                        linked_entity_type,
-                        linked_entity_id,
-                        inbound_email_id,
-                    ),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -775,21 +462,6 @@ class JobStore:
             connection.commit()
 
     def mark_notification_bounced(self, notification_id: str, error: str) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE Notification
-                    SET status = 'BOUNCED',
-                        lastError = ?,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (error, notification_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -810,23 +482,6 @@ class JobStore:
         if not provider_message_ids:
             return None
 
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.row_factory = sqlite3.Row
-                for provider_message_id in provider_message_ids:
-                    row = connection.execute(
-                        """
-                        SELECT id, providerMessageId
-                        FROM Notification
-                        WHERE providerMessageId = ?
-                        LIMIT 1
-                        """,
-                        (provider_message_id,),
-                    ).fetchone()
-                    if row is not None:
-                        return dict(row)
-            return None
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor(row_factory=dict_row) as cursor:
                 cursor.execute(
@@ -841,21 +496,6 @@ class JobStore:
                 return cursor.fetchone()
 
     def mark_teams_outbound_processing(self, outbound_message_id: str, attempt_count: int) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE TeamsOutboundMessage
-                    SET status = 'SENDING',
-                        attemptCount = ?,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (attempt_count, outbound_message_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -873,23 +513,6 @@ class JobStore:
     def mark_teams_outbound_sent(
         self, outbound_message_id: str, graph_message_id: str | None
     ) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE TeamsOutboundMessage
-                    SET status = 'SENT',
-                        graphMessageId = ?,
-                        lastError = NULL,
-                        sentAt = CURRENT_TIMESTAMP,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (graph_message_id, outbound_message_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -915,22 +538,6 @@ class JobStore:
         will_retry: bool,
     ) -> None:
         status = "RETRYING" if will_retry else "FAILED"
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE TeamsOutboundMessage
-                    SET status = ?,
-                        attemptCount = ?,
-                        lastError = ?,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (status, attempt_count, error, outbound_message_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -947,14 +554,6 @@ class JobStore:
             connection.commit()
 
     def has_teams_inbound_message(self, provider_message_id: str) -> bool:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                row = connection.execute(
-                    "SELECT 1 FROM TeamsInboundMessage WHERE providerMessageId = ? LIMIT 1",
-                    (provider_message_id,),
-                ).fetchone()
-                return row is not None
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -966,33 +565,6 @@ class JobStore:
             return row is not None
 
     def create_teams_inbound_message(self, payload: dict[str, Any]) -> str:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    INSERT INTO TeamsInboundMessage (
-                        id, subscriptionId, providerMessageId, teamId, channelId, senderDisplayName,
-                        senderUserId, content, contentType, truncated, processingStatus,
-                        processingNotes, messageCreatedAt, createdAt, updatedAt
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'RECEIVED', NULL, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                    """,
-                    (
-                        payload["id"],
-                        payload["subscriptionId"],
-                        payload["providerMessageId"],
-                        payload["teamId"],
-                        payload["channelId"],
-                        payload.get("senderDisplayName"),
-                        payload.get("senderUserId"),
-                        payload.get("content"),
-                        payload.get("contentType"),
-                        bool(payload.get("truncated")),
-                        payload["messageCreatedAt"],
-                    ),
-                )
-                connection.commit()
-            return str(payload["id"])
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -1025,21 +597,6 @@ class JobStore:
         subscription_id: str,
         delta_token: str | None,
     ) -> None:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.execute(
-                    """
-                    UPDATE TeamsIntakeSubscription
-                    SET deltaToken = ?,
-                        lastPolledAt = CURRENT_TIMESTAMP,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (delta_token, subscription_id),
-                )
-                connection.commit()
-            return
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -1055,19 +612,6 @@ class JobStore:
             connection.commit()
 
     def list_active_teams_subscriptions(self) -> list[dict[str, Any]]:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.row_factory = sqlite3.Row
-                rows = connection.execute(
-                    """
-                    SELECT id, teamId, channelId, deltaToken
-                    FROM TeamsIntakeSubscription
-                    WHERE active = 1
-                    ORDER BY createdAt ASC
-                    """
-                ).fetchall()
-                return [dict(row) for row in rows]
-
         with psycopg.connect(self._postgres_database_url, row_factory=dict_row) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -1083,38 +627,6 @@ class JobStore:
             return list(rows)
 
     def create_teams_intake_poll_job_if_missing(self) -> bool:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                existing = connection.execute(
-                    """
-                    SELECT 1 FROM BackgroundJob
-                    WHERE jobType = 'teams_intake_poll'
-                      AND status IN ('PENDING', 'IN_PROGRESS')
-                    LIMIT 1
-                    """
-                ).fetchone()
-                if existing:
-                    return False
-
-                connection.execute(
-                    """
-                    INSERT INTO BackgroundJob (
-                        id, jobType, status, payload, attemptCount, availableAt, createdAt, updatedAt
-                    ) VALUES (
-                        lower(hex(randomblob(16))),
-                        'teams_intake_poll',
-                        'PENDING',
-                        '{}',
-                        0,
-                        CURRENT_TIMESTAMP,
-                        CURRENT_TIMESTAMP,
-                        CURRENT_TIMESTAMP
-                    )
-                    """
-                )
-                connection.commit()
-                return True
-
         with psycopg.connect(self._postgres_database_url) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -1149,24 +661,6 @@ class JobStore:
             return True
 
     def get_teams_integration_flags(self) -> dict[str, bool]:
-        if self._is_sqlite:
-            with closing(self._sqlite_conn()) as connection:
-                connection.row_factory = sqlite3.Row
-                row = connection.execute(
-                    """
-                    SELECT sendEnabled, intakeEnabled
-                    FROM TeamsIntegrationConfig
-                    ORDER BY createdAt ASC
-                    LIMIT 1
-                    """
-                ).fetchone()
-                if not row:
-                    return {"sendEnabled": False, "intakeEnabled": False}
-                return {
-                    "sendEnabled": bool(row["sendEnabled"]),
-                    "intakeEnabled": bool(row["intakeEnabled"]),
-                }
-
         with psycopg.connect(self._postgres_database_url, row_factory=dict_row) as connection:
             with connection.cursor() as cursor:
                 cursor.execute(
@@ -1186,46 +680,6 @@ class JobStore:
                 "intakeEnabled": bool(row["intakeEnabled"]),
             }
 
-    def _claim_sqlite_job(self) -> BackgroundJob | None:
-        with closing(self._sqlite_conn()) as connection:
-            connection.row_factory = sqlite3.Row
-            connection.execute("BEGIN IMMEDIATE")
-            row = connection.execute(
-                """
-                SELECT id, jobType, payload, attemptCount
-                FROM BackgroundJob
-                WHERE status = 'PENDING'
-                  AND datetime(availableAt) <= datetime('now')
-                ORDER BY createdAt ASC
-                LIMIT 1
-                """
-            ).fetchone()
-
-            if row is None:
-                connection.commit()
-                return None
-
-            connection.execute(
-                """
-                UPDATE BackgroundJob
-                SET status = 'IN_PROGRESS',
-                    attemptCount = attemptCount + 1,
-                    startedAt = COALESCE(startedAt, CURRENT_TIMESTAMP),
-                    lockedAt = CURRENT_TIMESTAMP,
-                    workerId = ?,
-                    updatedAt = CURRENT_TIMESTAMP
-                WHERE id = ?
-                """,
-                (self._config.worker_id, row["id"]),
-            )
-            connection.commit()
-
-            return BackgroundJob(
-                id=row["id"],
-                job_type=row["jobType"],
-                payload=_parse_payload(row["payload"]),
-                attempt_count=row["attemptCount"] + 1,
-            )
 
     def _claim_postgres_job(self) -> BackgroundJob | None:
         with psycopg.connect(self._postgres_database_url, row_factory=dict_row) as connection:
@@ -1267,28 +721,6 @@ class JobStore:
             attempt_count=row["attemptCount"],
         )
 
-    def _requeue_stale_sqlite_jobs(self) -> int:
-        with closing(self._sqlite_conn()) as connection:
-            cursor = connection.execute(
-                """
-                UPDATE BackgroundJob
-                SET status = 'PENDING',
-                    error = CASE
-                        WHEN error IS NULL OR error = '' THEN 'Worker lock expired; job requeued.'
-                        ELSE error || '\nWorker lock expired; job requeued.'
-                    END,
-                    availableAt = CURRENT_TIMESTAMP,
-                    lockedAt = NULL,
-                    workerId = NULL,
-                    updatedAt = CURRENT_TIMESTAMP
-                WHERE status = 'IN_PROGRESS'
-                  AND lockedAt IS NOT NULL
-                  AND datetime(lockedAt) <= datetime('now', ?)
-                """,
-                (f"-{self._config.stale_lock_seconds} seconds",),
-            )
-            connection.commit()
-            return int(cursor.rowcount or 0)
 
     def _requeue_stale_postgres_jobs(self) -> int:
         with psycopg.connect(self._postgres_database_url) as connection:
@@ -1315,50 +747,6 @@ class JobStore:
             connection.commit()
             return row_count
 
-    def _fail_sqlite_job(self, job_id: str, error: str, *, retry: bool) -> None:
-        with closing(self._sqlite_conn()) as connection:
-            connection.row_factory = sqlite3.Row
-            row = connection.execute(
-                "SELECT attemptCount FROM BackgroundJob WHERE id = ?",
-                (job_id,),
-            ).fetchone()
-            if row is None:
-                return
-
-            attempt_count = int(row["attemptCount"])
-            should_retry = retry and attempt_count < self._config.max_attempts
-            if should_retry:
-                connection.execute(
-                    """
-                    UPDATE BackgroundJob
-                    SET status = 'PENDING',
-                        error = ?,
-                        availableAt = ?,
-                        lockedAt = NULL,
-                        finishedAt = NULL,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (
-                        error,
-                        _sqlite_timestamp_after_seconds(self._retry_delay_seconds(attempt_count)),
-                        job_id,
-                    ),
-                )
-            else:
-                connection.execute(
-                    """
-                    UPDATE BackgroundJob
-                    SET status = 'FAILED',
-                        error = ?,
-                        lockedAt = NULL,
-                        finishedAt = CURRENT_TIMESTAMP,
-                        updatedAt = CURRENT_TIMESTAMP
-                    WHERE id = ?
-                    """,
-                    (error, job_id),
-                )
-            connection.commit()
 
     def _fail_postgres_job(self, job_id: str, error: str, *, retry: bool) -> None:
         with psycopg.connect(self._postgres_database_url) as connection:
@@ -1425,9 +813,6 @@ def _parse_payload(value: str | None) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {"value": parsed}
 
 
-def _sqlite_timestamp_after_seconds(delay_seconds: float) -> str:
-    scheduled_for = datetime.now(timezone.utc) + timedelta(seconds=delay_seconds)
-    return scheduled_for.strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _new_id() -> str:

--- a/webapp/worker/tests/conftest.py
+++ b/webapp/worker/tests/conftest.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Let test modules import the sibling helpers regardless of how pytest is invoked.
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -41,6 +41,8 @@ from starter_worker.main import (
 class WorkerTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
+        if self._testMethodName.startswith("test_combined_raster_model_"):
+            return
         self.database_url = ensure_worker_database()
         truncate_all(self.database_url)
 

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sqlite3
 import sys
 import tempfile
 import unittest
 import unittest.mock
-from contextlib import closing
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
+
+import psycopg
+from psycopg.rows import dict_row
+from worker_db import ensure_worker_database, truncate_all
 
 from starter_worker.config import WorkerConfig, load_config
 from starter_worker.db import BackgroundJob, JobStore, _find_overage_rows, normalize_postgres_database_url
@@ -37,8 +39,8 @@ from starter_worker.main import (
 class WorkerTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
-        self.db_path = Path(self.temp_dir.name) / "worker-test.db"
-        self._create_schema()
+        self.database_url = ensure_worker_database()
+        truncate_all(self.database_url)
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
@@ -141,21 +143,8 @@ class WorkerTests(unittest.TestCase):
             "absoluteConstraints": [],
             "warnings": [],
         }
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.execute(
-                """
-                INSERT INTO RasterInputSet (id, scopeId, seasonModelJson)
-                VALUES ('input-1', 'scope-owl', ?)
-                """,
-                (json.dumps(season_model),),
-            )
-            connection.execute(
-                """
-                INSERT INTO RasterOptimizationRun (id, inputSetId, status, settings)
-                VALUES ('run-1', 'input-1', 'PENDING', '{"timeLimitSeconds": 60}')
-                """
-            )
-            connection.commit()
+        self._seed_input_set("input-1", season_model=season_model)
+        self._seed_run("run-1", input_set_id="input-1", settings='{"timeLimitSeconds": 60}')
 
         with patch(
             "starter_worker.main._solve_raster_model",
@@ -182,20 +171,20 @@ class WorkerTests(unittest.TestCase):
                 )(),
             )
 
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.row_factory = sqlite3.Row
+        with self._connect() as connection:
             row = connection.execute(
                 """
-                SELECT status, jobId, outcome, solverStatus, finishedAt
-                FROM RasterOptimizationRun
+                SELECT status, "jobId", outcome, "solverStatus", "finishedAt"
+                FROM "RasterOptimizationRun"
                 WHERE id = 'run-1'
                 """,
             ).fetchone()
             snapshot = connection.execute(
-                "SELECT id, optimality, totalConflicts FROM RasterSnapshot WHERE runId = 'run-1'",
+                'SELECT id, optimality, "totalConflicts" FROM "RasterSnapshot" '
+                "WHERE \"runId\" = 'run-1'",
             ).fetchone()
             assignments = connection.execute(
-                "SELECT team, rasterzahl FROM RasterAssignment ORDER BY team",
+                'SELECT team, rasterzahl FROM "RasterAssignment" ORDER BY team',
             ).fetchall()
 
         assert row is not None
@@ -208,24 +197,16 @@ class WorkerTests(unittest.TestCase):
         self.assertIsNotNone(row["finishedAt"])
         self.assertEqual(snapshot["optimality"], "PROVEN_OPTIMAL")
         self.assertEqual(snapshot["totalConflicts"], 0)
-        self.assertEqual([tuple(row) for row in assignments], [("I", 1), ("II", 2)])
+        self.assertEqual(
+            [(row["team"], row["rasterzahl"]) for row in assignments], [("I", 1), ("II", 2)]
+        )
 
     def test_process_raster_run_skips_cancelled_run(self) -> None:
         store = self._make_store()
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.execute(
-                """
-                INSERT INTO RasterInputSet (id, scopeId, seasonModelJson)
-                VALUES ('input-1', 'scope-owl', '{}')
-                """
-            )
-            connection.execute(
-                """
-                INSERT INTO RasterOptimizationRun (id, inputSetId, status, outcome, settings)
-                VALUES ('run-1', 'input-1', 'CANCELLED', 'CANCELLED', '{}')
-                """
-            )
-            connection.commit()
+        self._seed_input_set("input-1", season_model="{}")
+        self._seed_run(
+            "run-1", input_set_id="input-1", status="CANCELLED", outcome="CANCELLED"
+        )
 
         with patch("starter_worker.main._solve_raster_model") as solve:
             result = process_raster_run(
@@ -241,17 +222,20 @@ class WorkerTests(unittest.TestCase):
                 )(),
             )
 
-        with closing(sqlite3.connect(self.db_path)) as connection:
+        with self._connect() as connection:
             row = connection.execute(
-                "SELECT status, outcome, jobId FROM RasterOptimizationRun WHERE id = 'run-1'",
+                'SELECT status, outcome, "jobId" FROM "RasterOptimizationRun" '
+                "WHERE id = 'run-1'",
             ).fetchone()
-            snapshots = connection.execute(
-                "SELECT COUNT(*) FROM RasterSnapshot WHERE runId = 'run-1'",
-            ).fetchone()[0]
+            snapshot_count = connection.execute(
+                'SELECT COUNT(*) AS count FROM "RasterSnapshot" WHERE "runId" = \'run-1\'',
+            ).fetchone()
+            assert snapshot_count is not None
+            snapshots = snapshot_count["count"]
 
         solve.assert_not_called()
         self.assertEqual(result["status"], "CANCELLED")
-        self.assertEqual(row, ("CANCELLED", "CANCELLED", None))
+        self.assertEqual(row, {"status": "CANCELLED", "outcome": "CANCELLED", "jobId": None})
         self.assertEqual(snapshots, 0)
 
     @staticmethod
@@ -822,7 +806,7 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(inbound_bounce["processingStatus"], "IGNORED")
         self.assertEqual(notification["status"], "SENT")
 
-    def test_sqlite_job_store_claims_and_completes_job(self) -> None:
+    def test_job_store_claims_and_completes_job(self) -> None:
         self._insert_job(job_id="job-1", job_type="noop", payload={"message": "hello"})
         store = self._make_store()
 
@@ -844,7 +828,7 @@ class WorkerTests(unittest.TestCase):
         self.assertIsNotNone(row["finishedAt"])
         self.assertIsNone(row["lockedAt"])
 
-    def test_sqlite_job_store_retries_failure_before_max_attempts(self) -> None:
+    def test_job_store_retries_failure_before_max_attempts(self) -> None:
         self._insert_job(job_id="job-2", job_type="echo", payload={"message": "x"})
         store = self._make_store(max_attempts=3, retry_backoff_seconds=15)
 
@@ -861,7 +845,7 @@ class WorkerTests(unittest.TestCase):
         self.assertIsNone(row["finishedAt"])
         self.assertIsNone(row["lockedAt"])
 
-    def test_sqlite_job_store_marks_terminal_failure_after_max_attempts(self) -> None:
+    def test_job_store_marks_terminal_failure_after_max_attempts(self) -> None:
         self._insert_job(job_id="job-3", job_type="echo", payload={"message": "x"})
         store = self._make_store(max_attempts=1)
 
@@ -878,7 +862,7 @@ class WorkerTests(unittest.TestCase):
         self.assertIsNotNone(row["finishedAt"])
         self.assertIsNone(row["lockedAt"])
 
-    def test_sqlite_job_store_can_skip_retries_for_terminal_failure(self) -> None:
+    def test_job_store_can_skip_retries_for_terminal_failure(self) -> None:
         self._insert_job(job_id="job-terminal", job_type="echo", payload={"message": "x"})
         store = self._make_store(max_attempts=3)
 
@@ -894,22 +878,21 @@ class WorkerTests(unittest.TestCase):
         self.assertIsNotNone(row["finishedAt"])
         self.assertIsNone(row["lockedAt"])
 
-    def test_sqlite_job_store_requeues_stale_in_progress_job(self) -> None:
-        with closing(sqlite3.connect(self.db_path)) as connection:
+    def test_job_store_requeues_stale_in_progress_job(self) -> None:
+        with self._connect() as connection:
             connection.execute(
                 """
-                INSERT INTO BackgroundJob (
-                    id, jobType, status, payload, attemptCount, availableAt, startedAt,
-                    lockedAt, workerId, createdAt, updatedAt
+                INSERT INTO "BackgroundJob" (
+                    id, "jobType", status, payload, "attemptCount", "availableAt", "startedAt",
+                    "lockedAt", "workerId", "createdAt", "updatedAt"
                 ) VALUES (
-                    ?, ?, 'IN_PROGRESS', ?, 1, datetime('now', '-10 minutes'),
-                    datetime('now', '-10 minutes'), datetime('now', '-10 minutes'),
-                    'worker-old', datetime('now', '-10 minutes'), datetime('now', '-10 minutes')
+                    %s, %s, 'IN_PROGRESS', %s, 1, now() - interval '10 minutes',
+                    now() - interval '10 minutes', now() - interval '10 minutes',
+                    'worker-old', now() - interval '10 minutes', now() - interval '10 minutes'
                 )
                 """,
                 ("job-4", "noop", json.dumps({"message": "hello"})),
             )
-            connection.commit()
 
         store = self._make_store(stale_lock_seconds=60)
 
@@ -923,17 +906,18 @@ class WorkerTests(unittest.TestCase):
         self.assertIsNone(row["workerId"])
 
     def test_process_teams_intake_poll_stores_messages_and_updates_delta(self) -> None:
-        with closing(sqlite3.connect(self.db_path)) as connection:
+        self._seed_actor()
+        with self._connect() as connection:
             connection.execute(
                 """
-                INSERT INTO TeamsIntakeSubscription (
-                    id, teamId, channelId, active, deltaToken, createdByUserId, createdAt, updatedAt
+                INSERT INTO "TeamsIntakeSubscription" (
+                    id, "teamId", "channelId", active, "deltaToken", "createdByUserId",
+                    "createdAt", "updatedAt"
                 ) VALUES (
-                    'sub-1', 'team-1', 'channel-1', 1, NULL, 'admin-1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                    'sub-1', 'team-1', 'channel-1', true, NULL, 'admin-1', now(), now()
                 )
                 """
             )
-            connection.commit()
 
         with patch(
             "starter_worker.main.list_teams_channel_messages",
@@ -953,16 +937,17 @@ class WorkerTests(unittest.TestCase):
             result = process_teams_intake_poll(store)
 
         self.assertEqual(result["created"], 1)
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.row_factory = sqlite3.Row
+        with self._connect() as connection:
             row = connection.execute(
-                "SELECT providerMessageId FROM TeamsInboundMessage WHERE providerMessageId = ?",
+                'SELECT "providerMessageId" FROM "TeamsInboundMessage" '
+                'WHERE "providerMessageId" = %s',
                 ("teams-msg-1",),
             ).fetchone()
             self.assertIsNotNone(row)
             sub = connection.execute(
-                "SELECT deltaToken FROM TeamsIntakeSubscription WHERE id = 'sub-1'",
+                'SELECT "deltaToken" FROM "TeamsIntakeSubscription" WHERE id = \'sub-1\'',
             ).fetchone()
+            assert sub is not None
             self.assertEqual(sub["deltaToken"], "/delta-token-1")
 
     def test_load_config_reads_repo_env_file(self) -> None:
@@ -1050,6 +1035,24 @@ class WorkerTests(unittest.TestCase):
             "postgresql://worker:test@localhost:5432/app?sslmode=require",
         )
 
+    def test_worker_rejects_non_postgres_database_url(self) -> None:
+        # SQLite support was removed; a file: URL must fail loudly rather than
+        # silently running the worker against a database production never uses.
+        with self.assertRaises(ValueError) as caught:
+            normalize_postgres_database_url("file:./dev.db")
+
+        self.assertIn("PostgreSQL", str(caught.exception))
+
+    def test_load_config_requires_a_database_url(self) -> None:
+        env_path = Path(self.temp_dir.name) / ".env"
+        env_path.write_text("WORKER_ID=\"worker-1\"\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as caught:
+                load_config(env_path=env_path)
+
+        self.assertIn("WORKER_DATABASE_URL", str(caught.exception))
+
     def _make_store(
         self,
         *,
@@ -1059,7 +1062,7 @@ class WorkerTests(unittest.TestCase):
     ) -> JobStore:
         return JobStore(
             WorkerConfig(
-                database_url=f"file:{self.db_path}",
+                database_url=self.database_url,
                 poll_interval_seconds=0.1,
                 worker_id="worker-test",
                 max_attempts=max_attempts,
@@ -1069,238 +1072,89 @@ class WorkerTests(unittest.TestCase):
             )
         )
 
-    def _create_schema(self) -> None:
-        with closing(sqlite3.connect(self.db_path)) as connection:
+    def _connect(self) -> psycopg.Connection[dict[str, Any]]:
+        return psycopg.connect(self.database_url, row_factory=dict_row, autocommit=True)
+
+    def _seed_actor(self, user_id: str = "admin-1") -> str:
+        """Insert the User row that most raster and Teams rows reference."""
+        with self._connect() as connection:
             connection.execute(
                 """
-                CREATE TABLE BackgroundJob (
-                    id TEXT PRIMARY KEY,
-                    jobType TEXT NOT NULL,
-                    status TEXT NOT NULL DEFAULT 'PENDING',
-                    payload TEXT,
-                    result TEXT,
-                    error TEXT,
-                    attemptCount INTEGER NOT NULL DEFAULT 0,
-                    availableAt TEXT NOT NULL,
-                    startedAt TEXT,
-                    lockedAt TEXT,
-                    finishedAt TEXT,
-                    workerId TEXT,
-                    createdByUserId TEXT,
-                    createdAt TEXT NOT NULL,
-                    updatedAt TEXT NOT NULL
-                )
-                """
+                INSERT INTO "User" (id, email, name, "authMethod", "updatedAt")
+                VALUES (%s, %s, 'Admin', 'LOCAL', now())
+                ON CONFLICT (id) DO NOTHING
+                """,
+                (user_id, f"{user_id}@example.com"),
             )
+        return user_id
+
+    def _seed_scope(self, scope_id: str = "scope-owl", code: str = "owl") -> str:
+        with self._connect() as connection:
             connection.execute(
                 """
-                CREATE TABLE Notification (
-                    id TEXT PRIMARY KEY,
-                    providerMessageId TEXT,
-                    status TEXT NOT NULL DEFAULT 'QUEUED',
-                    lastError TEXT,
-                    updatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
+                INSERT INTO "Scope" (id, name, code, "updatedAt")
+                VALUES (%s, %s, %s, now())
+                ON CONFLICT (id) DO NOTHING
+                """,
+                (scope_id, code.upper(), code),
             )
+        return scope_id
+
+    def _seed_input_set(
+        self,
+        input_set_id: str,
+        *,
+        season_model: dict[str, object] | str,
+        scope_id: str = "scope-owl",
+    ) -> None:
+        self._seed_actor()
+        self._seed_scope(scope_id)
+        payload = season_model if isinstance(season_model, str) else json.dumps(season_model)
+        with self._connect() as connection:
             connection.execute(
                 """
-                CREATE TABLE InboundEmail (
-                    id TEXT PRIMARY KEY,
-                    providerMessageId TEXT NOT NULL UNIQUE,
-                    mailbox TEXT NOT NULL,
-                    internetMessageId TEXT,
-                    conversationId TEXT,
-                    senderEmail TEXT,
-                    senderName TEXT,
-                    subject TEXT NOT NULL,
-                    bodyPreview TEXT,
-                    bodyText TEXT,
-                    bodyHtml TEXT,
-                    inReplyTo TEXT,
-                    referenceIds TEXT NOT NULL DEFAULT '[]',
-                    receivedAt TEXT NOT NULL,
-                    processingStatus TEXT NOT NULL DEFAULT 'RECEIVED',
-                    processingNotes TEXT,
-                    correlatedNotificationId TEXT,
-                    linkedEntityType TEXT,
-                    linkedEntityId TEXT,
-                    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    updatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
+                INSERT INTO "RasterInputSet" (id, name, "createdById", "scopeId", "seasonModelJson")
+                VALUES (%s, %s, 'admin-1', %s, %s)
+                """,
+                (input_set_id, f"Input {input_set_id}", scope_id, payload),
             )
+
+    def _seed_run(
+        self,
+        run_id: str,
+        *,
+        input_set_id: str,
+        status: str = "PENDING",
+        outcome: str | None = None,
+        settings: str = "{}",
+    ) -> None:
+        with self._connect() as connection:
             connection.execute(
                 """
-                CREATE TABLE TeamsOutboundMessage (
-                    id TEXT PRIMARY KEY,
-                    status TEXT NOT NULL DEFAULT 'QUEUED',
-                    graphMessageId TEXT,
-                    attemptCount INTEGER NOT NULL DEFAULT 0,
-                    lastError TEXT,
-                    sentAt TEXT,
-                    updatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
+                INSERT INTO "RasterOptimizationRun" (
+                    id, "inputSetId", "startedById", status, outcome, settings
+                ) VALUES (%s, %s, 'admin-1', %s::"OptimizationRunStatus",
+                          %s::"OptimizationRunOutcome", %s)
+                """,
+                (run_id, input_set_id, status, outcome, settings),
             )
-            connection.execute(
-                """
-                CREATE TABLE TeamsIntegrationConfig (
-                    id TEXT PRIMARY KEY,
-                    sendEnabled INTEGER NOT NULL DEFAULT 0,
-                    intakeEnabled INTEGER NOT NULL DEFAULT 0,
-                    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE TeamsIntakeSubscription (
-                    id TEXT PRIMARY KEY,
-                    teamId TEXT NOT NULL,
-                    channelId TEXT NOT NULL,
-                    active INTEGER NOT NULL DEFAULT 1,
-                    deltaToken TEXT,
-                    lastPolledAt TEXT,
-                    createdByUserId TEXT NOT NULL,
-                    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    updatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE TeamsInboundMessage (
-                    id TEXT PRIMARY KEY,
-                    subscriptionId TEXT NOT NULL,
-                    providerMessageId TEXT NOT NULL UNIQUE,
-                    teamId TEXT NOT NULL,
-                    channelId TEXT NOT NULL,
-                    senderDisplayName TEXT,
-                    senderUserId TEXT,
-                    content TEXT,
-                    contentType TEXT,
-                    truncated INTEGER NOT NULL DEFAULT 0,
-                    processingStatus TEXT NOT NULL DEFAULT 'RECEIVED',
-                    processingNotes TEXT,
-                    messageCreatedAt TEXT NOT NULL,
-                    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                    updatedAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE RasterOptimizationRun (
-                    id TEXT PRIMARY KEY,
-                    inputSetId TEXT,
-                    jobId TEXT,
-                    status TEXT NOT NULL DEFAULT 'PENDING',
-                    outcome TEXT,
-                    objectiveValue REAL,
-                    objectiveBreakdown TEXT,
-                    solverStatus TEXT,
-                    settings TEXT NOT NULL DEFAULT '{}',
-                    finishedAt TEXT
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE RasterInputSet (
-                    id TEXT PRIMARY KEY,
-                    scopeId TEXT NOT NULL,
-                    seasonModelJson TEXT
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE RasterHallCapacity (
-                    id TEXT PRIMARY KEY,
-                    scopeId TEXT NOT NULL,
-                    clubId TEXT NOT NULL,
-                    hall TEXT NOT NULL,
-                    weekday TEXT NOT NULL,
-                    capacity INTEGER NOT NULL
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE RasterSnapshot (
-                    id TEXT PRIMARY KEY,
-                    runId TEXT,
-                    scopeId TEXT NOT NULL,
-                    origin TEXT NOT NULL,
-                    optimality TEXT NOT NULL,
-                    stale INTEGER NOT NULL DEFAULT 0,
-                    totalConflicts INTEGER NOT NULL DEFAULT 0,
-                    totalExcess INTEGER NOT NULL DEFAULT 0,
-                    maxExcess INTEGER NOT NULL DEFAULT 0,
-                    affectedClubs INTEGER NOT NULL DEFAULT 0,
-                    objectiveBreakdown TEXT NOT NULL DEFAULT '{}',
-                    createdAt TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE RasterAssignment (
-                    id TEXT PRIMARY KEY,
-                    snapshotId TEXT NOT NULL,
-                    league TEXT NOT NULL,
-                    "group" TEXT NOT NULL,
-                    clubId TEXT NOT NULL,
-                    clubName TEXT NOT NULL,
-                    team TEXT NOT NULL,
-                    rasterzahl INTEGER NOT NULL,
-                    status TEXT NOT NULL,
-                    weekday TEXT NOT NULL,
-                    hall TEXT NOT NULL,
-                    startTime TEXT,
-                    weekSlot TEXT
-                )
-                """
-            )
-            connection.execute(
-                """
-                CREATE TABLE RasterConflict (
-                    id TEXT PRIMARY KEY,
-                    snapshotId TEXT NOT NULL,
-                    matchWeek INTEGER NOT NULL,
-                    clubId TEXT NOT NULL,
-                    clubName TEXT NOT NULL,
-                    weekday TEXT NOT NULL,
-                    hall TEXT NOT NULL,
-                    capacity INTEGER NOT NULL,
-                    actualCount INTEGER NOT NULL,
-                    excess INTEGER NOT NULL,
-                    teams TEXT NOT NULL
-                )
-                """
-            )
-            connection.commit()
 
     def _insert_job(self, job_id: str, job_type: str, payload: dict[str, object]) -> None:
-        with closing(sqlite3.connect(self.db_path)) as connection:
+        with self._connect() as connection:
             connection.execute(
                 """
-                INSERT INTO BackgroundJob (
-                    id, jobType, status, payload, attemptCount,
-                    availableAt, createdAt, updatedAt
-                ) VALUES (?, ?, 'PENDING', ?, 0, datetime('now', '-1 minute'), datetime('now'), datetime('now'))
+                INSERT INTO "BackgroundJob" (
+                    id, "jobType", status, payload, "attemptCount",
+                    "availableAt", "createdAt", "updatedAt"
+                ) VALUES (%s, %s, 'PENDING', %s, 0, now() - interval '1 minute', now(), now())
                 """,
                 (job_id, job_type, json.dumps(payload)),
             )
-            connection.commit()
 
-    def _fetch_job(self, job_id: str) -> sqlite3.Row:
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.row_factory = sqlite3.Row
-            row: sqlite3.Row | None = connection.execute(
-                "SELECT * FROM BackgroundJob WHERE id = ?",
-                (job_id,),
+    def _fetch_job(self, job_id: str) -> dict[str, Any]:
+        with self._connect() as connection:
+            row = connection.execute(
+                'SELECT * FROM "BackgroundJob" WHERE id = %s', (job_id,)
             ).fetchone()
 
         assert row is not None
@@ -1312,36 +1166,42 @@ class WorkerTests(unittest.TestCase):
         *,
         provider_message_id: str | None = None,
     ) -> None:
-        with closing(sqlite3.connect(self.db_path)) as connection:
+        with self._connect() as connection:
             connection.execute(
                 """
-                INSERT INTO Notification (id, providerMessageId, status, lastError, updatedAt)
-                VALUES (?, ?, 'SENT', NULL, CURRENT_TIMESTAMP)
+                INSERT INTO "NotificationEvent" (id, "eventType")
+                VALUES (%s, 'USER_CREATED')
+                ON CONFLICT (id) DO NOTHING
+                """,
+                (f"event-{notification_id}",),
+            )
+            connection.execute(
+                """
+                INSERT INTO "Notification" (
+                    id, "eventId", "recipientEmail", subject, "bodyText",
+                    "providerMessageId", status, "lastError", "updatedAt"
+                ) VALUES (%s, %s, 'person@example.com', 'Subject', 'Body', %s, 'SENT', NULL, now())
                 """,
                 (
                     notification_id,
+                    f"event-{notification_id}",
                     provider_message_id or f"<provider-{notification_id}@example.com>",
                 ),
             )
-            connection.commit()
 
-    def _fetch_notification(self, notification_id: str) -> sqlite3.Row:
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.row_factory = sqlite3.Row
-            row: sqlite3.Row | None = connection.execute(
-                "SELECT * FROM Notification WHERE id = ?",
-                (notification_id,),
+    def _fetch_notification(self, notification_id: str) -> dict[str, Any]:
+        with self._connect() as connection:
+            row = connection.execute(
+                'SELECT * FROM "Notification" WHERE id = %s', (notification_id,)
             ).fetchone()
 
         assert row is not None
         return row
 
-    def _fetch_inbound_email(self, inbound_email_id: str) -> sqlite3.Row:
-        with closing(sqlite3.connect(self.db_path)) as connection:
-            connection.row_factory = sqlite3.Row
-            row: sqlite3.Row | None = connection.execute(
-                "SELECT * FROM InboundEmail WHERE id = ?",
-                (inbound_email_id,),
+    def _fetch_inbound_email(self, inbound_email_id: str) -> dict[str, Any]:
+        with self._connect() as connection:
+            row = connection.execute(
+                'SELECT * FROM "InboundEmail" WHERE id = %s', (inbound_email_id,)
             ).fetchone()
 
         assert row is not None

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 import psycopg
 from psycopg.rows import dict_row
 from worker_db import ensure_worker_database, truncate_all

--- a/webapp/worker/tests/worker_db.py
+++ b/webapp/worker/tests/worker_db.py
@@ -1,0 +1,105 @@
+"""PostgreSQL test database for the worker suite.
+
+The worker runs against PostgreSQL in every environment, so its tests do too.
+The schema comes from the real Prisma migrations rather than a hand-written copy,
+which is what let the SQLite fixture drift out of step with production.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import psycopg
+from psycopg import sql
+
+# The worker tests get their own database on the shared E2E PostgreSQL container.
+# Sharing business_app_starter_e2e_test would let a Playwright run and a pytest run
+# truncate each other's rows.
+DEFAULT_TEST_DATABASE_URL = (
+    "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_worker_test"
+)
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "prisma" / "migrations-postgres"
+
+_schema_ready = False
+
+
+def worker_test_database_url() -> str:
+    return os.environ.get("WORKER_TEST_DATABASE_URL", DEFAULT_TEST_DATABASE_URL)
+
+
+def _maintenance_conninfo(database_url: str) -> tuple[str, str]:
+    """Split a database URL into (conninfo against the 'postgres' db, target db name)."""
+    parsed = psycopg.conninfo.conninfo_to_dict(database_url)
+    database = str(parsed.get("dbname") or "")
+    if not database:
+        raise RuntimeError(f"WORKER_TEST_DATABASE_URL has no database name: {database_url}")
+    return psycopg.conninfo.make_conninfo(database_url, dbname="postgres"), database
+
+
+def _ensure_database(database_url: str) -> None:
+    maintenance_conninfo, database = _maintenance_conninfo(database_url)
+    try:
+        with psycopg.connect(maintenance_conninfo, autocommit=True) as connection:
+            exists = connection.execute(
+                "SELECT 1 FROM pg_database WHERE datname = %s", (database,)
+            ).fetchone()
+            if not exists:
+                connection.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database)))
+    except psycopg.OperationalError as error:
+        raise RuntimeError(
+            f"Cannot reach PostgreSQL for the worker tests ({database_url}).\n"
+            "Start the E2E PostgreSQL container first:\n"
+            "  pnpm run e2e:db          (from webapp/)\n"
+            "or point WORKER_TEST_DATABASE_URL at another PostgreSQL instance."
+        ) from error
+
+
+def _apply_migrations(database_url: str) -> None:
+    migrations = sorted(
+        path for path in MIGRATIONS_DIR.iterdir() if (path / "migration.sql").is_file()
+    )
+    if not migrations:
+        raise RuntimeError(f"No migrations found under {MIGRATIONS_DIR}")
+
+    with psycopg.connect(database_url, autocommit=True) as connection:
+        connection.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        connection.execute("CREATE SCHEMA public")
+        for migration in migrations:
+            statement = (migration / "migration.sql").read_text(encoding="utf-8")
+            try:
+                connection.execute(statement)
+            except psycopg.Error as error:
+                raise RuntimeError(f"Migration {migration.name} failed: {error}") from error
+
+
+def ensure_worker_database() -> str:
+    """Create and migrate the worker test database once per process."""
+    global _schema_ready
+    database_url = worker_test_database_url()
+    if not _schema_ready:
+        _ensure_database(database_url)
+        _apply_migrations(database_url)
+        _schema_ready = True
+    return database_url
+
+
+def truncate_all(database_url: str) -> None:
+    with psycopg.connect(database_url, autocommit=True) as connection:
+        tables = [
+            str(row[0])
+            for row in connection.execute(
+                """
+                SELECT tablename FROM pg_tables
+                WHERE schemaname = 'public' AND tablename <> '_prisma_migrations'
+                """
+            ).fetchall()
+        ]
+        if not tables:
+            return
+        connection.execute(
+            sql.SQL("TRUNCATE TABLE {} RESTART IDENTITY CASCADE").format(
+                sql.SQL(", ").join(sql.Identifier(table) for table in tables)
+            )
+        )


### PR DESCRIPTION
## Why

The webapp became PostgreSQL-only in `800e1c7` (2026-07-10), but the worker was not part of that commit. SQLite survived in it as a **test fixture and nothing else** — every `JobStore` test built its store with a `file:` URL, so the suite exercised 30 `_is_sqlite` branches that production never runs.

Those tests were not gating anything either: CI ran ruff, mypy, and complexity checks over the worker, but **never pytest**.

The fixture's schema was 13 tables hand-written in `test_main.py`, against the real migrations' **37**. It had already drifted — PR #7 added `RasterSnapshotScope` inserts to the PostgreSQL branch only, and no test noticed, because the SQLite test schema had no such table.

## What changed

**Tests first, then removal.** The safety net had to exist before 1870 lines of `db.py` could be touched.

- Worker tests now run against real PostgreSQL, schema built from `prisma/migrations-postgres` via psycopg — no Node dependency, and no hand-written schema left to drift.
- They use their own `business_app_starter_worker_test` database. Sharing the E2E singleton would let a concurrent Playwright run truncate rows underneath them.
- **CI now runs pytest** (`validate.yml`), and `validate.ps1` provisions PostgreSQL before pytest instead of leaving it to fail on a clean machine.
- `db.py`: −624 lines. 30 `_is_sqlite` branches and 5 SQLite-only helpers gone. Public method surface unchanged — the only removed `def`s are `_claim_sqlite_job`, `_fail_sqlite_job`, `_requeue_stale_sqlite_jobs`, `_sqlite_conn`, `_sqlite_timestamp_after_seconds`.

**Two silent fallbacks now fail loudly:**

- `normalize_postgres_database_url` rejects any non-PostgreSQL URL.
- `load_config` no longer defaults to `file:./dev.db`. That default meant a misconfigured production worker would quietly run against a SQLite file rather than refusing to start.

Both are covered by tests.

**Docs.** Several actively misdescribed reality: `AUTH_FLOWS.md` pointed at `prisma/schema.prisma` and `cli/README.md` at `scripts/ensure-local-db.mjs` — both deleted in July. The constitution's database constraint is amended (1.1.0) with rationale, and the best-practices review's PR6 is marked resolved: it predicted this exact drift and listed the sync options, but the drift landed in the worker's test schema, where the finding was not looking.

## Verification

`29 passed`, ruff clean, mypy clean on 11 files, `quality:python` exit 0, `check-text-conventions` exit 0.

The store tests now hand `JobStore` a `postgresql://` URL, so they exercise the branch production runs — which they never did before.

## Reviewer notes

- **CI has never run pytest**, so the workflow change is the one thing not verifiable locally. The container provisioning it depends on already runs in that job via Playwright's `globalSetup`, and `uv run` syncs the dev group itself, so the risk is low — but the first CI run is the real check.
- **The constitution mandates a version bump but carried no version** — only `Last updated: 2026-03-19`. I set 1.1.0 and treated the existing text as 1.0.0 to give the bump a baseline. Arguably this is MAJOR by their own rules (incompatible redefinition of a constraint); say the word and I will change it.
- Left alone deliberately: `constitution-template.md` (a reusable template for *other* projects, SHOULD/MAY language), `AGENTS.md:23` (speckit auto-generated, feature-tagged log — editing falsifies 017's record), and the numbered feature specs 010–018 (point-in-time records).

Separate from #7, which needs its combined-planning merge bugs fixed regardless.