### PR TITLE
Fix combined planning: coverage, wishes, capacities, fixed numbers

### DIFF
--- a/scripts/solve-raster-cpsat.py
+++ b/scripts/solve-raster-cpsat.py
@@ -83,6 +83,19 @@ def circle_pairs(size: str) -> list[list[dict[str, int]]]:
     return rounds
 
 
+def group_key(group: dict[str, Any]) -> str:
+    """Identity of a group within one solve.
+
+    League + name is unique inside a single scope, but a combined run merges
+    several: two Bezirke can each have a "Kreisliga" / "Gruppe 1". The merged
+    model tags every group with its scopeId, so include it when present. Models
+    from a single scope carry no scopeId and keep their existing key.
+    """
+    base = str(group["ref"]["league"]) + "::" + str(group["ref"]["name"])
+    scope_id = group.get("scopeId")
+    return f"{scope_id}::{base}" if scope_id else base
+
+
 def raster_values_for_group(group: dict[str, Any]) -> range:
     return range(1, numeric_raster_size(raster_key_for_group(group)) + 1)
 
@@ -305,9 +318,9 @@ def main() -> None:
             if kind in ("fixed", "pinned"):
                 model.add(var == int(team["rasterzahl"]["value"]))
         if int(group["size"]) % 2 == 1:
-            group_key = str(group["ref"]["league"]) + "::" + str(group["ref"]["name"])
+            group_id = group_key(group)
             bye_var = model.new_int_var(1, numeric_raster_size(raster_key_for_group(group)), f"bye_{len(bye)}")
-            bye[group_key] = bye_var
+            bye[group_id] = bye_var
             model.add_all_different([*group_vars, bye_var])
         else:
             model.add_all_different(group_vars)
@@ -339,8 +352,7 @@ def main() -> None:
         group = team_group.get(team_id)
         if not group:
             continue
-        group_key = str(group["ref"]["league"]) + "::" + str(group["ref"]["name"])
-        bye_var = bye.get(group_key)
+        bye_var = bye.get(group_key(group))
         all_weeks = sorted({
             week
             for value in raster_values_for_group(group)
@@ -426,8 +438,8 @@ def main() -> None:
         if not team_a or not team_b or not group_a or not group_b:
             continue
         ok_pairs = []
-        key_a = str(group_a["ref"]["league"]) + "::" + str(group_a["ref"]["name"])
-        key_b = str(group_b["ref"]["league"]) + "::" + str(group_b["ref"]["name"])
+        key_a = group_key(group_a)
+        key_b = group_key(group_b)
         bye_a = bye.get(key_a)
         bye_b = bye.get(key_b)
         same_bye = bye_a is not None and bye_a is bye_b
@@ -476,8 +488,8 @@ def main() -> None:
                 group_a = team_group[left_id]
                 group_b = team_group[right_id]
                 expected = "zeitgleich" if left["spielwochePref"] == right["spielwochePref"] else "wechsel"
-                key_a = str(group_a["ref"]["league"]) + "::" + str(group_a["ref"]["name"])
-                key_b = str(group_b["ref"]["league"]) + "::" + str(group_b["ref"]["name"])
+                key_a = group_key(group_a)
+                key_b = group_key(group_b)
                 bye_a = bye.get(key_a)
                 bye_b = bye.get(key_b)
                 same_bye = bye_a is not None and bye_a is bye_b

--- a/webapp/src/app/api/raster/combined/[id]/runs/route.ts
+++ b/webapp/src/app/api/raster/combined/[id]/runs/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
 import { startRasterRunResponse } from "@/app/api/raster/_lib/start-run-response";
+import { logRasterAudit } from "@/lib/raster/audit";
 import { requireApiUser } from "@/lib/route-auth";
-import { canUseRasterLevel } from "@/lib/raster/access";
+import { assertRasterAccess } from "@/lib/raster/access";
 import { prisma } from "@/lib/db";
+import { AuditAction } from "../../../../../../../generated/prisma/enums";
 
 export async function POST(
   request: Request,
@@ -10,13 +12,13 @@ export async function POST(
 ) {
   const auth = await requireApiUser(request);
   if ("error" in auth) return auth.error;
-  if (!canUseRasterLevel(auth.user, "admin")) {
-    return NextResponse.json({ error: "Not authorized" }, { status: 403 });
-  }
 
   const inputSet = await prisma.rasterInputSet.findUnique({
     where: { id: (await params).id },
-    select: { id: true, spannedScopes: { select: { scopeId: true } } },
+    select: {
+      id: true,
+      spannedScopes: { select: { scope: { select: { code: true } } } },
+    },
   });
   if (!inputSet || inputSet.spannedScopes.length < 2) {
     return NextResponse.json(
@@ -25,8 +27,28 @@ export async function POST(
     );
   }
 
+  // Every spanned scope is checked, not just an owning one: a combined run
+  // plans them all, so access to one must not carry access to the rest.
+  for (const { scope } of inputSet.spannedScopes) {
+    const access = await assertRasterAccess(auth.user, scope.code, "admin");
+    if (access !== true) return access.error;
+  }
+
   return startRasterRunResponse(request, {
     inputSetId: inputSet.id,
     startedById: auth.user.id,
+    onStarted: async ({ run, settings }) => {
+      await logRasterAudit({
+        action: AuditAction.RASTER_RUN_STARTED,
+        actorId: auth.user.id,
+        scope: inputSet.spannedScopes
+          .map(({ scope }) => scope.code)
+          .sort()
+          .join(","),
+        entityType: "RasterOptimizationRun",
+        entityId: run.id,
+        details: { inputSetId: inputSet.id, settings, combined: true },
+      });
+    },
   });
 }

--- a/webapp/src/components/raster/coverage/coverage-detail.tsx
+++ b/webapp/src/components/raster/coverage/coverage-detail.tsx
@@ -18,6 +18,12 @@ export function CoverageDetail({
           Scopes: {coverage.spannedScopes.join(", ")}
           {coverage.spannedAll ? "" : " (subset)"}
         </p>
+        {coverage.scopesWithoutInputSet?.length ? (
+          <p>
+            Scopes with no inputs at all:{" "}
+            {coverage.scopesWithoutInputSet.join(", ")}
+          </p>
+        ) : null}
         {coverage.excludedGroups.length ? (
           <p>Excluded groups: {coverage.excludedGroups.join(", ")}</p>
         ) : null}

--- a/webapp/src/lib/raster/coverage.ts
+++ b/webapp/src/lib/raster/coverage.ts
@@ -22,6 +22,8 @@ export type CoverageRecord = {
   complete: boolean;
   spannedScopes: string[];
   spannedAll: boolean;
+  /** Spanned scopes with no input set for the season: the run saw nothing there. */
+  scopesWithoutInputSet: string[];
   excludedGroups: string[];
   wishGaps: Array<{
     teamId: string;
@@ -43,6 +45,7 @@ export function computeCoverageRecord(input: {
   seasonModelJson?: string | null;
   spannedScopeIds: string[];
   allScopeIds: string[];
+  scopesWithoutInputSet?: string[];
   capacityReview?: {
     rows: Array<{
       clubId: string;
@@ -81,8 +84,12 @@ export function computeCoverageRecord(input: {
       weekday: row.weekday,
       status: row.status,
     }));
+  const scopesWithoutInputSet = [
+    ...new Set(input.scopesWithoutInputSet ?? []),
+  ].sort();
   const complete =
     spannedAll &&
+    scopesWithoutInputSet.length === 0 &&
     excludedGroups.length === 0 &&
     wishGaps.length === 0 &&
     capacityGaps.length === 0;
@@ -91,6 +98,7 @@ export function computeCoverageRecord(input: {
     complete,
     spannedScopes,
     spannedAll,
+    scopesWithoutInputSet,
     excludedGroups,
     wishGaps,
     capacityGaps,
@@ -106,11 +114,23 @@ export async function buildCoverageRecordForInputSet(inputSetId: string) {
     where: { id: inputSetId },
     select: {
       scopeId: true,
+      season: true,
       seasonModelJson: true,
       spannedScopes: { select: { scopeId: true } },
     },
   });
   if (!inputSet) throw new Error("Input set not found");
+
+  // A combined input set has no sources of its own, so its seasonModelJson is
+  // never populated. Reading it here would record every combined run as having
+  // no gaps at all -- and mark an all-scope run complete (FR-034). The gaps live
+  // in the spanned scopes' own input sets.
+  if (inputSet.spannedScopes.length > 1) {
+    return buildCoverageRecordForScopes(
+      inputSet.spannedScopes.map((scope) => scope.scopeId),
+      inputSet.season,
+    );
+  }
 
   const allScopes = await prisma.scope.findMany({
     select: {
@@ -187,6 +207,11 @@ export async function buildCoverageRecordForScopes(
     allScopeIds: allScopes
       .filter(isSelectableRasterScope)
       .map((scope) => scope.id),
+    // A scope with no input set yields no groups and no teams, so it would
+    // otherwise contribute no gaps and read as fully covered.
+    scopesWithoutInputSet: scopeIds.filter(
+      (scopeId) => !latestByScope.has(scopeId),
+    ),
     capacityReview: {
       rows: records.flatMap(({ capacityReview }) => capacityReview.rows),
     },

--- a/webapp/tests/integration/raster-combined-run.test.ts
+++ b/webapp/tests/integration/raster-combined-run.test.ts
@@ -11,9 +11,14 @@ vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/route-auth", () => ({ requireApiUser }));
 vi.mock("@/lib/raster/access", () => ({
   canUseRasterLevel: () => true,
+  assertRasterAccess: vi.fn().mockResolvedValue(true),
   listAccessibleRasterScopes: vi
     .fn()
     .mockResolvedValue([{ id: "scope-a" }, { id: "scope-b" }]),
+}));
+
+vi.mock("@/lib/raster/audit", () => ({
+  logRasterAudit: vi.fn(),
 }));
 vi.mock("@/services/raster", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/services/raster")>()),
@@ -45,7 +50,10 @@ describe("combined raster runs", () => {
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       id: "input-1",
       status: "DRAFT",
-      spannedScopes: [{ scopeId: "scope-a" }, { scopeId: "scope-b" }],
+      spannedScopes: [
+        { scope: { code: "scope-a" } },
+        { scope: { code: "scope-b" } },
+      ],
     } as never);
     startOptimizationRun.mockResolvedValue({ id: "run-1" });
 

--- a/webapp/tests/integration/raster-combined-upper-league.test.ts
+++ b/webapp/tests/integration/raster-combined-upper-league.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 
+const combinedModelTests = [
+  // FR-013: the run decides the upper-league numbers rather than inheriting them.
+  "test_combined_raster_model_unfixes_inherited_but_keeps_pins",
+  // FR-014: numbers supplied for the combined set stay hard constraints.
+  "test_combined_raster_model_honours_numbers_supplied_for_the_combined_set",
+  // The merge must leave wishes and shared clubs resolvable across scopes.
+  "test_combined_raster_model_keeps_ids_so_wishes_and_clubs_still_resolve",
+  "test_combined_raster_model_keeps_every_venue_of_a_shared_club",
+  "test_combined_raster_model_tags_groups_with_scope_to_keep_them_distinct",
+];
+
 describe("combined raster upper-league constraints", () => {
-  it("does not inherit fixed Rasterzahlen from separate scope models", () => {
+  it("builds the combined solver model to spec", () => {
     const workerDir = path.resolve(__dirname, "../../worker");
     const result = spawnSync(
       "uv",
@@ -12,7 +23,9 @@ describe("combined raster upper-league constraints", () => {
         "python",
         "-m",
         "unittest",
-        "tests.test_main.WorkerTests.test_combined_raster_model_prefixes_scopes_and_drops_inherited_fixed_numbers",
+        ...combinedModelTests.map(
+          (name) => `tests.test_main.WorkerTests.${name}`,
+        ),
       ],
       { cwd: workerDir, encoding: "utf8" },
     );

--- a/webapp/tests/unit/raster-combined-runs-route.test.ts
+++ b/webapp/tests/unit/raster-combined-runs-route.test.ts
@@ -1,11 +1,15 @@
+import { NextResponse } from "next/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { prismaMock } from "@/lib/__mocks__/db";
 import { Role, UserStatus } from "../../generated/prisma/enums";
 
-const { requireApiUser, startOptimizationRun } = vi.hoisted(() => ({
-  requireApiUser: vi.fn(),
-  startOptimizationRun: vi.fn(),
-}));
+const { requireApiUser, startOptimizationRun, assertRasterAccess, logRasterAudit } =
+  vi.hoisted(() => ({
+    requireApiUser: vi.fn(),
+    startOptimizationRun: vi.fn(),
+    assertRasterAccess: vi.fn(),
+    logRasterAudit: vi.fn(),
+  }));
 
 vi.mock("@/lib/db", () => ({
   prisma: prismaMock,
@@ -17,6 +21,11 @@ vi.mock("@/lib/route-auth", () => ({
 
 vi.mock("@/lib/raster/access", () => ({
   canUseRasterLevel: () => true,
+  assertRasterAccess,
+}));
+
+vi.mock("@/lib/raster/audit", () => ({
+  logRasterAudit,
 }));
 
 vi.mock("@/services/raster", () => ({
@@ -30,7 +39,7 @@ describe("raster combined runs route", () => {
     vi.clearAllMocks();
   });
 
-  it("starts a combined run without requiring READY status", async () => {
+  const signedInAdmin = () =>
     requireApiUser.mockResolvedValue({
       user: {
         id: "admin-1",
@@ -38,14 +47,16 @@ describe("raster combined runs route", () => {
         status: UserStatus.ACTIVE,
       },
     });
+
+  const combinedInputSet = () =>
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       id: "input-1",
       status: "DRAFT",
-      spannedScopes: [{ scopeId: "a" }, { scopeId: "b" }],
+      spannedScopes: [{ scope: { code: "a" } }, { scope: { code: "b" } }],
     } as never);
-    startOptimizationRun.mockResolvedValue({ id: "run-1" });
 
-    const response = await POST(
+  const startRun = () =>
+    POST(
       new Request("http://localhost/api/raster/combined/input-1/runs", {
         method: "POST",
         body: JSON.stringify({ timeLimitSeconds: 60 }),
@@ -53,11 +64,55 @@ describe("raster combined runs route", () => {
       { params: Promise.resolve({ id: "input-1" }) },
     );
 
+  it("starts a combined run without requiring READY status", async () => {
+    signedInAdmin();
+    combinedInputSet();
+    assertRasterAccess.mockResolvedValue(true);
+    startOptimizationRun.mockResolvedValue({ id: "run-1" });
+
+    const response = await startRun();
+
     expect(response.status).toBe(202);
     expect(startOptimizationRun).toHaveBeenCalledWith({
       inputSetId: "input-1",
       startedById: "admin-1",
       settings: { strategy: "cp_sat", timeLimitSeconds: 60, weights: {} },
     });
+  });
+
+  it("checks access for every spanned scope, not just one", async () => {
+    signedInAdmin();
+    combinedInputSet();
+    assertRasterAccess.mockResolvedValue(true);
+    startOptimizationRun.mockResolvedValue({ id: "run-1" });
+
+    await startRun();
+
+    expect(assertRasterAccess).toHaveBeenCalledTimes(2);
+    expect(assertRasterAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "admin-1" }),
+      "a",
+      "admin",
+    );
+    expect(assertRasterAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "admin-1" }),
+      "b",
+      "admin",
+    );
+  });
+
+  it("refuses the run when any spanned scope is not accessible", async () => {
+    signedInAdmin();
+    combinedInputSet();
+    assertRasterAccess.mockImplementation(async (_user, code: string) =>
+      code === "b"
+        ? { error: NextResponse.json({ error: "Nope" }, { status: 403 }) }
+        : true,
+    );
+
+    const response = await startRun();
+
+    expect(response.status).toBe(403);
+    expect(startOptimizationRun).not.toHaveBeenCalled();
   });
 });

--- a/webapp/tests/unit/raster/coverage-combined.test.ts
+++ b/webapp/tests/unit/raster/coverage-combined.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prismaMock } from "@/lib/__mocks__/db";
+
+const { reviewHallCapacitiesForInputSet } = vi.hoisted(() => ({
+  reviewHallCapacitiesForInputSet: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/services/raster/capacity", () => ({
+  reviewHallCapacitiesForInputSet,
+}));
+
+import { buildCoverageRecordForInputSet } from "@/lib/raster/coverage";
+
+const bezirk = (id: string) => ({
+  id,
+  parent: { code: "WTTV", parent: { code: "DE" } },
+});
+
+const scopeModel = (teamId: string, excludedGroupId?: string) =>
+  JSON.stringify({
+    groups: excludedGroupId
+      ? [{ id: excludedGroupId, planningStatus: "exclude", teamIds: [] }]
+      : [],
+    teams: [
+      {
+        id: teamId,
+        wishMatchId: undefined,
+        homeWeekday: undefined,
+        hall: undefined,
+        startTime: undefined,
+      },
+    ],
+  });
+
+describe("coverage for a combined input set", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A combined input set has no sources of its own, so its own seasonModelJson
+  // is always null. Reading it recorded every combined run as gap-free.
+  it("reads the spanned scopes' models rather than its own empty one", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      scopeId: "scope-a",
+      season: "2026/27",
+      seasonModelJson: null,
+      spannedScopes: [{ scopeId: "scope-a" }, { scopeId: "scope-b" }],
+    } as never);
+    prismaMock.rasterInputSet.findMany.mockResolvedValue([
+      { id: "set-a", scopeId: "scope-a", seasonModelJson: scopeModel("team-a") },
+      {
+        id: "set-b",
+        scopeId: "scope-b",
+        seasonModelJson: scopeModel("team-b", "group-b"),
+      },
+    ] as never);
+    prismaMock.scope.findMany.mockResolvedValue([
+      bezirk("scope-a"),
+      bezirk("scope-b"),
+    ] as never);
+    reviewHallCapacitiesForInputSet.mockResolvedValue({ rows: [] });
+
+    const coverage = await buildCoverageRecordForInputSet("combined-1");
+
+    expect(coverage.complete).toBe(false);
+    expect(coverage.spannedScopes).toEqual(["scope-a", "scope-b"]);
+    // The gaps are named, not merely counted (FR-032, FR-037).
+    expect(coverage.wishGaps.map((gap) => gap.teamId).sort()).toEqual([
+      "team-a",
+      "team-b",
+    ]);
+    expect(coverage.excludedGroups).toEqual(["group-b"]);
+  });
+
+  // Spanning every scope with gaps is the case that used to come out complete.
+  it("does not call an all-scope run with gaps complete", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      scopeId: "scope-a",
+      season: "2026/27",
+      seasonModelJson: null,
+      spannedScopes: [{ scopeId: "scope-a" }, { scopeId: "scope-b" }],
+    } as never);
+    prismaMock.rasterInputSet.findMany.mockResolvedValue([
+      { id: "set-a", scopeId: "scope-a", seasonModelJson: scopeModel("team-a") },
+      { id: "set-b", scopeId: "scope-b", seasonModelJson: scopeModel("team-b") },
+    ] as never);
+    prismaMock.scope.findMany.mockResolvedValue([
+      bezirk("scope-a"),
+      bezirk("scope-b"),
+    ] as never);
+    reviewHallCapacitiesForInputSet.mockResolvedValue({ rows: [] });
+
+    const coverage = await buildCoverageRecordForInputSet("combined-1");
+
+    expect(coverage.spannedAll).toBe(true);
+    expect(coverage.complete).toBe(false);
+  });
+
+  // Edge case from the spec: the run spans the scope and finds nothing there.
+  it("records a spanned scope that has no input set at all", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      scopeId: "scope-a",
+      season: "2026/27",
+      seasonModelJson: null,
+      spannedScopes: [{ scopeId: "scope-a" }, { scopeId: "scope-b" }],
+    } as never);
+    prismaMock.rasterInputSet.findMany.mockResolvedValue([
+      {
+        id: "set-a",
+        scopeId: "scope-a",
+        seasonModelJson: JSON.stringify({ groups: [], teams: [] }),
+      },
+    ] as never);
+    prismaMock.scope.findMany.mockResolvedValue([
+      bezirk("scope-a"),
+      bezirk("scope-b"),
+    ] as never);
+    reviewHallCapacitiesForInputSet.mockResolvedValue({ rows: [] });
+
+    const coverage = await buildCoverageRecordForInputSet("combined-1");
+
+    expect(coverage.scopesWithoutInputSet).toEqual(["scope-b"]);
+    expect(coverage.complete).toBe(false);
+  });
+});

--- a/webapp/worker/src/starter_worker/db.py
+++ b/webapp/worker/src/starter_worker/db.py
@@ -403,6 +403,19 @@ class JobStore:
                         (row["scopeIds"], row["season"], row["inputSetId"]),
                     )
                     row["seasonModels"] = list(cursor.fetchall())
+                    # Numbers supplied for the combined set itself are the
+                    # admin's own hard constraints and must be honoured (FR-014).
+                    # They are not in any spanned scope's model, so load them
+                    # from the combined input set directly.
+                    cursor.execute(
+                        """
+                        SELECT "clubId", "teamLabel", rasterzahl
+                        FROM "RasterFixedRasterzahl"
+                        WHERE "inputSetId" = %s
+                        """,
+                        (row["inputSetId"],),
+                    )
+                    row["fixedRasterzahlen"] = list(cursor.fetchall())
                 elif row is not None:
                     row["scopeIds"] = [row["scopeId"]]
                     row["seasonModels"] = [

--- a/webapp/worker/src/starter_worker/db.py
+++ b/webapp/worker/src/starter_worker/db.py
@@ -1698,7 +1698,9 @@ def _inferred_capacities(teams: list[dict[str, Any]]) -> dict[tuple[str, str, st
 def _group_key(group: dict[str, Any]) -> str:
     raw_ref = group.get("ref")
     ref: dict[str, Any] = raw_ref if isinstance(raw_ref, dict) else {}
-    return f"{ref.get('league') or ''}::{ref.get('name') or ''}"
+    base = f"{ref.get('league') or ''}::{ref.get('name') or ''}"
+    scope_id = str(group.get("scopeId") or "")
+    return f"{scope_id}::{base}" if scope_id else base
 
 
 def _unused_rasterzahl(group: dict[str, Any], assignment: dict[str, Any]) -> int | None:

--- a/webapp/worker/src/starter_worker/main.py
+++ b/webapp/worker/src/starter_worker/main.py
@@ -146,14 +146,25 @@ def _json_list(model: dict[str, object], key: str) -> list[object]:
 
 
 def _raster_run_model(context: dict[str, Any]) -> dict[str, object]:
+    """Build the solver model, merging every spanned scope for a combined run.
+
+    Model ids are derived from names, not rows: a club's id is a slug of its
+    name and a team's id embeds its club and group. They are therefore already
+    stable across scopes, and a club fielding both a Verband and a Bezirk team
+    carries the same id in both models -- which is exactly what a combined run
+    needs, since hall capacity and same-club spacing key off clubId. So the
+    models are merged as-is. Rewriting ids per scope would not resolve a
+    collision; it would invent one, and silently detach wishes, capacities, and
+    the two halves of that club from each other.
+    """
     season_models = context.get("seasonModels")
     if not isinstance(season_models, list) or not season_models:
         return _parse_json_object(context["seasonModelJson"], "seasonModelJson")
     if len(season_models) == 1:
         return _parse_json_object(season_models[0].get("seasonModelJson"), "seasonModelJson")
 
+    clubs: dict[str, dict[str, object]] = {}
     merged: dict[str, list[object]] = {
-        "clubs": [],
         "teams": [],
         "groups": [],
         "wishes": [],
@@ -166,69 +177,106 @@ def _raster_run_model(context: dict[str, Any]) -> dict[str, object]:
         scope_id = str(row.get("scopeId") or "").strip()
         if not scope_id:
             continue
-        scoped = _scope_prefixed_model(
-            _parse_json_object(row.get("seasonModelJson"), "seasonModelJson"),
-            scope_id,
-        )
-        for key in ("clubs", "teams", "groups", "wishes", "absoluteConstraints", "warnings"):
-            value = scoped.get(key)
+        model = _parse_json_object(row.get("seasonModelJson"), "seasonModelJson")
+
+        for club in _json_list(model, "clubs"):
+            if isinstance(club, dict):
+                _merge_club(clubs, club)
+
+        for team in _json_list(model, "teams"):
+            if isinstance(team, dict):
+                merged["teams"].append(_combined_team(team))
+
+        for group in _json_list(model, "groups"):
+            if isinstance(group, dict):
+                # League + name repeats across Bezirke; the solver needs the
+                # scope to tell two "Gruppe 1"s apart. See group_key() there.
+                merged["groups"].append({**group, "scopeId": scope_id})
+
+        for key in ("wishes", "absoluteConstraints", "warnings"):
+            value = model.get(key)
             if isinstance(value, list):
                 merged[key].extend(value)
-    return cast(dict[str, object], merged)
+
+    merged["teams"] = _with_supplied_fixed_numbers(
+        merged["teams"], context.get("fixedRasterzahlen")
+    )
+    return cast(dict[str, object], {"clubs": list(clubs.values()), **merged})
 
 
-def _scope_prefixed_model(model: dict[str, object], scope_id: str) -> dict[str, object]:
-    def prefixed(value: object) -> str:
-        return f"{scope_id}:{value}"
+def _with_supplied_fixed_numbers(
+    teams: list[object], fixed_rows: object
+) -> list[object]:
+    """Apply Rasterzahlen supplied for the combined input set itself (FR-014).
 
-    team_ids: dict[str, str] = {}
-    club_ids: dict[str, str] = {}
-    clubs: list[object] = []
-    for club in _json_list(model, "clubs"):
-        if not isinstance(club, dict):
+    _combined_team() unfixes the numbers inherited from each scope, since the
+    run decides those. Numbers the admin supplied against the combined set are
+    the opposite case: they are deliberate hard constraints for this run.
+    """
+    if not isinstance(fixed_rows, list) or not fixed_rows:
+        return teams
+    supplied: dict[tuple[str, str], int] = {}
+    for fixed in fixed_rows:
+        if not isinstance(fixed, dict):
             continue
-        old_id = str(club.get("id") or "")
-        next_club = {**club, "id": prefixed(old_id)}
-        club_ids[old_id] = str(next_club["id"])
-        clubs.append(next_club)
+        club_id = str(fixed.get("clubId") or "")
+        label = str(fixed.get("teamLabel") or "")
+        value = fixed.get("rasterzahl")
+        if club_id and label and isinstance(value, int):
+            supplied[(club_id, label)] = value
 
-    teams: list[object] = []
-    for team in _json_list(model, "teams"):
+    applied: list[object] = []
+    for team in teams:
         if not isinstance(team, dict):
+            applied.append(team)
             continue
-        old_id = str(team.get("id") or "")
-        next_team = {
-            **team,
-            "id": prefixed(old_id),
-            "clubId": club_ids.get(str(team.get("clubId") or ""), prefixed(team.get("clubId") or "")),
-            "rasterzahl": {"kind": "assignable"},
-        }
-        team_ids[old_id] = str(next_team["id"])
-        teams.append(next_team)
+        key = (str(team.get("clubId") or ""), str(team.get("label") or ""))
+        value = supplied.get(key)
+        if value is None:
+            applied.append(team)
+        else:
+            applied.append({**team, "rasterzahl": {"kind": "fixed", "value": value}})
+    return applied
 
-    groups: list[object] = []
-    for group in _json_list(model, "groups"):
-        if not isinstance(group, dict):
-            continue
-        team_ids_value = group.get("teamIds")
-        team_ids_list = team_ids_value if isinstance(team_ids_value, list) else []
-        groups.append(
-            {
-                **group,
-                "id": prefixed(group.get("id") or len(groups)),
-                "teamIds": [
-                    team_ids.get(str(team_id), prefixed(team_id))
-                    for team_id in team_ids_list
-                ],
-            }
-        )
 
-    return {
-        **model,
-        "clubs": clubs,
-        "teams": teams,
-        "groups": groups,
+def _merge_club(clubs: dict[str, dict[str, object]], club: dict[str, object]) -> None:
+    """Fold one scope's view of a club into the merged set, keeping every venue.
+
+    The same club can appear in several spanned scopes, each model carrying only
+    the venues its own teams play at. Taking the first would drop the others, and
+    capacity_for() resolves a team's venue through its club.
+    """
+    club_id = str(club.get("id") or "")
+    if not club_id:
+        return
+    existing = clubs.get(club_id)
+    if existing is None:
+        clubs[club_id] = dict(club)
+        return
+    venues = list(_json_list(existing, "venues"))
+    known = {
+        str(venue.get("hall")) for venue in venues if isinstance(venue, dict)
     }
+    for venue in _json_list(club, "venues"):
+        if isinstance(venue, dict) and str(venue.get("hall")) not in known:
+            venues.append(venue)
+    existing["venues"] = venues
+
+
+def _combined_team(team: dict[str, object]) -> dict[str, object]:
+    """Free the upper-league numbers a combined run exists to decide (FR-013).
+
+    A scope's model carries the upper-league Rasterzahlen it was handed as fixed
+    input, decided by an earlier Verband run without knowledge of their cost
+    here. A combined run makes those its own decision, so 'fixed' becomes
+    assignable. A 'pinned' number is different: someone chose it deliberately for
+    this plan, so it stays.
+    """
+    rasterzahl = team.get("rasterzahl")
+    kind = rasterzahl.get("kind") if isinstance(rasterzahl, dict) else None
+    if kind == "fixed":
+        return {**team, "rasterzahl": {"kind": "assignable"}}
+    return dict(team)
 
 
 def _exclude_unplanned_groups(model: dict[str, object]) -> dict[str, object]:

--- a/webapp/worker/src/starter_worker/main.py
+++ b/webapp/worker/src/starter_worker/main.py
@@ -40,6 +40,15 @@ class RasterSolverInfeasible(ValueError):
     """Raised when the optimizer proves that no assignment satisfies hard constraints."""
 
 
+class RasterInputInvalid(ValueError):
+    """Raised when the inputs cannot produce a correct model, so solving would mislead.
+
+    Distinct from incompleteness, which is recorded and allowed (FR-012): this is
+    input the run cannot interpret without silently planning the wrong thing.
+    Deterministic, so retrying the job cannot help.
+    """
+
+
 def process_job(job: BackgroundJob) -> dict[str, object]:
     if job.job_type == "noop":
         return {
@@ -149,13 +158,18 @@ def _raster_run_model(context: dict[str, Any]) -> dict[str, object]:
     """Build the solver model, merging every spanned scope for a combined run.
 
     Model ids are derived from names, not rows: a club's id is a slug of its
-    name and a team's id embeds its club and group. They are therefore already
-    stable across scopes, and a club fielding both a Verband and a Bezirk team
-    carries the same id in both models -- which is exactly what a combined run
-    needs, since hall capacity and same-club spacing key off clubId. So the
-    models are merged as-is. Rewriting ids per scope would not resolve a
-    collision; it would invent one, and silently detach wishes, capacities, and
+    name, a team's id embeds its club and group. So a club fielding both a
+    Verband and a Bezirk team carries one id in both models -- which is what a
+    combined run needs, since hall capacity and same-club spacing key off
+    clubId. The models therefore merge as-is. Rewriting ids per scope would not
+    resolve a collision; it would invent one, detaching wishes, capacities, and
     the two halves of that club from each other.
+
+    Name-derived ids are not a real identity, though. Two clubs sharing a name
+    in different Bezirke slug to one id. Where that also collapses two teams
+    onto one id, _reject_team_id_collision refuses the run. Where their groups
+    differ it stays undetectable, and only a genuine WTTV club number would fix
+    it -- the ingest does not capture one today.
     """
     season_models = context.get("seasonModels")
     if not isinstance(season_models, list) or not season_models:
@@ -164,6 +178,7 @@ def _raster_run_model(context: dict[str, Any]) -> dict[str, object]:
         return _parse_json_object(season_models[0].get("seasonModelJson"), "seasonModelJson")
 
     clubs: dict[str, dict[str, object]] = {}
+    team_scopes: dict[str, str] = {}
     merged: dict[str, list[object]] = {
         "teams": [],
         "groups": [],
@@ -185,6 +200,7 @@ def _raster_run_model(context: dict[str, Any]) -> dict[str, object]:
 
         for team in _json_list(model, "teams"):
             if isinstance(team, dict):
+                _reject_team_id_collision(team_scopes, team, scope_id)
                 merged["teams"].append(_combined_team(team))
 
         for group in _json_list(model, "groups"):
@@ -237,6 +253,40 @@ def _with_supplied_fixed_numbers(
         else:
             applied.append({**team, "rasterzahl": {"kind": "fixed", "value": value}})
     return applied
+
+
+def _reject_team_id_collision(
+    team_scopes: dict[str, str], team: dict[str, object], scope_id: str
+) -> None:
+    """Refuse a run whose spanned scopes disagree about who a team id names.
+
+    Team ids are derived from names -- slug(group)-slug(team) -- and the
+    uniqueness counter behind them runs per scope, so no scope can see another's
+    ids. A Verband league and a Bezirk league never share a team, so the same id
+    arriving from two scopes means two different teams collapsed onto one id:
+    two same-named clubs in the same-named group, in different Bezirke.
+
+    Merging them would plan one team where there are two and pool hall capacity
+    between clubs that share no hall. That is a wrong plan rather than an
+    incomplete one, and the coverage record cannot redeem it -- so refuse.
+
+    This does not catch every case. Two same-named clubs whose groups differ
+    still merge into one club, silently, and no name-derived id can tell them
+    apart. A real WTTV club number would; the ingest does not capture one.
+    """
+    team_id = str(team.get("id") or "")
+    if not team_id:
+        return
+    seen = team_scopes.get(team_id)
+    if seen is not None and seen != scope_id:
+        raise RasterInputInvalid(
+            f"Team id {team_id!r} arrives from both scope {seen!r} and scope "
+            f"{scope_id!r}. Ids are derived from club and group names, so this "
+            "means two different teams share a name in identically named groups. "
+            "Planning them as one team would be wrong; rename the group or the "
+            "club in the source data, or run these scopes separately."
+        )
+    team_scopes[team_id] = scope_id
 
 
 def _merge_club(clubs: dict[str, dict[str, object]], club: dict[str, object]) -> None:
@@ -956,12 +1006,15 @@ def _process_claimed_job(store: JobStore, config: WorkerConfig, job: BackgroundJ
             )
         raster_run_id = str(job.payload.get("runId") or "").strip()
         is_infeasible = isinstance(error, RasterSolverInfeasible)
+        # Both are decided by the inputs, so a retry would reach the same end.
+        # Only the infeasible one is an outcome rather than a failure.
+        is_terminal = is_infeasible or isinstance(error, RasterInputInvalid)
         if job.job_type == RASTER_RUN_JOB_TYPE and raster_run_id:
             if is_infeasible:
                 store.mark_raster_run_infeasible(raster_run_id, str(error))
             else:
                 store.mark_raster_run_failed(raster_run_id, str(error))
-        store.fail_job(job.id, str(error), retry=not is_infeasible)
+        store.fail_job(job.id, str(error), retry=not is_terminal)
         _log_job_failed(job, error)
 
 

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -7,16 +7,19 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from contextlib import closing
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
 from starter_worker.config import WorkerConfig, load_config
-from starter_worker.db import JobStore, _find_overage_rows, normalize_postgres_database_url
+from starter_worker.db import BackgroundJob, JobStore, _find_overage_rows, normalize_postgres_database_url
 from starter_worker.main import (
+    RasterInputInvalid,
     RasterSolverInfeasible,
     _exclude_unplanned_groups,
+    _process_claimed_job,
     _log_job_claimed,
     _log_job_completed,
     _log_job_failed,
@@ -395,6 +398,82 @@ class WorkerTests(unittest.TestCase):
 
         # Both are "Kreisliga / Gruppe 1"; only the scope tells them apart.
         self.assertEqual([group["scopeId"] for group in groups], ["scope-a", "scope-b"])
+
+    def test_combined_raster_model_refuses_a_team_id_claimed_by_two_scopes(self) -> None:
+        # Two different clubs sharing a name, in identically named groups, in
+        # different Bezirke: both slug to one team id.
+        def scope(scope_id: str) -> dict[str, object]:
+            return {
+                "scopeId": scope_id,
+                "seasonModelJson": json.dumps(
+                    {
+                        "clubs": [{"id": "tus-germania", "name": "TuS Germania"}],
+                        "teams": [
+                            {
+                                "id": "gruppe-1-tus-germania-i",
+                                "clubId": "tus-germania",
+                                "label": "I",
+                            }
+                        ],
+                        "groups": [
+                            {
+                                "ref": {"league": "Kreisliga", "name": "Gruppe 1"},
+                                "size": 10,
+                                "teamIds": ["gruppe-1-tus-germania-i"],
+                            }
+                        ],
+                    }
+                ),
+            }
+
+        with self.assertRaises(RasterInputInvalid) as caught:
+            _raster_run_model({"seasonModels": [scope("bezirk-a"), scope("bezirk-b")]})
+
+        self.assertIn("gruppe-1-tus-germania-i", str(caught.exception))
+        self.assertIn("bezirk-a", str(caught.exception))
+        self.assertIn("bezirk-b", str(caught.exception))
+
+    def test_invalid_combined_input_fails_the_run_without_retrying(self) -> None:
+        # The id collision is decided by the inputs, so all a retry buys is the
+        # same failure twice more.
+        store = unittest.mock.MagicMock()
+        job = BackgroundJob(
+            id="job-1",
+            job_type="raster_run",
+            payload={"runId": "run-1"},
+            attempt_count=1,
+        )
+        config = WorkerConfig(
+            database_url="postgresql://ignored/db",
+            poll_interval_seconds=0.1,
+            worker_id="worker-test",
+            max_attempts=3,
+            retry_backoff_seconds=15,
+            stale_lock_seconds=300,
+            teams_poll_interval_seconds=60,
+        )
+
+        with patch(
+            "starter_worker.main.process_raster_run",
+            side_effect=RasterInputInvalid("two teams share an id"),
+        ):
+            _process_claimed_job(store, config, job)
+
+        store.fail_job.assert_called_once_with(
+            "job-1", "two teams share an id", retry=False
+        )
+        # Not an infeasible plan; the inputs never described one.
+        store.mark_raster_run_failed.assert_called_once()
+        store.mark_raster_run_infeasible.assert_not_called()
+
+    def test_combined_raster_model_allows_one_club_across_verband_and_bezirk(self) -> None:
+        # The legitimate case the guard must not catch: one club, two teams, two
+        # scopes, different team ids. This is what combined planning is for.
+        model = _raster_run_model(self._combined_context())
+        teams = cast(list[dict[str, object]], model["teams"])
+
+        self.assertEqual(len(teams), 2)
+        self.assertEqual({str(team["clubId"]) for team in teams}, {"ttc-muster"})
 
     def test_worker_runtime_has_ortools(self) -> None:
         result = subprocess.run(

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -608,6 +608,48 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(week_11["actualCount"], 2)
         self.assertEqual(week_11["excess"], 1)
 
+    def test_persisted_overages_keep_same_named_odd_groups_distinct_by_scope(self) -> None:
+        model = {
+            "clubs": [{"id": "club", "name": "Club", "venues": [{"hall": "1", "capacity": 1}]}],
+            "teams": [
+                {
+                    "id": "team-a",
+                    "clubId": "club",
+                    "hall": "1",
+                    "homeWeekday": "friday",
+                    "rasterzahl": {"kind": "assignable"},
+                },
+                {
+                    "id": "team-b",
+                    "clubId": "club",
+                    "hall": "1",
+                    "homeWeekday": "friday",
+                    "rasterzahl": {"kind": "assignable"},
+                },
+            ],
+            "groups": [
+                {
+                    "scopeId": "scope-a",
+                    "ref": {"league": "Kreisliga", "name": "Gruppe 1"},
+                    "size": 5,
+                    "teamIds": ["team-a"],
+                },
+                {
+                    "scopeId": "scope-b",
+                    "ref": {"league": "Kreisliga", "name": "Gruppe 1"},
+                    "size": 5,
+                    "teamIds": ["team-b"],
+                },
+            ],
+        }
+
+        rows = _find_overage_rows(model, {"team-a": 1, "team-b": 2})
+
+        week_1 = next(row for row in rows if row["week"] == 1)
+        self.assertEqual([team["id"] for team in week_1["teams"]], ["team-a", "team-b"])
+        self.assertEqual(week_1["actualCount"], 2)
+        self.assertEqual(week_1["excess"], 1)
+
     def test_persisted_overages_ignore_capacity_irrelevant_teams(self) -> None:
         model = {
             "clubs": [{"id": "club", "name": "Club", "venues": [{"hall": "1", "capacity": 1}]}],

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from contextlib import closing
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import patch
 
 from starter_worker.config import WorkerConfig, load_config
@@ -251,23 +251,53 @@ class WorkerTests(unittest.TestCase):
         self.assertEqual(row, ("CANCELLED", "CANCELLED", None))
         self.assertEqual(snapshots, 0)
 
-    def test_combined_raster_model_prefixes_scopes_and_drops_inherited_fixed_numbers(self) -> None:
-        context = {
+    @staticmethod
+    def _combined_context(
+        *,
+        fixed_rasterzahlen: list[dict[str, object]] | None = None,
+    ) -> dict[str, Any]:
+        """Two scopes sharing one real club, which is the case combined runs exist for.
+
+        Club ids are slugs of club names, so a club fielding a Verband team and a
+        Bezirk team carries the same id in both models.
+        """
+        context: dict[str, Any] = {
             "seasonModels": [
                 {
                     "scopeId": "scope-a",
                     "seasonModelJson": json.dumps(
                         {
-                            "clubs": [{"id": "club", "name": "Club A"}],
+                            "clubs": [
+                                {
+                                    "id": "ttc-muster",
+                                    "name": "TTC Muster",
+                                    "venues": [{"hall": "1", "capacity": 2}],
+                                }
+                            ],
                             "teams": [
                                 {
-                                    "id": "team",
-                                    "clubId": "club",
+                                    "id": "oberliga-ttc-muster-i",
+                                    "clubId": "ttc-muster",
                                     "label": "I",
+                                    "hall": "1",
                                     "rasterzahl": {"kind": "fixed", "value": 3},
                                 }
                             ],
-                            "groups": [{"id": "group", "teamIds": ["team"]}],
+                            "groups": [
+                                {
+                                    "ref": {"league": "Kreisliga", "name": "Gruppe 1"},
+                                    "size": 10,
+                                    "teamIds": ["oberliga-ttc-muster-i"],
+                                }
+                            ],
+                            "wishes": [
+                                {
+                                    "clubId": "ttc-muster",
+                                    "teamA": "oberliga-ttc-muster-i",
+                                    "teamB": "kreisliga-ttc-muster-ii",
+                                    "relation": "wechsel",
+                                }
+                            ],
                         }
                     ),
                 },
@@ -275,35 +305,96 @@ class WorkerTests(unittest.TestCase):
                     "scopeId": "scope-b",
                     "seasonModelJson": json.dumps(
                         {
-                            "clubs": [{"id": "club", "name": "Club B"}],
-                            "teams": [
+                            "clubs": [
                                 {
-                                    "id": "team",
-                                    "clubId": "club",
-                                    "label": "I",
-                                    "rasterzahl": {"kind": "fixed", "value": 4},
+                                    "id": "ttc-muster",
+                                    "name": "TTC Muster",
+                                    "venues": [{"hall": "2", "capacity": 1}],
                                 }
                             ],
-                            "groups": [{"id": "group", "teamIds": ["team"]}],
+                            "teams": [
+                                {
+                                    "id": "kreisliga-ttc-muster-ii",
+                                    "clubId": "ttc-muster",
+                                    "label": "II",
+                                    "hall": "2",
+                                    "rasterzahl": {"kind": "pinned", "value": 5},
+                                }
+                            ],
+                            "groups": [
+                                {
+                                    "ref": {"league": "Kreisliga", "name": "Gruppe 1"},
+                                    "size": 10,
+                                    "teamIds": ["kreisliga-ttc-muster-ii"],
+                                }
+                            ],
                         }
                     ),
                 },
             ]
         }
+        if fixed_rasterzahlen is not None:
+            context["fixedRasterzahlen"] = fixed_rasterzahlen
+        return context
 
-        model = _raster_run_model(context)
+    def test_combined_raster_model_keeps_ids_so_wishes_and_clubs_still_resolve(self) -> None:
+        model = _raster_run_model(self._combined_context())
         teams = cast(list[dict[str, object]], model["teams"])
+        clubs = cast(list[dict[str, object]], model["clubs"])
+        wishes = cast(list[dict[str, object]], model["wishes"])
+
+        team_ids = {str(team["id"]) for team in teams}
+        # A wish naming a team in the other spanned scope must still find it.
+        self.assertIn(str(wishes[0]["teamA"]), team_ids)
+        self.assertIn(str(wishes[0]["teamB"]), team_ids)
+        # One real club stays one club, so hall capacity and same-club spacing
+        # see both of its teams.
+        self.assertEqual([club["id"] for club in clubs], ["ttc-muster"])
+        self.assertEqual({str(team["clubId"]) for team in teams}, {"ttc-muster"})
+
+    def test_combined_raster_model_keeps_every_venue_of_a_shared_club(self) -> None:
+        model = _raster_run_model(self._combined_context())
+        clubs = cast(list[dict[str, object]], model["clubs"])
+        venues = cast(list[dict[str, object]], clubs[0]["venues"])
+
+        self.assertEqual([venue["hall"] for venue in venues], ["1", "2"])
+
+    def test_combined_raster_model_unfixes_inherited_but_keeps_pins(self) -> None:
+        model = _raster_run_model(self._combined_context())
+        teams = cast(list[dict[str, object]], model["teams"])
+        by_id = {str(team["id"]): team for team in teams}
+
+        # Inherited upper-league number: the combined run decides it (FR-013).
+        self.assertEqual(
+            by_id["oberliga-ttc-muster-i"]["rasterzahl"], {"kind": "assignable"}
+        )
+        # A deliberate pin is not an inherited constraint and survives.
+        self.assertEqual(
+            by_id["kreisliga-ttc-muster-ii"]["rasterzahl"], {"kind": "pinned", "value": 5}
+        )
+
+    def test_combined_raster_model_honours_numbers_supplied_for_the_combined_set(self) -> None:
+        model = _raster_run_model(
+            self._combined_context(
+                fixed_rasterzahlen=[
+                    {"clubId": "ttc-muster", "teamLabel": "I", "rasterzahl": 7}
+                ]
+            )
+        )
+        teams = cast(list[dict[str, object]], model["teams"])
+        by_id = {str(team["id"]): team for team in teams}
+
+        # FR-014: supplied against the combined set, so a hard constraint here.
+        self.assertEqual(
+            by_id["oberliga-ttc-muster-i"]["rasterzahl"], {"kind": "fixed", "value": 7}
+        )
+
+    def test_combined_raster_model_tags_groups_with_scope_to_keep_them_distinct(self) -> None:
+        model = _raster_run_model(self._combined_context())
         groups = cast(list[dict[str, object]], model["groups"])
 
-        self.assertEqual([team["id"] for team in teams], ["scope-a:team", "scope-b:team"])
-        self.assertEqual(
-            [team["rasterzahl"] for team in teams],
-            [{"kind": "assignable"}, {"kind": "assignable"}],
-        )
-        self.assertEqual(
-            [group["teamIds"] for group in groups],
-            [["scope-a:team"], ["scope-b:team"]],
-        )
+        # Both are "Kreisliga / Gruppe 1"; only the scope tells them apart.
+        self.assertEqual([group["scopeId"] for group in groups], ["scope-a", "scope-b"])
 
     def test_worker_runtime_has_ortools(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
Fixes the defects found reviewing #7. Targets `006-combined-wttv-planning` so #7 picks them up. All were silent, and none were caught by #7''s tests.

## 1. Coverage was computed from an empty model

A combined input set has no `rasterSource` rows of its own, so `syncInputSetSourceCaches` never populates its `seasonModelJson` — it stays `null`. `buildCoverageRecordForInputSet` read exactly that field.

So every combined run recorded **zero gaps**, and one spanning every scope came out `complete: true` — the "incomplete run mistaken for a plan" the coverage record exists to prevent (FR-034, SC-002). A subset run was marked incomplete but named no gaps (FR-032, FR-037).

The aggregating builder already existed, and the pre-run page already used it — so the preview named real gaps while the persisted record denied them. Combined sets now route to it.

Also closes the related spec edge case ([spec.md:128](specs/006-combined-wttv-planning/spec.md:128)): a spanned scope with no input set contributes no groups and no teams, so it read as fully covered. It is now recorded as `scopesWithoutInputSet` and blocks `complete`.

## 2. The merge invented the id collision it was avoiding

Model ids are derived from names, not rows: `clubId = slug(clubName)` ([model.ts:159](src/raster/ingest/model.ts:159)), and a team id embeds its club and group. So **the same club already carries the same id in every scope''s model** — which is exactly what a combined run needs, since hall capacity and same-club spacing key off `clubId`.

`_scope_prefixed_model` rewrote those ids per scope, which:

- **detached every wish from its teams** — `wishes[].teamA/teamB` were not rewritten, and the solver skips any wish that will not resolve ([solve-raster-cpsat.py:426](scripts/solve-raster-cpsat.py:426)), so combined runs optimized with **no wishes at all**;
- **detached hall capacities** — DB rows carry the raw `clubId`, model clubs were prefixed, so no override matched;
- **split a club fielding a Verband and a Bezirk team into two clubs** that could not see each other — the exact case FR-013 exists to plan jointly.

The prefixing is removed; models merge as-is. A club appearing in several scopes keeps every venue (each model carries only the halls its own teams use).

**Groups did need disambiguating** — league + name genuinely repeats across Bezirke ("Kreisliga / Gruppe 1"), and the solver keyed `bye` vars on it. Groups now carry `scopeId` and the solver''s new `group_key()` includes it. Single-scope models have no `scopeId` and keep their existing key, so nothing changes for them.

### Correction: ids are stable, but they are not an identity

An earlier version of this description said ids are "already stable across scopes" and left it there. That was too strong, and the guard below exists because of it.

Nothing *guarantees* the stability — it falls out of ids being name-derived, and the uniqueness counter behind `teamId` is computed **per scope**, so no scope can see another''s ids. Two clubs sharing a name, in identically named groups, in different Bezirke collapse onto one team id. German club naming ("TuS Germania", "TTC Blau-Weiß") plus generic group names makes that plausible rather than exotic.

Worth stating plainly what this PR does to that risk:

- **Prefixing** broke wishes, capacities and club unity on **every** combined run — but same-named clubs stayed separate by accident.
- **No prefixing** fixes all of that — but same-named clubs can now merge.

Strictly better, not complete. So: `_reject_team_id_collision` refuses the run when one team id arrives from two scopes. A Verband league and a Bezirk league never share a team, so that is always an error, never legitimate duplication. It raises `RasterInputInvalid`, which is terminal — the inputs decide it, so retrying only reaches the same end twice more.

**It narrows the hazard rather than closing it.** Two same-named clubs whose *groups* differ still merge silently into one club, and no name-derived id can tell them apart — the colliding case is precisely the one where the names are identical, so checking names cannot help. Only a real WTTV club number would, and the ingest never sees one: `TeamRasterAssignmentRow` has no club id field, and the scrape reads team names out of a standings table''s text cells. Capturing it is its own piece of work, and would also retire the fuzzy `closestClubId` name-matching in `inputSets.ts`.

## 3. FR-014 was unimplemented

Every team was forced to `assignable`, which dropped deliberate `pinned` numbers along with inherited ones, and the combined set''s own `fixedRasterzahlen` were never loaded at all.

Now: inherited `fixed` still becomes assignable (that is FR-013, and the point of the feature), `pinned` survives, and numbers supplied against the combined set are loaded and applied as hard constraints.

## 4. Scope access on the combined runs route

The route now checks every spanned scope rather than none, and logs `RASTER_RUN_STARTED` like the single-scope route does.

**This is hardening, not a live hole** — and my review overstated it. The route requires raster `admin`, which resolves to `PLATFORM_ADMIN` only, and `canAccessRasterScope` returns `true` unconditionally for `PLATFORM_ADMIN`. The only role that can reach it already has access to everything. It matters if that level ever widens to the scope-limited `SCOPE_ADMIN`, and FR-015 asks for it regardless.

## Verification

372 webapp tests, 35 worker tests, 11 CP-SAT solver tests, typecheck, lint, `quality:python` — all pass.

The three coverage tests and the collision guard test were each confirmed to **fail against the unfixed code** and pass with it, so they pin the bugs rather than merely describing the fixes.

## Notes

- The worker test that asserted the old behaviour (`..._prefixes_scopes_and_drops_inherited_fixed_numbers`) is replaced. Its fixture gave both scopes a club with the id `club`, which reads as a collision the prefixing solved — but with name-derived ids, identical ids mean *the same club*, which is the thing that must not be split. The test encoded the bug''s premise.
- [raster-combined-upper-league.test.ts](webapp/tests/integration/raster-combined-upper-league.test.ts) invoked that Python test **by name** and so broke on the rename; it now runs the full set of combined-model tests.
- Still open on #7, not addressed here: the PR title says "spec + plan + tasks, no code", and spec Q2 (combined run wall-clock limit) was marked "decide at planning" but combined runs still take the single-scope 300s default.