### PR TITLE
Confine scope-admin role changes to own scopes and rank

### DIFF
--- a/webapp/src/lib/rbac.ts
+++ b/webapp/src/lib/rbac.ts
@@ -75,3 +75,54 @@ export async function mayManageScopeAssignment(
 
   return (await getActorScopeIds(actor.id)).includes(scopeId);
 }
+
+async function actorSharesScopeWithTarget(actorId: string, targetId: string) {
+  const actorScopeIds = await getUserScopeIds(actorId);
+  if (actorScopeIds.length === 0) {
+    return false;
+  }
+  const shared = await prisma.userScopeAssignment.findFirst({
+    where: { userId: targetId, scopeId: { in: actorScopeIds } },
+    select: { scopeId: true },
+  });
+  return !!shared;
+}
+
+/**
+ * Whether `actor` may set `target`'s role to `nextRole`.
+ *
+ * `canAssignRole` alone guards only the destination rank, which lets a scope
+ * admin demote a user ranked above them (a platform admin) or reroll a user in
+ * a scope they do not hold. The spec confines a scope admin to acting within
+ * their own scopes (User Story 2 scenario 5; edge case "acts on a user who
+ * holds scopes outside the admin's own"), so a scope admin may change a role
+ * only for a target at or below their own rank and sharing at least one scope,
+ * and never their own.
+ */
+export async function mayManageUserRole(
+  actor: Pick<User, "id" | "role">,
+  target: Pick<User, "id" | "role">,
+  nextRole: Role,
+  sharesScope: (
+    actorId: string,
+    targetId: string,
+  ) => Promise<boolean> = actorSharesScopeWithTarget,
+) {
+  if (!canAssignRole(actor, nextRole)) {
+    return false;
+  }
+
+  if (actor.role === Role.PLATFORM_ADMIN) {
+    return true;
+  }
+
+  if (actor.role !== Role.SCOPE_ADMIN || actor.id === target.id) {
+    return false;
+  }
+
+  if (!canAssignRole(actor, target.role)) {
+    return false;
+  }
+
+  return sharesScope(actor.id, target.id);
+}

--- a/webapp/src/services/api/user-admin.ts
+++ b/webapp/src/services/api/user-admin.ts
@@ -6,7 +6,7 @@ import {
 import { safeLogAudit } from "@/lib/audit";
 import { prisma } from "@/lib/db";
 import { jsonError } from "@/lib/http";
-import { canAssignRole } from "@/lib/rbac";
+import { canAssignRole, getUserScopeIds, mayManageUserRole } from "@/lib/rbac";
 import {
   requireRouteUser,
   requireRouteUserWithRoles,
@@ -98,6 +98,16 @@ export async function lookupUserByEmail(
     return { user: null };
   }
 
+  // FR-042: a scope admin sees a user's assignments only for scopes they hold.
+  // listManagedUserScopes filters the same way; the lookup must not be the leak.
+  const visibleAssignments =
+    auth.user.role === Role.PLATFORM_ADMIN
+      ? user.scopeAssignments
+      : await filterAssignmentsToActorScopes(
+          auth.user.id,
+          user.scopeAssignments,
+        );
+
   return {
     user: {
       id: user.id,
@@ -106,9 +116,21 @@ export async function lookupUserByEmail(
       role: user.role,
       status: user.status,
       authMethod: user.authMethod,
-      scopes: user.scopeAssignments.map((assignment) => assignment.scope),
+      scopes: visibleAssignments.map((assignment) => assignment.scope),
     },
   };
+}
+
+async function filterAssignmentsToActorScopes<
+  T extends { scopeId: string },
+>(actorId: string, assignments: T[]): Promise<T[]> {
+  if (assignments.length === 0) {
+    return assignments;
+  }
+  const actorScopeIds = new Set(await getUserScopeIds(actorId));
+  return assignments.filter((assignment) =>
+    actorScopeIds.has(assignment.scopeId),
+  );
 }
 
 export async function createLocalUser(
@@ -377,7 +399,7 @@ export async function updateManagedUserRole(
     return managed;
   }
 
-  if (!canAssignRole(managed.actor, body.role)) {
+  if (!(await mayManageUserRole(managed.actor, managed.user, body.role))) {
     return { error: jsonError("Not authorized to assign this role", 403) };
   }
 

--- a/webapp/src/services/api/user-admin.ts
+++ b/webapp/src/services/api/user-admin.ts
@@ -390,6 +390,7 @@ export async function updateManagedUserRole(
   if (!Object.values(Role).includes(body.role)) {
     return { error: jsonError("Invalid role", 400) };
   }
+  const nextRole = body.role;
 
   const managed = await requireManagedUserContext(params, request, [
     Role.PLATFORM_ADMIN,
@@ -397,10 +398,6 @@ export async function updateManagedUserRole(
   ]);
   if ("error" in managed) {
     return managed;
-  }
-
-  if (!(await mayManageUserRole(managed.actor, managed.user, body.role))) {
-    return { error: jsonError("Not authorized to assign this role", 403) };
   }
 
   let updated: User;
@@ -415,10 +412,38 @@ export async function updateManagedUserRole(
             throw jsonError("User not found", 404);
           }
 
+          const canManageFreshRole = await mayManageUserRole(
+            managed.actor,
+            fresh,
+            nextRole,
+            async (actorId, targetId) => {
+              const actorScopeIds = await tx.userScopeAssignment.findMany({
+                where: { userId: actorId },
+                select: { scopeId: true },
+              });
+              if (actorScopeIds.length === 0) {
+                return false;
+              }
+
+              return !!(await tx.userScopeAssignment.findFirst({
+                where: {
+                  userId: targetId,
+                  scopeId: {
+                    in: actorScopeIds.map((assignment) => assignment.scopeId),
+                  },
+                },
+                select: { scopeId: true },
+              }));
+            },
+          );
+          if (!canManageFreshRole) {
+            throw jsonError("Not authorized to assign this role", 403);
+          }
+
           const denied = await ensureAdminUserCanChange(
             fresh,
             {
-              role: body.role,
+              role: nextRole,
               message: "Cannot change role of the last Admin user",
             },
             tx.user.count,
@@ -429,7 +454,7 @@ export async function updateManagedUserRole(
 
           return tx.user.update({
             where: { id: managed.user.id },
-            data: { role: body.role },
+            data: { role: nextRole },
           });
         },
         { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },

--- a/webapp/tests/integration/scope-admin-escalation.test.ts
+++ b/webapp/tests/integration/scope-admin-escalation.test.ts
@@ -9,6 +9,11 @@ const auth = vi.hoisted(() => ({
 
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/audit", () => ({ safeLogAudit: vi.fn() }));
+vi.mock("@/services/notifications/service", () => ({
+  safeQueueRoleChangedNotifications: vi.fn(),
+  safeQueueUserCreatedNotifications: vi.fn(),
+  safeQueueUserStatusChangedNotifications: vi.fn(),
+}));
 vi.mock("@/services/api/route-context", () => ({
   requireRouteUserWithRoles: auth.requireRouteUserWithRoles,
 }));
@@ -75,6 +80,61 @@ describe("scope admin escalation", () => {
 
     expect(result.status).toBe(403);
     expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses demoting a platform admin", async () => {
+    // canAssignRole guards only the destination role, so a scope admin could
+    // otherwise strip a platform admin by moving them down to SCOPE_USER.
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "target",
+      role: Role.PLATFORM_ADMIN,
+      status: UserStatus.ACTIVE,
+    } as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_USER }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses a role change for a user outside the actor's scopes", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-owl" },
+    ] as never);
+    prismaMock.userScopeAssignment.findFirst.mockResolvedValue(null as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_ADMIN }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a role change for a user within the actor's scopes", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-owl" },
+    ] as never);
+    prismaMock.userScopeAssignment.findFirst.mockResolvedValue({
+      scopeId: "scope-owl",
+    } as never);
+    prismaMock.user.update.mockResolvedValue({
+      id: "target",
+      role: Role.SCOPE_ADMIN,
+    } as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_ADMIN }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { role: Role.SCOPE_ADMIN } }),
+    );
   });
 
   it("refuses listing users for scope admins", async () => {

--- a/webapp/tests/integration/scope-admin-escalation.test.ts
+++ b/webapp/tests/integration/scope-admin-escalation.test.ts
@@ -99,6 +99,23 @@ describe("scope admin escalation", () => {
     expect(prismaMock.user.update).not.toHaveBeenCalled();
   });
 
+  it("refuses demoting a target promoted after the initial lookup", async () => {
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce(targetUser() as never)
+      .mockResolvedValueOnce({
+        id: "target",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      } as never);
+
+    const result = await updateRole(jsonRequest({ role: Role.SCOPE_USER }), {
+      params: Promise.resolve({ id: "target" }),
+    });
+
+    expect(result.status).toBe(403);
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
   it("refuses a role change for a user outside the actor's scopes", async () => {
     prismaMock.user.findUnique.mockResolvedValue(targetUser() as never);
     prismaMock.userScopeAssignment.findMany.mockResolvedValue([

--- a/webapp/tests/integration/user-lookup.test.ts
+++ b/webapp/tests/integration/user-lookup.test.ts
@@ -66,9 +66,75 @@ describe("user lookup", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ user: null });
   });
+
+  it("shows a scope admin only the target's scopes they hold (FR-042)", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(
+      user("target@example.com", Role.SCOPE_USER, [
+        assignment("scope-owl", "OWL"),
+        assignment("scope-koeln", "KOELN"),
+      ]) as never,
+    );
+    // The actor holds OWL only.
+    prismaMock.userScopeAssignment.findMany.mockResolvedValue([
+      { scopeId: "scope-owl" },
+    ] as never);
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=target@example.com"),
+    );
+
+    const body = await response.json();
+    expect(body.user.scopes.map((scope: { code: string }) => scope.code)).toEqual([
+      "OWL",
+    ]);
+  });
+
+  it("shows a platform admin every scope the target holds", async () => {
+    requireRouteUserWithRoles.mockResolvedValue({
+      user: { id: "actor", role: Role.PLATFORM_ADMIN, status: UserStatus.ACTIVE },
+    });
+    prismaMock.user.findUnique.mockResolvedValue(
+      user("target@example.com", Role.SCOPE_USER, [
+        assignment("scope-owl", "OWL"),
+        assignment("scope-koeln", "KOELN"),
+      ]) as never,
+    );
+
+    const response = await lookupUser(
+      new Request("http://localhost/api/users/lookup?email=target@example.com"),
+    );
+
+    const body = await response.json();
+    expect(body.user.scopes.map((scope: { code: string }) => scope.code)).toEqual([
+      "OWL",
+      "KOELN",
+    ]);
+    // No per-actor scope filtering query for a platform admin.
+    expect(prismaMock.userScopeAssignment.findMany).not.toHaveBeenCalled();
+  });
 });
 
-function user(email: string, role: Role = Role.SCOPE_USER) {
+function assignment(scopeId: string, code: string) {
+  return {
+    scopeId,
+    scope: {
+      id: scopeId,
+      code,
+      name: code,
+      parent: {
+        code: "WTTV",
+        name: "WTTV",
+        parent: { code: "DE", name: "Germany" },
+      },
+    },
+  };
+}
+
+function user(
+  email: string,
+  role: Role = Role.SCOPE_USER,
+  scopeAssignments: ReturnType<typeof assignment>[] = [],
+) {
   return {
     id: "target",
     email,
@@ -76,6 +142,6 @@ function user(email: string, role: Role = Role.SCOPE_USER) {
     role,
     status: UserStatus.ACTIVE,
     authMethod: "LOCAL",
-    scopeAssignments: [],
+    scopeAssignments,
   };
 }

--- a/webapp/tests/unit/auth/scope-grant-authorization.test.ts
+++ b/webapp/tests/unit/auth/scope-grant-authorization.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { canAssignRole, mayManageScopeAssignment } from "@/lib/rbac";
+import {
+  canAssignRole,
+  mayManageScopeAssignment,
+  mayManageUserRole,
+} from "@/lib/rbac";
 import { Role } from "../../../generated/prisma/enums";
 
 const owl = "scope-owl";
 const koeln = "scope-koeln";
 const germany = "scope-de";
+
+const shareScopes = async () => true;
+const shareNoScopes = async () => false;
 
 describe("scope assignment authorization", () => {
   it("allows a scope admin to grant a held scope", async () => {
@@ -67,5 +74,77 @@ describe("scope assignment authorization", () => {
         async () => false,
       ),
     ).resolves.toBe(false);
+  });
+});
+
+describe("user role management authorization", () => {
+  const scopeAdmin = { id: "actor", role: Role.SCOPE_ADMIN };
+
+  it("lets a scope admin set a shared-scope user's role within their rank", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.SCOPE_USER },
+        Role.SCOPE_ADMIN,
+        shareScopes,
+      ),
+    ).resolves.toBe(true);
+  });
+
+  it("refuses raising a role above the actor's own", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.SCOPE_USER },
+        Role.PLATFORM_ADMIN,
+        shareScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses demoting a user ranked above the actor", async () => {
+    // The exploit: canAssignRole guards only the destination role, so without
+    // the target-rank check a scope admin could strip a platform admin.
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.PLATFORM_ADMIN },
+        Role.SCOPE_USER,
+        shareScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses acting on a user outside the actor's scopes", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "target", role: Role.SCOPE_USER },
+        Role.SCOPE_USER,
+        shareNoScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("refuses a scope admin rerolling themselves", async () => {
+    await expect(
+      mayManageUserRole(
+        scopeAdmin,
+        { id: "actor", role: Role.SCOPE_ADMIN },
+        Role.SCOPE_USER,
+        shareScopes,
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("lets a platform admin set any role", async () => {
+    await expect(
+      mayManageUserRole(
+        { id: "actor", role: Role.PLATFORM_ADMIN },
+        { id: "target", role: Role.SCOPE_ADMIN },
+        Role.PLATFORM_ADMIN,
+        shareNoScopes,
+      ),
+    ).resolves.toBe(true);
   });
 });


### PR DESCRIPTION
Fixes two access findings from reviewing #8. Targets `007-scope-access-management` so #8 picks them up. Both were reachable at the API and neither was tested.

## 1. HIGH — a scope admin could demote a platform admin (and reroll users cross-scope)

[`updateManagedUserRole`](webapp/src/services/api/user-admin.ts) gated only on:

```ts
if (!canAssignRole(managed.actor, body.role)) { ... 403 }
```

`canAssignRole` checks the **destination** role against the actor''s rank — not the **target''s current** rank, and not scope membership. So:

- `PATCH /api/users/{platformAdminId}/role` with `{role: "SCOPE_USER"}` as a scope admin: `canAssignRole(SCOPE_ADMIN, SCOPE_USER)` → true, and `ensureAdminUserCanChange` only blocks it if that platform admin is the *last* one. With ≥2 platform admins it **succeeds** — a scope admin strips a platform admin.
- Same mechanism horizontally: an OWL scope admin demotes the Köln scope admin, or promotes any user in a scope they don''t hold.

The spec forbids exactly this — User Story 2 scenario 5 ("act only within their own scopes"), and the edge case "a scope admin attempts to act on a user who holds scopes outside the admin''s own". The existing escalation test covered only the *upward* case (setting a target to PLATFORM_ADMIN), so the downward and cross-scope paths were unenforced and untested.

New `mayManageUserRole` mirrors `mayManageScopeAssignment`: destination rank ≤ actor, **target rank ≤ actor**, not self, and — for a scope admin — **sharing at least one scope**. Platform admins unchanged.

## 2. MEDIUM — user lookup leaked scopes the admin doesn''t hold (FR-042)

`lookupUserByEmail` returned the target''s **complete** assignment list to a scope admin. FR-042: "A scope admin MUST see [which scopes a user holds] only for scopes they hold." `listManagedUserScopes` already filters the same data — the lookup was the one path that didn''t. Now filtered to the actor''s scopes for non-platform-admins; platform admins still see all.

## Tests

- Unit: `mayManageUserRole` — ceiling, target-rank (the demote-platform-admin block), cross-scope refusal, self refusal, platform-admin allow.
- Route: demote-platform-admin → 403, cross-scope role change → 403, shared-scope role change → 200, plus the existing upward-escalation test still green.
- FR-042: lookup shows a scope admin only shared scopes; a platform admin sees all with no filtering query.

Each new test was confirmed to **fail with its fix reverted**. Full suite **405 passing**, typecheck and lint clean.

Finding 3 from the review (no self-guard on role change) is subsumed — `mayManageUserRole` refuses a scope admin acting on themselves. A platform admin self-demotion stays allowed, guarded by the last-admin rule.