### PR TITLE
E2E must never reset the ambient DATABASE_URL

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,9 @@ jobs:
       AUTH_BASE_URL: http://localhost:3290/app-starter
       BETTERAUTH_SECRET: ci-betterauth-secret-for-playwright-tests-only
       DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
+      # E2E provisions and resets this database; it never falls back to
+      # DATABASE_URL. On CI the two point at the same throwaway container.
+      E2E_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       MIGRATION_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       WORKER_DATABASE_URL: postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test
       # The worker suite gets its own database on the same container so a pytest

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,12 +1,19 @@
 # Local dev/test uses PostgreSQL. Docker Compose can provide the database.
 DATABASE_URL="postgresql://starter:replace-with-a-real-secret@localhost:3288/business_app_starter?connection_limit=10"
 
-# Database the E2E suite provisions and RESETS on every run (prisma migrate
-# reset --force destroys all its data). It is deliberately separate from
-# DATABASE_URL and never falls back to it, so E2E can never wipe your dev or
-# production database. Leave blank to use the throwaway local container at
-# localhost:45432; set it only to point E2E at another dedicated, disposable
-# database.
+# E2E_DATABASE_URL: the database the end-to-end (Playwright) test suite runs
+# against. Used only by the E2E tooling -- playwright.config.ts, global.setup.ts
+# and scripts/ensure-e2e-db.mjs -- never by the app at runtime.
+#
+# The E2E setup runs `prisma migrate reset --force` on this database before the
+# tests, which DROPS AND RECREATES it and destroys all its data. So it must be a
+# dedicated, disposable database, never your dev or production one.
+#
+# It is deliberately independent of DATABASE_URL and never falls back to it, so
+# running the E2E suite can never wipe the database your app uses. Leave this
+# blank to use the throwaway local container at localhost:45432 (started by
+# `node scripts/ensure-e2e-db.mjs`); set it only to point the suite at another
+# dedicated, disposable database.
 # E2E_DATABASE_URL="postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test"
 
 # Runtime-specific PostgreSQL Docker/production configuration.

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,6 +1,14 @@
 # Local dev/test uses PostgreSQL. Docker Compose can provide the database.
 DATABASE_URL="postgresql://starter:replace-with-a-real-secret@localhost:3288/business_app_starter?connection_limit=10"
 
+# Database the E2E suite provisions and RESETS on every run (prisma migrate
+# reset --force destroys all its data). It is deliberately separate from
+# DATABASE_URL and never falls back to it, so E2E can never wipe your dev or
+# production database. Leave blank to use the throwaway local container at
+# localhost:45432; set it only to point E2E at another dedicated, disposable
+# database.
+# E2E_DATABASE_URL="postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test"
+
 # Runtime-specific PostgreSQL Docker/production configuration.
 # APP_DATABASE_URL is used by the Next.js app runtime.
 # WORKER_DATABASE_URL is used by the Python worker runtime.

--- a/webapp/eslint.config.mjs
+++ b/webapp/eslint.config.mjs
@@ -22,6 +22,8 @@ const config = [
       ".agents/**",
       ".claude/**",
       "**/*.min.js",
+      "**/*.d.ts",
+      "**/*.d.mts",
     ],
   },
   ...nextVitals,

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,13 +1,11 @@
 import "dotenv/config";
 import { defineConfig } from "@playwright/test";
+import { resolveE2eDatabaseUrl } from "./scripts/e2e-database-url.mjs";
 
 const port = Number(process.env.E2E_PORT ?? "3280");
 const normalizedBasePath = process.env.E2E_BASE_PATH ?? "/app-starter";
 const authBaseUrl = `http://localhost:${port}${normalizedBasePath}`;
-const databaseUrl =
-  process.env.E2E_DATABASE_URL ??
-  process.env.DATABASE_URL ??
-  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+const databaseUrl = resolveE2eDatabaseUrl();
 const reuseExistingServer = process.env.E2E_REUSE_SERVER === "1";
 
 process.env.E2E_PORT = String(port);

--- a/webapp/scripts/e2e-database-url.d.mts
+++ b/webapp/scripts/e2e-database-url.d.mts
@@ -1,0 +1,4 @@
+export const DEFAULT_E2E_DATABASE_URL: string;
+export function resolveE2eDatabaseUrl(
+  env?: Record<string, string | undefined>,
+): string;

--- a/webapp/scripts/e2e-database-url.mjs
+++ b/webapp/scripts/e2e-database-url.mjs
@@ -1,0 +1,20 @@
+// Port 45432 sits below the Windows dynamic port range (49152+), where Hyper-V
+// reserves blocks at boot. A published port inside that range can become
+// unbindable after a reboot: see waitForPublishedPort in ensure-e2e-db.mjs.
+export const DEFAULT_E2E_DATABASE_URL =
+  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+
+/**
+ * The database the E2E suite provisions and RESETS.
+ *
+ * This deliberately does NOT fall back to DATABASE_URL. DATABASE_URL may point
+ * at a real, even production, database, and the E2E setup runs
+ * `prisma migrate reset --force` — which irreversibly destroys all data. A
+ * previous `E2E_DATABASE_URL ?? DATABASE_URL ?? default` chain aimed exactly
+ * that reset at a live LAN database; only Prisma's agent guard stopped it. So
+ * E2E uses E2E_DATABASE_URL when explicitly set, otherwise the throwaway local
+ * default, and never the ambient DATABASE_URL. Do not add DATABASE_URL back.
+ */
+export function resolveE2eDatabaseUrl(env = process.env) {
+  return env.E2E_DATABASE_URL?.trim() || DEFAULT_E2E_DATABASE_URL;
+}

--- a/webapp/scripts/ensure-e2e-db.mjs
+++ b/webapp/scripts/ensure-e2e-db.mjs
@@ -1,16 +1,9 @@
 import { spawnSync } from "node:child_process";
 import net from "node:net";
 
-// Port 45432 sits below the Windows dynamic port range (49152+), where Hyper-V
-// reserves blocks at boot. A published port inside that range can become
-// unbindable after a reboot: see waitForPublishedPort.
-const DEFAULT_E2E_DATABASE_URL =
-  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+import { resolveE2eDatabaseUrl } from "./e2e-database-url.mjs";
 
-const databaseUrl =
-  process.env.E2E_DATABASE_URL?.trim() ||
-  process.env.DATABASE_URL?.trim() ||
-  DEFAULT_E2E_DATABASE_URL;
+const databaseUrl = resolveE2eDatabaseUrl();
 
 if (
   !databaseUrl.startsWith("postgresql://") &&

--- a/webapp/scripts/ensure-e2e-db.mjs
+++ b/webapp/scripts/ensure-e2e-db.mjs
@@ -138,7 +138,7 @@ async function waitForPublishedPort() {
         ? [
             "On Windows this usually means the port falls inside a reserved range. Check:",
             "  netsh interface ipv4 show excludedportrange protocol=tcp",
-            `If ${hostPort} falls inside a listed range, set DATABASE_URL to a free port below 49152.`,
+            `If ${hostPort} falls inside a listed range, set E2E_DATABASE_URL to a free port below 49152.`,
           ].join("\n")
         : "Check that the container's published port is not blocked by the host.",
     ].join("\n"),

--- a/webapp/tests/e2e/global.setup.ts
+++ b/webapp/tests/e2e/global.setup.ts
@@ -1,14 +1,9 @@
 import "dotenv/config";
 import { spawnSync } from "node:child_process";
-
-const defaultE2eDatabaseUrl =
-  "postgresql://starter:starter_e2e_password@localhost:45432/business_app_starter_e2e_test";
+import { resolveE2eDatabaseUrl } from "../../scripts/e2e-database-url.mjs";
 
 export default async function globalSetup() {
-  const databaseUrl =
-    process.env.E2E_DATABASE_URL ??
-    process.env.DATABASE_URL ??
-    defaultE2eDatabaseUrl;
+  const databaseUrl = resolveE2eDatabaseUrl();
   const env = {
     ...process.env,
     APP_DATABASE_URL: databaseUrl,

--- a/webapp/tests/unit/e2e-database-url.test.ts
+++ b/webapp/tests/unit/e2e-database-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_E2E_DATABASE_URL,
+  resolveE2eDatabaseUrl,
+} from "../../scripts/e2e-database-url.mjs";
+
+describe("resolveE2eDatabaseUrl", () => {
+  // The whole point: E2E resets its database, so it must never inherit
+  // DATABASE_URL, which may be a real or production database.
+  it("ignores DATABASE_URL", () => {
+    expect(
+      resolveE2eDatabaseUrl({
+        DATABASE_URL: "postgresql://prod-host:5432/production",
+      }),
+    ).toBe(DEFAULT_E2E_DATABASE_URL);
+  });
+
+  it("uses E2E_DATABASE_URL when set, even alongside DATABASE_URL", () => {
+    expect(
+      resolveE2eDatabaseUrl({
+        E2E_DATABASE_URL: "postgresql://e2e-host:5432/e2e",
+        DATABASE_URL: "postgresql://prod-host:5432/production",
+      }),
+    ).toBe("postgresql://e2e-host:5432/e2e");
+  });
+
+  it("falls back to the throwaway local default", () => {
+    expect(resolveE2eDatabaseUrl({})).toBe(DEFAULT_E2E_DATABASE_URL);
+  });
+
+  it("treats a blank E2E_DATABASE_URL as unset", () => {
+    expect(
+      resolveE2eDatabaseUrl({
+        E2E_DATABASE_URL: "   ",
+        DATABASE_URL: "postgresql://prod-host:5432/production",
+      }),
+    ).toBe(DEFAULT_E2E_DATABASE_URL);
+  });
+});


### PR DESCRIPTION
Safety fix, stacked on #8 because #8 is where the `E2E_DATABASE_URL` mechanism (and its `DATABASE_URL` fallback) is introduced.

## The footgun

The E2E setup runs `prisma migrate reset --force` — which **irreversibly destroys every row** in its target database. That target resolved as:

```ts
E2E_DATABASE_URL ?? DATABASE_URL ?? default   // playwright.config, ensure-e2e-db, global.setup
```

So with no `E2E_DATABASE_URL` set, the developer''s `DATABASE_URL` — which may point at a real or even production database — **became the reset target**. This is not hypothetical: running `validate.ps1` in a worktree whose `.env` pointed `DATABASE_URL` at a live LAN database aimed `prisma migrate reset --force` straight at it. Only Prisma''s built-in AI-agent guard stopped the reset.

## The fix

Remove the `DATABASE_URL` fallback. E2E now uses `E2E_DATABASE_URL` when explicitly set, otherwise the throwaway local container, and **never** the ambient `DATABASE_URL`. With no local container running it fails to connect — which is safe — rather than resetting whatever `DATABASE_URL` happens to hold.

The resolution was duplicated inline in three files. It''s now one helper — `scripts/e2e-database-url.mjs`, runnable by the plain-node `ensure-e2e-db` script and imported by the TS config via a `.d.mts` — with a unit test asserting `DATABASE_URL` is ignored:

```
✓ ignores DATABASE_URL
✓ uses E2E_DATABASE_URL when set, even alongside DATABASE_URL
✓ falls back to the throwaway local default
✓ treats a blank E2E_DATABASE_URL as unset
```

Confirmed to **fail with the fallback restored**, so it locks the footgun closed against regression — the comment in the helper also says "do not add DATABASE_URL back".

## Also

- `E2E_DATABASE_URL` documented in `.env.example` with a "this database gets RESET" warning.
- Set explicitly in CI (`validate.yml`), where it equals the existing throwaway container URL — so CI behaviour is unchanged.
- eslint config ignores `*.d.ts` / `*.d.mts` (the new declaration file).

## Verification

typecheck, lint, and **398 unit tests** pass.

## Note

Stacked on `007-scope-access-management`. Merge order into #8 is now: this + #24 (scope-admin role guard) both land in #8, then #8 → main. Independent of #24 — different files.