### PR TITLE
Fix raster import follow-ups

### DIFF
--- a/scripts/solve-raster-cpsat.py
+++ b/scripts/solve-raster-cpsat.py
@@ -335,6 +335,8 @@ def main() -> None:
                 right = teams[right_id]
                 if left["clubId"] != right["clubId"]:
                     continue
+                if left.get("planned") is False and right.get("planned") is False:
+                    continue
                 allowed = []
                 is_st4 = model.new_bool_var(f"same_club_st4_{left_id}_{right_id}")
                 for a in raster_values_for_group(group):

--- a/specs/011-raster-import-ux/spec.md
+++ b/specs/011-raster-import-ux/spec.md
@@ -134,7 +134,7 @@ A raster planner can create a second planning workspace for the same scope and s
 - **FR-016**: Permission-limited users MUST see only actions they are allowed to perform. Creating a workspace and adding, parsing, or validating sources require feature 007's scheduler access (`PLATFORM_ADMIN`, or `SCOPE_ADMIN` holding the scope); a `SCOPE_USER` sees a read-only view without create/add actions. Enforced at the API, not only hidden in the UI.
 - **FR-017**: The system MUST support deliberate creation of multiple workspaces for the same scope and season.
 - **FR-018**: Inferring gym capacities from a workspace MUST first sync the selected workspace's parsed sources and MUST raise stale inferred capacity rows while preserving reviewed/manual rows.
-- **FR-019**: Manual team-to-wish PDF matches made during review MUST survive validation, optimizer run startup, and any parsed-source cache sync for the same workspace, as long as the matched wish still exists.
+- **FR-019**: Manual review choices, including team-to-wish PDF matches and A/B week preferences, MUST survive validation, optimizer run startup, and any parsed-source cache sync for the same workspace, as long as any referenced matched wish still exists.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/011-raster-import-ux/spec.md
+++ b/specs/011-raster-import-ux/spec.md
@@ -134,6 +134,7 @@ A raster planner can create a second planning workspace for the same scope and s
 - **FR-016**: Permission-limited users MUST see only actions they are allowed to perform. Creating a workspace and adding, parsing, or validating sources require feature 007's scheduler access (`PLATFORM_ADMIN`, or `SCOPE_ADMIN` holding the scope); a `SCOPE_USER` sees a read-only view without create/add actions. Enforced at the API, not only hidden in the UI.
 - **FR-017**: The system MUST support deliberate creation of multiple workspaces for the same scope and season.
 - **FR-018**: Inferring gym capacities from a workspace MUST first sync the selected workspace's parsed sources and MUST raise stale inferred capacity rows while preserving reviewed/manual rows.
+- **FR-019**: Manual team-to-wish PDF matches made during review MUST survive validation, optimizer run startup, and any parsed-source cache sync for the same workspace, as long as the matched wish still exists.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/011-raster-import-ux/spec.md
+++ b/specs/011-raster-import-ux/spec.md
@@ -121,15 +121,19 @@ A raster planner can create a second planning workspace for the same scope and s
 - **FR-010**: Users MUST be able to create an additional workspace for the same scope and season after one already exists.
 - **FR-010a**: Creating a workspace MUST require only a user-visible workspace name.
 - **FR-010b**: The first workspace name SHOULD default to the current scope and season.
+- **FR-010c**: Workspace names MUST be unique within the same scope and season, so the selector cannot show indistinguishable planning workspaces.
 - **FR-011**: The primary click-TT URL add action MUST be visible in the main import flow, not hidden behind a bottom-of-page advanced section.
 - **FR-012**: After a source is saved, the page MUST show the saved source and its next required action without making the user search the page.
 - **FR-012a**: Saving a source MUST NOT automatically parse it in the default flow.
 - **FR-012b**: Newly saved unparsed sources MUST present Parse as the prominent next action.
+- **FR-012c**: Source parsing MUST be explicit and consistent across source types, with a Parse all action for the selected workspace.
+- **FR-012d**: Registering a click-TT URL MUST allow the display name to be omitted and use the visible default name.
 - **FR-013**: The source list MUST distinguish saved-but-unparsed sources from parsed sources.
 - **FR-014**: Parsed sources MUST show a concise summary of imported content.
 - **FR-015**: Parse failures MUST leave the saved source visible and show a recoverable error message.
 - **FR-016**: Permission-limited users MUST see only actions they are allowed to perform. Creating a workspace and adding, parsing, or validating sources require feature 007's scheduler access (`PLATFORM_ADMIN`, or `SCOPE_ADMIN` holding the scope); a `SCOPE_USER` sees a read-only view without create/add actions. Enforced at the API, not only hidden in the UI.
 - **FR-017**: The system MUST support deliberate creation of multiple workspaces for the same scope and season.
+- **FR-018**: Inferring gym capacities from a workspace MUST first sync the selected workspace's parsed sources and MUST raise stale inferred capacity rows while preserving reviewed/manual rows.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/011-raster-import-ux/spec.md
+++ b/specs/011-raster-import-ux/spec.md
@@ -22,6 +22,10 @@
 - Q: Which users may create workspaces and add/parse sources? → A: Feature 007's scheduler level — `PLATFORM_ADMIN`, or `SCOPE_ADMIN` holding the scope; `SCOPE_USER` gets a read-only view (FR-016).
 - Q: When the user changes scope or season while a workspace is selected? → A: Reset the selection and re-apply the auto-select rule for the new context (FR-007a).
 
+### Session 2026-07-21
+
+- Q: How should club identity mismatches between the season model and wish/capacity imports be handled when fuzzy matching misses real aliases? → A: Review must be exhaustive for unresolved capacity-relevant model clubs. The system may preselect one strong suggestion, but must still show an empty manual selector when no unique suggestion exists, so future naming variants are not hidden.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Import sources in current context (Priority: P1)
@@ -135,6 +139,7 @@ A raster planner can create a second planning workspace for the same scope and s
 - **FR-017**: The system MUST support deliberate creation of multiple workspaces for the same scope and season.
 - **FR-018**: Inferring gym capacities from a workspace MUST first sync the selected workspace's parsed sources and MUST raise stale inferred capacity rows while preserving reviewed/manual rows.
 - **FR-019**: Manual review choices, including team-to-wish PDF matches and A/B week preferences, MUST survive validation, optimizer run startup, and any parsed-source cache sync for the same workspace, as long as any referenced matched wish still exists.
+- **FR-020**: Gym-capacity club mapping review MUST surface every unresolved capacity-relevant season-model club whose club id is not already linked to a wish-import club id. A unique strong match MAY be preselected, but lack of a unique match MUST still produce a manual review row with an empty searchable target selector. The review MUST NOT rely on a finite list of known spelling variants, and MUST NOT hide unresolved clubs merely because their teams are currently marked `capacityRelevant: false`; only groups explicitly marked `exclude` may suppress their teams from this mapping review.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/011-raster-import-ux/tasks.md
+++ b/specs/011-raster-import-ux/tasks.md
@@ -65,6 +65,7 @@ Tests included (constitution II; spec has acceptance scenarios + measurable SCs)
 - [X] T019 [P] E2E `webapp/tests/e2e/raster-import-ux.spec.ts`: the US1–US3 primary journey (context → add → save → parse).
 - [X] T020 [P] Run `webapp` validate (typecheck, lint, `pnpm test`); update raster docs / `CONTINUE.md`.
 - [X] T021 Verify end-to-end the legacy-sources adoption and the `SCOPE_USER` read-only edge cases per [quickstart.md](./quickstart.md) (FR-009b, FR-016).
+- [X] T022 Follow-up polish: prevent duplicate workspace names, default click-TT URL display names, add Parse all, defer upper-league parsing until explicit parse, and sync parsed sources before gym-capacity inference (FR-010c, FR-012c, FR-012d, FR-018).
 
 ## Dependencies & order
 

--- a/specs/011-raster-import-ux/tasks.md
+++ b/specs/011-raster-import-ux/tasks.md
@@ -66,6 +66,7 @@ Tests included (constitution II; spec has acceptance scenarios + measurable SCs)
 - [X] T020 [P] Run `webapp` validate (typecheck, lint, `pnpm test`); update raster docs / `CONTINUE.md`.
 - [X] T021 Verify end-to-end the legacy-sources adoption and the `SCOPE_USER` read-only edge cases per [quickstart.md](./quickstart.md) (FR-009b, FR-016).
 - [X] T022 Follow-up polish: prevent duplicate workspace names, default click-TT URL display names, add Parse all, defer upper-league parsing until explicit parse, sync parsed sources before gym-capacity inference, and preserve manual team-to-wish PDF matches across validate/run source sync (FR-010c, FR-012c, FR-012d, FR-018, FR-019).
+- [X] T023 Follow-up club identity review: gym-capacity club mapping review is exhaustive over unresolved capacity-relevant model clubs, preselects only unique strong suggestions, shows empty manual selectors for unmatched or ambiguous clubs, and skips only groups explicitly marked `exclude`; unit-test the fallback so future spelling variants do not require code changes (FR-020).
 
 ## Dependencies & order
 

--- a/specs/011-raster-import-ux/tasks.md
+++ b/specs/011-raster-import-ux/tasks.md
@@ -65,7 +65,7 @@ Tests included (constitution II; spec has acceptance scenarios + measurable SCs)
 - [X] T019 [P] E2E `webapp/tests/e2e/raster-import-ux.spec.ts`: the US1–US3 primary journey (context → add → save → parse).
 - [X] T020 [P] Run `webapp` validate (typecheck, lint, `pnpm test`); update raster docs / `CONTINUE.md`.
 - [X] T021 Verify end-to-end the legacy-sources adoption and the `SCOPE_USER` read-only edge cases per [quickstart.md](./quickstart.md) (FR-009b, FR-016).
-- [X] T022 Follow-up polish: prevent duplicate workspace names, default click-TT URL display names, add Parse all, defer upper-league parsing until explicit parse, and sync parsed sources before gym-capacity inference (FR-010c, FR-012c, FR-012d, FR-018).
+- [X] T022 Follow-up polish: prevent duplicate workspace names, default click-TT URL display names, add Parse all, defer upper-league parsing until explicit parse, sync parsed sources before gym-capacity inference, and preserve manual team-to-wish PDF matches across validate/run source sync (FR-010c, FR-012c, FR-012d, FR-018, FR-019).
 
 ## Dependencies & order
 

--- a/src/raster/score/evaluate.ts
+++ b/src/raster/score/evaluate.ts
@@ -89,6 +89,7 @@ export function evaluate(
         const rightRz = assignment[rightId];
         if (!right || rightRz === undefined || left.clubId !== right.clubId)
           continue;
+        if (left.planned === false && right.planned === false) continue;
         if (leftRz === bye || rightRz === bye) continue;
         const spieltag = derbySpieltag(rasterSize, leftRz, rightRz);
         if (spieltag !== undefined && spieltag > 4)

--- a/src/raster/types.ts
+++ b/src/raster/types.ts
@@ -71,6 +71,7 @@ export interface Team {
     | { kind: "pinned"; value: Rasterzahl };
   requestedRasterzahl?: Rasterzahl[];
   capacityRelevant?: boolean;
+  planned?: boolean;
   confidence: "ok" | "review";
 }
 

--- a/tests/unit/evaluate.test.ts
+++ b/tests/unit/evaluate.test.ts
@@ -112,4 +112,45 @@ describe("raster evaluation", () => {
       expect.objectContaining({ kind: "derby-late" })
     );
   });
+
+  it("does not apply derby hard constraints between imported unplanned teams", () => {
+    const model: SeasonModel = {
+      clubs: [
+        {
+          id: "elsen",
+          name: "TuRa Elsen",
+          venues: [{ hall: "1", name: "Halle" }],
+          notes: ""
+        }
+      ],
+      teams: [
+        {
+          id: "elsen-2",
+          clubId: "elsen",
+          label: "Erwachsene II",
+          homeWeekday: "friday",
+          hall: "1",
+          planned: false,
+          rasterzahl: { kind: "fixed", value: 11 },
+          confidence: "ok"
+        },
+        {
+          id: "elsen-3",
+          clubId: "elsen",
+          label: "Erwachsene III",
+          homeWeekday: "friday",
+          hall: "1",
+          planned: false,
+          rasterzahl: { kind: "fixed", value: 5 },
+          confidence: "ok"
+        }
+      ],
+      groups: [{ ref: { league: "LL", name: "LL" }, size: 12, teamIds: ["elsen-2", "elsen-3"] }],
+      wishes: [],
+      absoluteConstraints: [],
+      warnings: []
+    };
+
+    expect(evaluate(model, {}).hardViolations).toHaveLength(0);
+  });
 });

--- a/tests/unit/upper-league-capacity.test.ts
+++ b/tests/unit/upper-league-capacity.test.ts
@@ -99,6 +99,81 @@ function clubWithUpperLeagueTeam(options?: {
   };
 }
 
+function clubWithUnplannedUpperLeagueDerbyPair(): SeasonModel {
+  return {
+    clubs: [
+      {
+        id: "tura-elsen",
+        name: "TuRa Elsen",
+        venues: [
+          { hall: "1", name: "Halle 1", capacityByWeekday: { friday: 1 } },
+        ],
+        notes: "",
+      },
+      { id: "filler-club", name: "Filler", venues: [], notes: "" },
+    ],
+    teams: [
+      {
+        id: "landesliga-tura-elsen-ii",
+        clubId: "tura-elsen",
+        label: "II",
+        group: { league: "Landesliga", name: "Landesliga 1" },
+        homeWeekday: "friday",
+        hall: "1",
+        rasterzahl: { kind: "fixed", value: 11 },
+        planned: false,
+        confidence: "ok",
+      },
+      {
+        id: "landesliga-tura-elsen-iii",
+        clubId: "tura-elsen",
+        label: "III",
+        group: { league: "Landesliga", name: "Landesliga 1" },
+        homeWeekday: "friday",
+        hall: "1",
+        rasterzahl: { kind: "fixed", value: 5 },
+        planned: false,
+        confidence: "ok",
+      },
+      {
+        id: "bezirksliga-tura-elsen-iv",
+        clubId: "tura-elsen",
+        label: "IV",
+        group: { league: "Bezirksliga", name: "Bezirksliga 1" },
+        homeWeekday: "friday",
+        hall: "1",
+        rasterzahl: { kind: "assignable" },
+        confidence: "ok",
+      },
+      {
+        id: "bezirksliga-filler",
+        clubId: "filler-club",
+        label: "F1",
+        group: { league: "Bezirksliga", name: "Bezirksliga 1" },
+        homeWeekday: "tuesday",
+        hall: "9",
+        rasterzahl: { kind: "fixed", value: 1 },
+        confidence: "ok",
+      },
+    ],
+    groups: [
+      {
+        ref: { league: "Landesliga", name: "Landesliga 1" },
+        size: 12,
+        teamIds: ["landesliga-tura-elsen-ii", "landesliga-tura-elsen-iii"],
+      },
+      {
+        ref: { league: "Bezirksliga", name: "Bezirksliga 1" },
+        size: 12,
+        teamIds: ["bezirksliga-tura-elsen-iv", "bezirksliga-filler"],
+      },
+    ],
+    wishes: [],
+    absoluteConstraints: [],
+    warnings: [],
+  };
+}
+
 async function solve(model: SeasonModel): Promise<Assignment> {
   const dir = await mkdtemp(path.join(tmpdir(), "upper-league-capacity-"));
   try {
@@ -195,5 +270,23 @@ describe("upper-league Rasterzahl occupies hall capacity", () => {
 
     expect(assignment["verbandsliga-tura-elsen-i"]).toBe(10);
     expect(evaluate(model, assignment).overUsages).toEqual([]);
+  }, 120_000);
+
+  it("uses unplanned upper-league Rasterzahlen for capacity without derby infeasibility", async () => {
+    const model = clubWithUnplannedUpperLeagueDerbyPair();
+
+    const collision = evaluate(model, {
+      "landesliga-tura-elsen-ii": 11,
+      "landesliga-tura-elsen-iii": 5,
+      "bezirksliga-tura-elsen-iv": 5,
+      "bezirksliga-filler": 1,
+    });
+    expect(collision.overUsages.length).toBeGreaterThan(0);
+    expect(collision.hardViolations).toEqual([]);
+
+    const assignment = await solve(model);
+
+    expect(assignment["landesliga-tura-elsen-ii"]).toBe(11);
+    expect(assignment["landesliga-tura-elsen-iii"]).toBe(5);
   }, 120_000);
 });

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -188,11 +188,12 @@ pnpm run cli:install-releases
 ## Docker Deployment
 
 - Local `pnpm run dev` uses PostgreSQL via `DATABASE_URL`; there is no SQLite fallback.
+- For local development, run one worker directly with `pnpm run worker:dev`; the Docker worker is opt-in so it does not claim jobs at the same time.
 - Put Docker-only PostgreSQL and initial admin values in `.env.docker` using `.env.docker.example` as the template, then start Docker with `pnpm docker up`.
 - Production-style Docker uses separate database URL names by runtime: `APP_DATABASE_URL`, `WORKER_DATABASE_URL`, and `MIGRATION_DATABASE_URL`.
 - Docker services receive explicit allowlisted environment variables; the Postgres container only receives `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD`.
 - `pnpm docker build app migrate worker` builds the production app, migration, and worker images.
-- `pnpm docker up -d worker` starts the Python background worker against the same Postgres database.
+- `pnpm docker up -d worker` explicitly starts the Docker Python background worker against the same Postgres database.
 - Review [`docs/runtime-credentials.md`](./docs/runtime-credentials.md) before adding secrets to app, worker, or migration environments.
 - `sh ./scripts/deploy.sh` now performs a pre-deploy PostgreSQL dump, applies migrations, and restarts the app and worker. Set `CLI_RELEASES_BUILD_DURING_DEPLOY=docker` to build `starterctl` release archives in a GoReleaser container, `CLI_RELEASES_BUILD_DURING_DEPLOY=true` to build with host tools, or `CLI_RELEASES_SOURCE_DIR=/path/to/artifacts` to install prebuilt archives.
 - Manual PostgreSQL backup: `sh ./scripts/backup-postgres.sh`. Dumps are written to `./backups/postgres/business-app-starter-<UTC-timestamp>.dump` and validated with `pg_restore -l`.

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -151,6 +151,7 @@ services:
       && node webapp/server.js"
 
   worker:
+    profiles: ["worker"]
     image: ${WORKER_IMAGE_NAME:-click-tt-worker}:latest
     build:
       context: ..

--- a/webapp/src/app/(dashboard)/raster/_lib/review-helpers.tsx
+++ b/webapp/src/app/(dashboard)/raster/_lib/review-helpers.tsx
@@ -54,6 +54,7 @@ export function extractPlanningGroups(
   const teams = new Map((parsed.teams ?? []).map((team) => [team.id, team]));
   return (parsed.groups ?? [])
     .map((group) => {
+      const isExcluded = group.planningStatus === "exclude";
       const teamRows = (group.teamIds ?? [])
         .map((teamId) => teams.get(teamId))
         .filter((team) => team?.id)
@@ -63,7 +64,9 @@ export function extractPlanningGroups(
             id: team!.id!,
             label: team!.label ?? team!.name ?? team!.id!,
             fields: formatWishFields(team!),
-            missing: missingWishFields(team!).join(", ") || "-",
+            missing: isExcluded
+              ? "deferred"
+              : missingWishFields(team!).join(", ") || "-",
             spielwochePref: normalizeWeekSlot(
               team!.spielwochePref ?? selectedWish?.spielwochePref ?? undefined,
             ),
@@ -86,7 +89,9 @@ export function extractPlanningGroups(
           [group.ref?.league, group.ref?.name].filter(Boolean).join(" / ") ||
           groupId ||
           "Group",
-        missingTeams: teamRows.filter((team) => team.missing !== "-").length,
+        missingTeams: isExcluded
+          ? 0
+          : teamRows.filter((team) => team.missing !== "-").length,
         planningStatus: group.planningStatus ?? null,
         teams: teamRows,
       };

--- a/webapp/src/app/(dashboard)/raster/review/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/review/page.tsx
@@ -95,6 +95,47 @@ export default async function RasterReviewPage({
             />
           </div>
         ) : null}
+        <details
+          className="mt-3 border-t border-[var(--border)] pt-3"
+          open={
+            !!capacityReview &&
+            (capacityReview.aliasCandidates.length > 0 ||
+              capacityReview.blockingCount > 0)
+          }
+        >
+          <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+            Gym capacities
+          </summary>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            {canEdit ? (
+              <InferCapacitiesButton
+                inputSetId={inputSet.id}
+                label="Recheck capacities"
+              />
+            ) : null}
+          </div>
+          {capacityReview ? (
+            <div className="my-3 grid gap-3">
+              <p className="text-sm text-[var(--muted-foreground)]">
+                {capacityReview.inferredCount} inferred,{" "}
+                {capacityReview.missingCount} missing,{" "}
+                {capacityReview.insufficientCount} lower than inferred,{" "}
+                {capacityReview.higherCount} higher than inferred.
+              </p>
+              <ClubAliasReview
+                canEdit={canEdit}
+                candidates={capacityReview.aliasCandidates}
+                inputSetId={inputSet.id}
+                wishClubOptions={capacityReview.wishClubOptions}
+              />
+            </div>
+          ) : null}
+          <CapacityTable
+            canEdit={canEdit}
+            scope={context.scope.code}
+            rows={capacities}
+          />
+        </details>
         <GroupPlanningReview
           groups={extractPlanningGroups(
             inputSet.id,
@@ -112,47 +153,6 @@ export default async function RasterReviewPage({
           />
         ) : null}
       </section>
-      <details
-        className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4"
-        open={
-          !!capacityReview &&
-          (capacityReview.aliasCandidates.length > 0 ||
-            capacityReview.blockingCount > 0)
-        }
-      >
-        <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-          Gym capacities
-        </summary>
-        <div className="mt-3 flex flex-wrap items-center gap-3">
-          {canEdit ? (
-            <InferCapacitiesButton
-              inputSetId={inputSet.id}
-              label="Recheck capacities"
-            />
-          ) : null}
-        </div>
-        {capacityReview ? (
-          <div className="my-3 grid gap-3">
-            <p className="text-sm text-[var(--muted-foreground)]">
-              {capacityReview.inferredCount} inferred,{" "}
-              {capacityReview.missingCount} missing,{" "}
-              {capacityReview.insufficientCount} lower than inferred,{" "}
-              {capacityReview.higherCount} higher than inferred.
-            </p>
-            <ClubAliasReview
-              canEdit={canEdit}
-              candidates={capacityReview.aliasCandidates}
-              inputSetId={inputSet.id}
-              wishClubOptions={capacityReview.wishClubOptions}
-            />
-          </div>
-        ) : null}
-        <CapacityTable
-          canEdit={canEdit}
-          scope={context.scope.code}
-          rows={capacities}
-        />
-      </details>
     </div>
   );
 }

--- a/webapp/src/app/(dashboard)/raster/review/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/review/page.tsx
@@ -124,12 +124,59 @@ export default async function RasterReviewPage({
           ) : null}
         </div>
         {capacityReview ? (
-          <p className="my-3 text-sm text-[var(--muted-foreground)]">
-            {capacityReview.inferredCount} inferred,{" "}
-            {capacityReview.missingCount} missing,{" "}
-            {capacityReview.insufficientCount} lower than inferred,{" "}
-            {capacityReview.higherCount} higher than inferred.
-          </p>
+          <div className="my-3 grid gap-3">
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {capacityReview.inferredCount} inferred,{" "}
+              {capacityReview.missingCount} missing,{" "}
+              {capacityReview.insufficientCount} lower than inferred,{" "}
+              {capacityReview.higherCount} higher than inferred.
+            </p>
+            {capacityReview.aliasCandidates.length ? (
+              <details className="rounded-md border border-[var(--border)] p-3">
+                <summary className="cursor-pointer text-sm font-medium">
+                  Suspected club aliases (
+                  {capacityReview.aliasCandidates.length})
+                </summary>
+                <div className="mt-3 overflow-x-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead className="text-xs uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+                      <tr>
+                        <th className="px-2 py-2">Season model</th>
+                        <th className="px-2 py-2">Wish import</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {capacityReview.aliasCandidates.map((candidate) => (
+                        <tr
+                          className="border-t border-[var(--border)]"
+                          key={`${candidate.modelClubId}-${candidate.wishClubId}`}
+                        >
+                          <td className="px-2 py-2">
+                            <span className="font-medium">
+                              {candidate.modelClubName}
+                            </span>
+                            <br />
+                            <span className="text-[var(--muted-foreground)]">
+                              {candidate.modelClubId}
+                            </span>
+                          </td>
+                          <td className="px-2 py-2">
+                            <span className="font-medium">
+                              {candidate.wishClubName}
+                            </span>
+                            <br />
+                            <span className="text-[var(--muted-foreground)]">
+                              {candidate.wishClubId}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </details>
+            ) : null}
+          </div>
         ) : null}
         <CapacityTable
           canEdit={canEdit}

--- a/webapp/src/app/(dashboard)/raster/review/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/review/page.tsx
@@ -4,6 +4,7 @@ import { MatchReviewPanel } from "@/components/raster/match-review-panel";
 import { WishImportReviewPanel } from "@/components/raster/wish-import-review-panel";
 import { canUseRasterLevel } from "@/lib/raster/access";
 import { listMatchReviewState } from "@/lib/raster/match-review";
+import { resolveWorkspaceSelection } from "@/lib/raster/workspace-selection";
 import { FixedScheduleNumbersForm } from "@/components/raster/input-set-actions";
 import {
   GroupModeReview,
@@ -36,12 +37,16 @@ export default async function RasterReviewPage({
 }) {
   const context = await requireRasterStep(searchParams);
   if ("error" in context) return <RasterStepError message={context.error} />;
+  const params = await searchParams;
 
   const [inputSets, capacities] = await Promise.all([
     listInputSets(context.scope.id, context.season),
     listHallCapacities(context.scope.id),
   ]);
-  const inputSet = inputSets[0] ?? null;
+  const inputSet = resolveWorkspaceSelection(
+    inputSets,
+    params.workspace,
+  ).selected;
   const [capacityReview, matchReview, wishImportReview] = inputSet
     ? await Promise.all([
         reviewHallCapacitiesForInputSet(inputSet.id),

--- a/webapp/src/app/(dashboard)/raster/review/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/review/page.tsx
@@ -111,11 +111,11 @@ export default async function RasterReviewPage({
           />
         ) : null}
       </section>
-      <section className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
-        <div className="mb-3 flex flex-wrap items-center gap-3">
-          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-            Gym capacities
-          </h2>
+      <details className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
+        <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+          Gym capacities
+        </summary>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
           {canEdit ? (
             <InferCapacitiesButton
               inputSetId={inputSet.id}
@@ -124,7 +124,7 @@ export default async function RasterReviewPage({
           ) : null}
         </div>
         {capacityReview ? (
-          <p className="mb-3 text-sm text-[var(--muted-foreground)]">
+          <p className="my-3 text-sm text-[var(--muted-foreground)]">
             {capacityReview.inferredCount} inferred,{" "}
             {capacityReview.missingCount} missing,{" "}
             {capacityReview.insufficientCount} lower than inferred,{" "}
@@ -136,7 +136,7 @@ export default async function RasterReviewPage({
           scope={context.scope.code}
           rows={capacities}
         />
-      </section>
+      </details>
     </div>
   );
 }

--- a/webapp/src/app/(dashboard)/raster/review/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/review/page.tsx
@@ -1,4 +1,5 @@
 import { CapacityTable } from "@/components/raster/capacity/capacity-table";
+import { ClubAliasReview } from "@/components/raster/capacity/club-alias-review";
 import { InferCapacitiesButton } from "@/components/raster/capacity/infer-capacities-button";
 import { MatchReviewPanel } from "@/components/raster/match-review-panel";
 import { WishImportReviewPanel } from "@/components/raster/wish-import-review-panel";
@@ -111,7 +112,14 @@ export default async function RasterReviewPage({
           />
         ) : null}
       </section>
-      <details className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
+      <details
+        className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4"
+        open={
+          !!capacityReview &&
+          (capacityReview.aliasCandidates.length > 0 ||
+            capacityReview.blockingCount > 0)
+        }
+      >
         <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
           Gym capacities
         </summary>
@@ -131,51 +139,12 @@ export default async function RasterReviewPage({
               {capacityReview.insufficientCount} lower than inferred,{" "}
               {capacityReview.higherCount} higher than inferred.
             </p>
-            {capacityReview.aliasCandidates.length ? (
-              <details className="rounded-md border border-[var(--border)] p-3">
-                <summary className="cursor-pointer text-sm font-medium">
-                  Suspected club aliases (
-                  {capacityReview.aliasCandidates.length})
-                </summary>
-                <div className="mt-3 overflow-x-auto">
-                  <table className="w-full text-left text-sm">
-                    <thead className="text-xs uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-                      <tr>
-                        <th className="px-2 py-2">Season model</th>
-                        <th className="px-2 py-2">Wish import</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {capacityReview.aliasCandidates.map((candidate) => (
-                        <tr
-                          className="border-t border-[var(--border)]"
-                          key={`${candidate.modelClubId}-${candidate.wishClubId}`}
-                        >
-                          <td className="px-2 py-2">
-                            <span className="font-medium">
-                              {candidate.modelClubName}
-                            </span>
-                            <br />
-                            <span className="text-[var(--muted-foreground)]">
-                              {candidate.modelClubId}
-                            </span>
-                          </td>
-                          <td className="px-2 py-2">
-                            <span className="font-medium">
-                              {candidate.wishClubName}
-                            </span>
-                            <br />
-                            <span className="text-[var(--muted-foreground)]">
-                              {candidate.wishClubId}
-                            </span>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </details>
-            ) : null}
+            <ClubAliasReview
+              canEdit={canEdit}
+              candidates={capacityReview.aliasCandidates}
+              inputSetId={inputSet.id}
+              wishClubOptions={capacityReview.wishClubOptions}
+            />
           </div>
         ) : null}
         <CapacityTable

--- a/webapp/src/app/(dashboard)/raster/run/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/run/page.tsx
@@ -1,5 +1,6 @@
 import { InputSetRunActions } from "@/components/raster/input-set-actions";
 import { canUseRasterLevel } from "@/lib/raster/access";
+import { resolveWorkspaceSelection } from "@/lib/raster/workspace-selection";
 import {
   listInputSets,
   reviewHallCapacitiesForInputSet,
@@ -17,9 +18,13 @@ export default async function RasterRunPage({
 }) {
   const context = await requireRasterStep(searchParams);
   if ("error" in context) return <RasterStepError message={context.error} />;
+  const params = await searchParams;
 
-  const inputSet =
-    (await listInputSets(context.scope.id, context.season))[0] ?? null;
+  const inputSets = await listInputSets(context.scope.id, context.season);
+  const inputSet = resolveWorkspaceSelection(
+    inputSets,
+    params.workspace,
+  ).selected;
   const capacityReview = inputSet
     ? await reviewHallCapacitiesForInputSet(inputSet.id)
     : null;

--- a/webapp/src/app/(dashboard)/raster/runs/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/runs/page.tsx
@@ -1,4 +1,5 @@
 import { ScenarioComparison } from "@/components/raster/scenario-comparison";
+import { resolveWorkspaceSelection } from "@/lib/raster/workspace-selection";
 import { listInputSets, listScenarios } from "@/services/raster";
 import {
   RasterStepError,
@@ -13,12 +14,16 @@ export default async function RasterRunsPage({
 }) {
   const context = await requireRasterStep(searchParams);
   if ("error" in context) return <RasterStepError message={context.error} />;
+  const params = await searchParams;
 
   const [inputSets, scenarios] = await Promise.all([
     listInputSets(context.scope.id, context.season),
     listScenarios({ scopeId: context.scope.id, season: context.season }),
   ]);
-  const inputSet = inputSets[0] ?? null;
+  const inputSet = resolveWorkspaceSelection(
+    inputSets,
+    params.workspace,
+  ).selected;
 
   return (
     <section className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">

--- a/webapp/src/app/(dashboard)/raster/snapshots/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/snapshots/[id]/page.tsx
@@ -5,7 +5,6 @@ import {
   getSnapshot,
   listSnapshotAssignments,
   listSnapshotConflicts,
-  summarizeSnapshotConflicts,
 } from "@/services/raster";
 import { AssignmentTable } from "@/components/raster/assignments/assignment-table";
 import { IncompleteBadge } from "@/components/raster/coverage/incomplete-badge";
@@ -45,11 +44,11 @@ export default async function RasterSnapshotPage({
     ? requestedScope
     : null;
   const combined = coveredScopes.length > 1;
-  const [assignments, conflicts, topClubs] = await Promise.all([
+  const [assignments, conflicts] = await Promise.all([
     listSnapshotAssignments(snapshot.id, { scopeId: selectedScopeId }),
     listSnapshotConflicts(snapshot.id, { scopeId: selectedScopeId }),
-    summarizeSnapshotConflicts(snapshot.id, { scopeId: selectedScopeId }),
   ]);
+  const topClubs = summarizeConflictClubs(conflicts);
 
   return (
     <div className="space-y-7">
@@ -109,12 +108,13 @@ export default async function RasterSnapshotPage({
         {topClubs.length ? (
           topClubs.slice(0, 10).map((club) => (
             <div
-              className="grid grid-cols-[minmax(12rem,1fr)_6rem_6rem] gap-3 border-b border-[var(--border)] px-4 py-3 text-sm last:border-b-0"
+              className="grid gap-3 border-b border-[var(--border)] px-4 py-3 text-sm last:border-b-0 md:grid-cols-[minmax(12rem,1fr)_5rem_8rem_10rem]"
               key={club.clubId}
             >
               <span className="font-medium">{club.clubName}</span>
               <span>{club.rows} rows</span>
-              <span>{club.excess} total excess</span>
+              <span>{club.optimizerExcess} optimizer excess</span>
+              <span>{club.preExistingExcess} pre-existing fixed excess</span>
             </div>
           ))
         ) : (
@@ -134,30 +134,39 @@ export default async function RasterSnapshotPage({
           </p>
         </div>
         {conflicts.length ? (
-          conflicts.slice(0, 10).map((conflict) => (
-            <div
-              className="grid gap-3 border-b border-[var(--border)] px-4 py-3 text-sm last:border-b-0"
-              key={conflict.id}
-            >
-              <div className="grid gap-2 md:grid-cols-[minmax(12rem,1fr)_5rem_7rem_6rem_6rem_6rem]">
-                <span className="font-medium">{conflict.clubName}</span>
-                <span>W{conflict.matchWeek}</span>
-                <span>{conflict.weekday}</span>
-                <span>Gym {conflict.hall}</span>
-                <span>cap {conflict.capacity}</span>
-                <span>
-                  peak {conflict.actualCount}, +{conflict.excess}
-                </span>
+          conflicts.slice(0, 10).map((conflict) => {
+            const teams = parseConflictTeams(conflict.teams);
+            return (
+              <div
+                className="grid gap-3 border-b border-[var(--border)] px-4 py-3 text-sm last:border-b-0"
+                key={conflict.id}
+              >
+                <div className="grid gap-2 md:grid-cols-[minmax(12rem,1fr)_5rem_7rem_6rem_6rem_6rem]">
+                  <span className="font-medium">{conflict.clubName}</span>
+                  <span>W{conflict.matchWeek}</span>
+                  <span>{conflict.weekday}</span>
+                  <span>Gym {conflict.hall}</span>
+                  <span>cap {conflict.capacity}</span>
+                  <span>
+                    peak {conflict.actualCount}, +{conflict.excess}
+                  </span>
+                </div>
+                {isImportedFixedConflict(teams) ? (
+                  <p className="text-sm text-[var(--muted-foreground)]">
+                    Pre-existing upper-league clash: all teams are imported
+                    fixed Rasterzahlen, not optimizer choices.
+                  </p>
+                ) : null}
+                <ul className="grid gap-1 text-sm text-[var(--muted-foreground)] md:grid-cols-2">
+                  {teams.map((team, index) => (
+                    <li key={`${conflict.id}-${index}`}>
+                      <ConflictTeamLine team={team} />
+                    </li>
+                  ))}
+                </ul>
               </div>
-              <ul className="grid gap-1 text-sm text-[var(--muted-foreground)] md:grid-cols-2">
-                {parseConflictTeams(conflict.teams).map((team, index) => (
-                  <li key={`${conflict.id}-${index}`}>
-                    <ConflictTeamLine team={team} />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))
+            );
+          })
         ) : (
           <p className="px-4 py-6 text-sm text-[var(--muted-foreground)]">
             No gym slot excesses.
@@ -230,6 +239,7 @@ type ConflictTeam = {
   assignedRasterzahl?: number;
   requestedRasterzahl?: number[];
   assignmentStatus?: string;
+  planned?: boolean;
   weekSlot?: string;
   startTime?: string;
   durationMinutes?: number;
@@ -278,6 +288,8 @@ function parseConflictTeams(value: string): ConflictTeam[] {
             assignmentStatus: row.assignmentStatus
               ? String(row.assignmentStatus)
               : undefined,
+            planned:
+              typeof row.planned === "boolean" ? row.planned : undefined,
             weekSlot: row.weekSlot ? String(row.weekSlot) : undefined,
             startTime: row.startTime ? String(row.startTime) : undefined,
             durationMinutes:
@@ -297,6 +309,67 @@ function parseConflictTeams(value: string): ConflictTeam[] {
     .map((team) => team.trim())
     .filter(Boolean)
     .map((id) => ({ id }));
+}
+
+function isImportedFixedConflict(teams: ConflictTeam[]) {
+  return (
+    teams.length > 0 &&
+    teams.every(
+      (team) =>
+        team.assignmentStatus?.toLowerCase() === "fixed" &&
+        (team.planned === false || isUpperLeague(team.league)),
+    )
+  );
+}
+
+function isUpperLeague(league?: string) {
+  return /\b(?:verbandsliga|landesliga|oberliga|nrw-liga)\b/i.test(
+    league ?? "",
+  );
+}
+
+function summarizeConflictClubs(
+  conflicts: Array<{
+    clubId: string;
+    clubName: string;
+    excess: number;
+    teams: string;
+  }>,
+) {
+  const byClub = new Map<
+    string,
+    {
+      clubId: string;
+      clubName: string;
+      rows: number;
+      optimizerExcess: number;
+      preExistingExcess: number;
+    }
+  >();
+
+  for (const conflict of conflicts) {
+    const current = byClub.get(conflict.clubId) ?? {
+      clubId: conflict.clubId,
+      clubName: conflict.clubName,
+      rows: 0,
+      optimizerExcess: 0,
+      preExistingExcess: 0,
+    };
+    current.rows += 1;
+    if (isImportedFixedConflict(parseConflictTeams(conflict.teams))) {
+      current.preExistingExcess += conflict.excess;
+    } else {
+      current.optimizerExcess += conflict.excess;
+    }
+    byClub.set(conflict.clubId, current);
+  }
+
+  return [...byClub.values()].sort(
+    (left, right) =>
+      right.optimizerExcess +
+      right.preExistingExcess -
+      (left.optimizerExcess + left.preExistingExcess),
+  );
 }
 
 function Metric({ label, value }: { label: string; value: string | number }) {

--- a/webapp/src/app/(dashboard)/raster/snapshots/[id]/page.tsx
+++ b/webapp/src/app/(dashboard)/raster/snapshots/[id]/page.tsx
@@ -93,7 +93,13 @@ export default async function RasterSnapshotPage({
       <CoverageDetail coverageJson={snapshot.run?.coverageJson} />
 
       <section className="grid gap-3 md:grid-cols-4">
-        <Metric label="Optimality" value={snapshot.optimality} />
+        <Metric
+          label="Optimality"
+          value={displaySnapshotOptimality(
+            snapshot.optimality,
+            snapshot.run?.settings,
+          )}
+        />
         <Metric label="Conflicts" value={snapshot.totalConflicts} />
         <Metric label="Total excess" value={snapshot.totalExcess} />
         <Metric label="Max slot excess" value={snapshot.maxExcess} />
@@ -326,6 +332,16 @@ function isUpperLeague(league?: string) {
   return /\b(?:verbandsliga|landesliga|oberliga|nrw-liga)\b/i.test(
     league ?? "",
   );
+}
+
+function displaySnapshotOptimality(optimality: string, settings?: string | null) {
+  if (optimality !== "PROVEN_OPTIMAL") return optimality;
+  try {
+    const parsed = JSON.parse(settings ?? "{}") as { strategy?: unknown };
+    return parsed.strategy === "initial_heuristic" ? "FEASIBLE" : optimality;
+  } catch {
+    return optimality;
+  }
 }
 
 function summarizeConflictClubs(

--- a/webapp/src/app/api/raster/input-sets/[id]/capacities/infer/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/capacities/infer/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { requireRasterInputSet } from "@/lib/raster/route-context";
-import { inferHallCapacitiesFromInputSet } from "@/services/raster";
+import {
+  inferHallCapacitiesFromInputSet,
+  syncInputSetSourceCaches,
+} from "@/services/raster";
 
 export async function POST(
   request: Request,
@@ -13,6 +16,7 @@ export async function POST(
   );
   if ("error" in context) return context.error;
 
+  await syncInputSetSourceCaches(context.inputSet.id);
   return NextResponse.json({
     result: await inferHallCapacitiesFromInputSet(
       context.inputSet.id,

--- a/webapp/src/app/api/raster/input-sets/[id]/club-aliases/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/club-aliases/route.ts
@@ -4,6 +4,7 @@ import { logRasterAudit } from "@/lib/raster/audit";
 import { requireRasterInputSet } from "@/lib/raster/route-context";
 import {
   inferHallCapacitiesFromInputSet,
+  syncInputSetSourceCaches,
   updateClubAliasMapping,
 } from "@/services/raster";
 import { AuditAction } from "../../../../../../../generated/prisma/enums";
@@ -40,6 +41,7 @@ export async function POST(
   if (!inputSet) {
     return NextResponse.json({ error: "Club alias not found" }, { status: 404 });
   }
+  await syncInputSetSourceCaches(context.inputSet.id);
   const capacities = await inferHallCapacitiesFromInputSet(
     context.inputSet.id,
     context.user.id,

--- a/webapp/src/app/api/raster/input-sets/[id]/club-aliases/route.ts
+++ b/webapp/src/app/api/raster/input-sets/[id]/club-aliases/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { logRasterAudit } from "@/lib/raster/audit";
+import { requireRasterInputSet } from "@/lib/raster/route-context";
+import {
+  inferHallCapacitiesFromInputSet,
+  updateClubAliasMapping,
+} from "@/services/raster";
+import { AuditAction } from "../../../../../../../generated/prisma/enums";
+
+const bodySchema = z.object({
+  sourceClubId: z.string().trim().min(1),
+  targetClubId: z.string().trim().min(1),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const context = await requireRasterInputSet(
+    request,
+    (await params).id,
+    "scheduler",
+  );
+  if ("error" in context) return context.error;
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid club alias", issues: parsed.error.issues },
+      { status: 422 },
+    );
+  }
+
+  const inputSet = await updateClubAliasMapping(
+    context.inputSet.id,
+    parsed.data.sourceClubId,
+    parsed.data.targetClubId,
+  );
+  if (!inputSet) {
+    return NextResponse.json({ error: "Club alias not found" }, { status: 404 });
+  }
+  const capacities = await inferHallCapacitiesFromInputSet(
+    context.inputSet.id,
+    context.user.id,
+  );
+
+  await logRasterAudit({
+    action: AuditAction.RASTER_PLANNING_CHANGED,
+    actorId: context.user.id,
+    scope: context.inputSet.scope.code,
+    entityType: "RasterInputSet",
+    entityId: context.inputSet.id,
+    details: { type: "club-alias", ...parsed.data },
+  });
+
+  return NextResponse.json({ inputSet, capacities });
+}

--- a/webapp/src/app/api/raster/input-sets/route.ts
+++ b/webapp/src/app/api/raster/input-sets/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { requireApiUser } from "@/lib/route-auth";
 import { assertRasterAccess, resolveRasterScope } from "@/lib/raster/access";
 import { normalizeRasterSeason } from "@/lib/raster/season";
-import { createInputSet, listInputSets } from "@/services/raster";
+import {
+  createInputSet,
+  DuplicateInputSetNameError,
+  listInputSets,
+} from "@/services/raster";
 import { z } from "zod";
 
 const createInputSetBodySchema = z.object({
@@ -65,12 +69,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Scope not found" }, { status: 404 });
   }
 
-  const inputSet = await createInputSet({
-    scopeId: scope.id,
-    name: parsed.data.name,
-    season: normalizeRasterSeason(parsed.data.season),
-    createdById: auth.user.id,
-  });
+  let inputSet;
+  try {
+    inputSet = await createInputSet({
+      scopeId: scope.id,
+      name: parsed.data.name,
+      season: normalizeRasterSeason(parsed.data.season),
+      createdById: auth.user.id,
+    });
+  } catch (error) {
+    if (error instanceof DuplicateInputSetNameError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    throw error;
+  }
 
   return NextResponse.json({ inputSet }, { status: 201 });
 }

--- a/webapp/src/app/api/raster/sources/upload/route.ts
+++ b/webapp/src/app/api/raster/sources/upload/route.ts
@@ -5,7 +5,7 @@ import { normalizeRasterSeason } from "@/lib/raster/season";
 import { rasterIngest } from "@/lib/raster/pipeline";
 import { isZip, readRasterBundle } from "@/lib/raster/bundle";
 import { prisma } from "@/lib/db";
-import { getFilePath, saveFile } from "@/lib/file-storage";
+import { saveFile } from "@/lib/file-storage";
 import {
   importRasterRoster,
   replaceRasterSource,
@@ -148,29 +148,17 @@ async function processUploadedFile(params: {
     }
   }
   if (normalizedSourceType === "UPPER_LEAGUE_RASTER") {
-    try {
-      return [
-        await importUpperLeagueRasterSource(
-          buffer,
-          params.file.name || "source.pdf",
-          params.displayName,
-          params.fileCount,
-          params.scope.id,
-          params.inputSetId,
-          params.season,
-        ),
-      ];
-    } catch (error) {
-      return NextResponse.json(
-        {
-          error:
-            error instanceof Error
-              ? error.message
-              : "Upper-league raster import failed.",
-        },
-        { status: 422 },
-      );
-    }
+    return [
+      await saveUpperLeagueRasterSource(
+        buffer,
+        params.file.name || "source.pdf",
+        params.displayName,
+        params.fileCount,
+        params.scope.id,
+        params.inputSetId,
+        params.season,
+      ),
+    ];
   }
   return [
     await saveRasterSource(
@@ -186,7 +174,7 @@ async function processUploadedFile(params: {
   ];
 }
 
-async function importUpperLeagueRasterSource(
+async function saveUpperLeagueRasterSource(
   buffer: Buffer,
   fileName: string,
   displayName: string,
@@ -196,7 +184,6 @@ async function importUpperLeagueRasterSource(
   season: string,
 ) {
   const sourceRef = await saveFile(buffer, fileName);
-  const parsed = await rasterIngest.parseUpperLeagueRasterPdf(getFilePath(sourceRef));
   return replaceRasterSource({
     scopeId,
     inputSetId,
@@ -204,7 +191,6 @@ async function importUpperLeagueRasterSource(
     sourceType: "UPPER_LEAGUE_RASTER",
     sourceRef,
     displayName: sourceDisplayName(displayName, fileName, fileCount),
-    parsedJson: JSON.stringify(parsed),
   });
 }
 

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -116,12 +116,13 @@ export function ClubAliasReview({
                     disabled={!canEdit || busyId !== null}
                     list={`club-alias-targets-${candidate.modelClubId}`}
                     value={targets[candidate.modelClubId] ?? ""}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const value = event.currentTarget.value;
                       setTargets((current) => ({
                         ...current,
-                        [candidate.modelClubId]: event.currentTarget.value,
-                      }))
-                    }
+                        [candidate.modelClubId]: value,
+                      }));
+                    }}
                   />
                   <datalist id={`club-alias-targets-${candidate.modelClubId}`}>
                     {wishClubOptions.map((option) => (

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { withBasePath } from "@/lib/base-path";
 
 type ClubAliasCandidate = {
+  capacityRelevant: boolean;
   confirmed?: boolean;
   modelClubId: string;
   modelClubName: string;
@@ -34,6 +35,10 @@ export function ClubAliasReview({
   const [targets, setTargets] = useState<Record<string, string>>(() =>
     initialTargets(candidates),
   );
+  const [capacityRelevantOnly, setCapacityRelevantOnly] = useState(false);
+  const visibleCandidates = capacityRelevantOnly
+    ? candidates.filter((candidate) => candidate.capacityRelevant)
+    : candidates;
   if (!candidates.length) return null;
 
   async function apply(candidate: ClubAliasCandidate) {
@@ -75,100 +80,118 @@ export function ClubAliasReview({
   return (
     <details className="rounded-md border border-[var(--border)] p-3" open>
       <summary className="cursor-pointer text-sm font-medium">
-        Club mappings to review ({candidates.length})
+        Club mappings to review ({visibleCandidates.length}
+        {capacityRelevantOnly ? ` of ${candidates.length}` : ""})
       </summary>
       <p className="mt-2 text-sm text-[var(--muted-foreground)]">
         These capacity clubs use ids that are not linked to the wish import.
         Confirm the suggested match or choose the right wish club.
       </p>
+      <label className="mt-3 flex items-center gap-2 text-sm text-[var(--muted-foreground)]">
+        <input
+          checked={capacityRelevantOnly}
+          className="h-4 w-4"
+          onChange={(event) =>
+            setCapacityRelevantOnly(event.currentTarget.checked)
+          }
+          type="checkbox"
+        />
+        Show only capacity-relevant clubs
+      </label>
       <div className="mt-3 overflow-x-auto">
-        <table className="w-full text-left text-sm">
-          <thead className="text-xs uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-            <tr>
-              <th className="px-2 py-2">Season model</th>
-              <th className="px-2 py-2">Map to wish club</th>
-              <th className="px-2 py-2">Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {candidates.map((candidate) => (
-              <tr
-                className="border-t border-[var(--border)]"
-                key={`${candidate.modelClubId}-${candidate.wishClubId ?? "choose"}`}
-              >
-                <td className="px-2 py-2">
-                  <span className="font-medium">
-                    {candidate.modelClubName}
-                  </span>
-                  <br />
-                  <span className="text-[var(--muted-foreground)]">
-                    {candidate.modelClubId}
-                  </span>
-                  {candidate.confirmed ? (
-                    <span className="ml-2 text-xs text-[var(--muted-foreground)]">
-                      mapped
-                    </span>
-                  ) : null}
-                </td>
-                <td className="px-2 py-2">
-                  <input
-                    className="h-9 w-full min-w-72 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
-                    disabled={!canEdit || busyId !== null}
-                    list={`club-alias-targets-${candidate.modelClubId}`}
-                    value={targets[candidate.modelClubId] ?? ""}
-                    onChange={(event) => {
-                      const value = event.currentTarget.value;
-                      setTargets((current) => ({
-                        ...current,
-                        [candidate.modelClubId]: value,
-                      }));
-                    }}
-                  />
-                  <datalist id={`club-alias-targets-${candidate.modelClubId}`}>
-                    {wishClubOptions.map((option) => (
-                      <option
-                        key={option.clubId}
-                        value={clubOptionText(option)}
-                      />
-                    ))}
-                  </datalist>
-                </td>
-                <td className="px-2 py-2">
-                  {canEdit ? (
-                    <button
-                      className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                      disabled={
-                        busyId !== null ||
-                        !wishClubOptions.some(
-                          (option) =>
-                            clubOptionText(option) ===
-                            targets[candidate.modelClubId],
-                        )
-                      }
-                      onClick={() => void apply(candidate)}
-                      type="button"
-                    >
-                      {busyId === candidate.modelClubId
-                        ? "Saving..."
-                        : candidate.confirmed
-                          ? "Update mapping"
-                          : "Map to wish club"}
-                    </button>
-                  ) : (
-                    <span className="text-[var(--muted-foreground)]">
-                      Scheduler required
-                    </span>
-                  )}
-                </td>
+        {visibleCandidates.length ? (
+          <table className="w-full text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+              <tr>
+                <th className="px-2 py-2">Season model</th>
+                <th className="px-2 py-2">Map to wish club</th>
+                <th className="px-2 py-2">Action</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {visibleCandidates.map((candidate) => (
+                <tr
+                  className="border-t border-[var(--border)]"
+                  key={`${candidate.modelClubId}-${candidate.wishClubId ?? "choose"}`}
+                >
+                  <td className="px-2 py-2">
+                    <span className="font-medium">
+                      {candidate.modelClubName}
+                    </span>
+                    <br />
+                    <span className="text-[var(--muted-foreground)]">
+                      {candidate.modelClubId}
+                    </span>
+                    {candidate.confirmed ? (
+                      <span className="ml-2 text-xs text-[var(--muted-foreground)]">
+                        mapped
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      className="h-9 w-full min-w-72 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
+                      disabled={!canEdit || busyId !== null}
+                      list={`club-alias-targets-${candidate.modelClubId}`}
+                      value={targets[candidate.modelClubId] ?? ""}
+                      onChange={(event) => {
+                        const value = event.currentTarget.value;
+                        setTargets((current) => ({
+                          ...current,
+                          [candidate.modelClubId]: value,
+                        }));
+                      }}
+                    />
+                    <datalist
+                      id={`club-alias-targets-${candidate.modelClubId}`}
+                    >
+                      {wishClubOptions.map((option) => (
+                        <option
+                          key={option.clubId}
+                          value={clubOptionText(option)}
+                        />
+                      ))}
+                    </datalist>
+                  </td>
+                  <td className="px-2 py-2">
+                    {canEdit ? (
+                      <button
+                        className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                        disabled={
+                          busyId !== null ||
+                          !wishClubOptions.some(
+                            (option) =>
+                              clubOptionText(option) ===
+                              targets[candidate.modelClubId],
+                          )
+                        }
+                        onClick={() => void apply(candidate)}
+                        type="button"
+                      >
+                        {busyId === candidate.modelClubId
+                          ? "Saving..."
+                          : candidate.confirmed
+                            ? "Update mapping"
+                            : "Map to wish club"}
+                      </button>
+                    ) : (
+                      <span className="text-[var(--muted-foreground)]">
+                        Scheduler required
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-sm text-[var(--muted-foreground)]">
+            No capacity-relevant club mappings to review.
+          </p>
+        )}
       </div>
       {message ? (
-        <p className="mt-2 text-sm text-[var(--muted-foreground)]">
-          {message}
-        </p>
+        <p className="mt-2 text-sm text-[var(--muted-foreground)]">{message}</p>
       ) : null}
     </details>
   );

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -8,8 +8,8 @@ type ClubAliasCandidate = {
   confirmed?: boolean;
   modelClubId: string;
   modelClubName: string;
-  wishClubId: string;
-  wishClubName: string;
+  wishClubId?: string;
+  wishClubName?: string;
 };
 
 type WishClubOption = {
@@ -94,7 +94,7 @@ export function ClubAliasReview({
             {candidates.map((candidate) => (
               <tr
                 className="border-t border-[var(--border)]"
-                key={`${candidate.modelClubId}-${candidate.wishClubId}`}
+                key={`${candidate.modelClubId}-${candidate.wishClubId ?? "choose"}`}
               >
                 <td className="px-2 py-2">
                   <span className="font-medium">
@@ -180,12 +180,18 @@ function clubOptionText(option: WishClubOption) {
 
 function initialTargets(candidates: ClubAliasCandidate[]) {
   return Object.fromEntries(
-    candidates.map((candidate) => [
-      candidate.modelClubId,
-      clubOptionText({
-        clubId: candidate.wishClubId,
-        clubName: candidate.wishClubName,
-      }),
-    ]),
+    candidates.flatMap((candidate) =>
+      candidate.wishClubId && candidate.wishClubName
+        ? [
+            [
+              candidate.modelClubId,
+              clubOptionText({
+                clubId: candidate.wishClubId,
+                clubName: candidate.wishClubName,
+              }),
+            ],
+          ]
+        : [],
+    ),
   );
 }

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { withBasePath } from "@/lib/base-path";
 
 type ClubAliasCandidate = {
+  confirmed?: boolean;
   modelClubId: string;
   modelClubName: string;
   wishClubId: string;
@@ -31,15 +32,7 @@ export function ClubAliasReview({
   const [busyId, setBusyId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [targets, setTargets] = useState<Record<string, string>>(() =>
-    Object.fromEntries(
-      candidates.map((candidate) => [
-        candidate.modelClubId,
-        clubOptionText({
-          clubId: candidate.wishClubId,
-          clubName: candidate.wishClubName,
-        }),
-      ]),
-    ),
+    initialTargets(candidates),
   );
   if (!candidates.length) return null;
 
@@ -72,7 +65,7 @@ export function ClubAliasReview({
         setMessage(body.error ?? `Failed (${response.status})`);
         return;
       }
-      setMessage("Mapping applied; capacities refreshed.");
+      setMessage("Mapping saved; capacities refreshed.");
       router.refresh();
     } finally {
       setBusyId(null);
@@ -82,7 +75,7 @@ export function ClubAliasReview({
   return (
     <details className="rounded-md border border-[var(--border)] p-3" open>
       <summary className="cursor-pointer text-sm font-medium">
-        Suspected unmapped clubs ({candidates.length})
+        Club mappings to review ({candidates.length})
       </summary>
       <p className="mt-2 text-sm text-[var(--muted-foreground)]">
         These names look like the same club, but the model and wish import use
@@ -111,6 +104,11 @@ export function ClubAliasReview({
                   <span className="text-[var(--muted-foreground)]">
                     {candidate.modelClubId}
                   </span>
+                  {candidate.confirmed ? (
+                    <span className="ml-2 text-xs text-[var(--muted-foreground)]">
+                      mapped
+                    </span>
+                  ) : null}
                 </td>
                 <td className="px-2 py-2">
                   <input
@@ -150,8 +148,10 @@ export function ClubAliasReview({
                       type="button"
                     >
                       {busyId === candidate.modelClubId
-                        ? "Mapping..."
-                        : "Map to wish club"}
+                        ? "Saving..."
+                        : candidate.confirmed
+                          ? "Update mapping"
+                          : "Map to wish club"}
                     </button>
                   ) : (
                     <span className="text-[var(--muted-foreground)]">
@@ -175,4 +175,16 @@ export function ClubAliasReview({
 
 function clubOptionText(option: WishClubOption) {
   return `${option.clubName} - ${option.clubId}`;
+}
+
+function initialTargets(candidates: ClubAliasCandidate[]) {
+  return Object.fromEntries(
+    candidates.map((candidate) => [
+      candidate.modelClubId,
+      clubOptionText({
+        clubId: candidate.wishClubId,
+        clubName: candidate.wishClubName,
+      }),
+    ]),
+  );
 }

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -78,8 +78,8 @@ export function ClubAliasReview({
         Club mappings to review ({candidates.length})
       </summary>
       <p className="mt-2 text-sm text-[var(--muted-foreground)]">
-        These names look like the same club, but the model and wish import use
-        different ids. Confirm only when the pair is correct.
+        These capacity clubs use ids that are not linked to the wish import.
+        Confirm the suggested match or choose the right wish club.
       </p>
       <div className="mt-3 overflow-x-auto">
         <table className="w-full text-left text-sm">

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { withBasePath } from "@/lib/base-path";
 
 type ClubAliasCandidate = {
@@ -30,16 +30,23 @@ export function ClubAliasReview({
   wishClubOptions: WishClubOption[];
 }) {
   const router = useRouter();
-  const [busyId, setBusyId] = useState<string | null>(null);
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [busyIds, setBusyIds] = useState<Record<string, boolean>>({});
   const [message, setMessage] = useState<string | null>(null);
+  const [localCandidates, setLocalCandidates] = useState(candidates);
   const [targets, setTargets] = useState<Record<string, string>>(() =>
     initialTargets(candidates),
   );
   const [capacityRelevantOnly, setCapacityRelevantOnly] = useState(false);
   const visibleCandidates = capacityRelevantOnly
-    ? candidates.filter((candidate) => candidate.capacityRelevant)
-    : candidates;
-  if (!candidates.length) return null;
+    ? localCandidates.filter((candidate) => candidate.capacityRelevant)
+    : localCandidates;
+  if (!localCandidates.length) return null;
+
+  function refreshSoon() {
+    if (refreshTimer.current) clearTimeout(refreshTimer.current);
+    refreshTimer.current = setTimeout(() => router.refresh(), 600);
+  }
 
   async function apply(candidate: ClubAliasCandidate) {
     const selected = wishClubOptions.find(
@@ -49,7 +56,7 @@ export function ClubAliasReview({
       setMessage("Choose a wish club from the list.");
       return;
     }
-    setBusyId(candidate.modelClubId);
+    setBusyIds((current) => ({ ...current, [candidate.modelClubId]: true }));
     setMessage(null);
     try {
       const response = await fetch(
@@ -70,10 +77,22 @@ export function ClubAliasReview({
         setMessage(body.error ?? `Failed (${response.status})`);
         return;
       }
-      setMessage("Mapping saved; capacities refreshed.");
-      router.refresh();
+      setMessage("Mapping saved.");
+      setLocalCandidates((current) =>
+        current.map((item) =>
+          item.modelClubId === candidate.modelClubId
+            ? {
+                ...item,
+                confirmed: true,
+                wishClubId: selected.clubId,
+                wishClubName: selected.clubName,
+              }
+            : item,
+        ),
+      );
+      refreshSoon();
     } finally {
-      setBusyId(null);
+      setBusyIds((current) => ({ ...current, [candidate.modelClubId]: false }));
     }
   }
 
@@ -81,7 +100,7 @@ export function ClubAliasReview({
     <details className="rounded-md border border-[var(--border)] p-3" open>
       <summary className="cursor-pointer text-sm font-medium">
         Club mappings to review ({visibleCandidates.length}
-        {capacityRelevantOnly ? ` of ${candidates.length}` : ""})
+        {capacityRelevantOnly ? ` of ${localCandidates.length}` : ""})
       </summary>
       <p className="mt-2 text-sm text-[var(--muted-foreground)]">
         These capacity clubs use ids that are not linked to the wish import.
@@ -109,79 +128,82 @@ export function ClubAliasReview({
               </tr>
             </thead>
             <tbody>
-              {visibleCandidates.map((candidate) => (
-                <tr
-                  className="border-t border-[var(--border)]"
-                  key={`${candidate.modelClubId}-${candidate.wishClubId ?? "choose"}`}
-                >
-                  <td className="px-2 py-2">
-                    <span className="font-medium">
-                      {candidate.modelClubName}
-                    </span>
-                    <br />
-                    <span className="text-[var(--muted-foreground)]">
-                      {candidate.modelClubId}
-                    </span>
-                    {candidate.confirmed ? (
-                      <span className="ml-2 text-xs text-[var(--muted-foreground)]">
-                        mapped
+              {visibleCandidates.map((candidate) => {
+                const busy = busyIds[candidate.modelClubId] === true;
+                return (
+                  <tr
+                    className="border-t border-[var(--border)]"
+                    key={`${candidate.modelClubId}-${candidate.wishClubId ?? "choose"}`}
+                  >
+                    <td className="px-2 py-2">
+                      <span className="font-medium">
+                        {candidate.modelClubName}
                       </span>
-                    ) : null}
-                  </td>
-                  <td className="px-2 py-2">
-                    <input
-                      className="h-9 w-full min-w-72 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
-                      disabled={!canEdit || busyId !== null}
-                      list={`club-alias-targets-${candidate.modelClubId}`}
-                      value={targets[candidate.modelClubId] ?? ""}
-                      onChange={(event) => {
-                        const value = event.currentTarget.value;
-                        setTargets((current) => ({
-                          ...current,
-                          [candidate.modelClubId]: value,
-                        }));
-                      }}
-                    />
-                    <datalist
-                      id={`club-alias-targets-${candidate.modelClubId}`}
-                    >
-                      {wishClubOptions.map((option) => (
-                        <option
-                          key={option.clubId}
-                          value={clubOptionText(option)}
-                        />
-                      ))}
-                    </datalist>
-                  </td>
-                  <td className="px-2 py-2">
-                    {canEdit ? (
-                      <button
-                        className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                        disabled={
-                          busyId !== null ||
-                          !wishClubOptions.some(
-                            (option) =>
-                              clubOptionText(option) ===
-                              targets[candidate.modelClubId],
-                          )
-                        }
-                        onClick={() => void apply(candidate)}
-                        type="button"
-                      >
-                        {busyId === candidate.modelClubId
-                          ? "Saving..."
-                          : candidate.confirmed
-                            ? "Update mapping"
-                            : "Map to wish club"}
-                      </button>
-                    ) : (
+                      <br />
                       <span className="text-[var(--muted-foreground)]">
-                        Scheduler required
+                        {candidate.modelClubId}
                       </span>
-                    )}
-                  </td>
-                </tr>
-              ))}
+                      {candidate.confirmed ? (
+                        <span className="ml-2 text-xs text-[var(--muted-foreground)]">
+                          mapped
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <input
+                        className="h-9 w-full min-w-72 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
+                        disabled={!canEdit || busy}
+                        list={`club-alias-targets-${candidate.modelClubId}`}
+                        value={targets[candidate.modelClubId] ?? ""}
+                        onChange={(event) => {
+                          const value = event.currentTarget.value;
+                          setTargets((current) => ({
+                            ...current,
+                            [candidate.modelClubId]: value,
+                          }));
+                        }}
+                      />
+                      <datalist
+                        id={`club-alias-targets-${candidate.modelClubId}`}
+                      >
+                        {wishClubOptions.map((option) => (
+                          <option
+                            key={option.clubId}
+                            value={clubOptionText(option)}
+                          />
+                        ))}
+                      </datalist>
+                    </td>
+                    <td className="px-2 py-2">
+                      {canEdit ? (
+                        <button
+                          className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                          disabled={
+                            busy ||
+                            !wishClubOptions.some(
+                              (option) =>
+                                clubOptionText(option) ===
+                                targets[candidate.modelClubId],
+                            )
+                          }
+                          onClick={() => void apply(candidate)}
+                          type="button"
+                        >
+                          {busy
+                            ? "Saving..."
+                            : candidate.confirmed
+                              ? "Update mapping"
+                              : "Map to wish club"}
+                        </button>
+                      ) : (
+                        <span className="text-[var(--muted-foreground)]">
+                          Scheduler required
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         ) : (

--- a/webapp/src/components/raster/capacity/club-alias-review.tsx
+++ b/webapp/src/components/raster/capacity/club-alias-review.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { withBasePath } from "@/lib/base-path";
+
+type ClubAliasCandidate = {
+  modelClubId: string;
+  modelClubName: string;
+  wishClubId: string;
+  wishClubName: string;
+};
+
+type WishClubOption = {
+  clubId: string;
+  clubName: string;
+};
+
+export function ClubAliasReview({
+  canEdit,
+  candidates,
+  inputSetId,
+  wishClubOptions,
+}: {
+  canEdit: boolean;
+  candidates: ClubAliasCandidate[];
+  inputSetId: string;
+  wishClubOptions: WishClubOption[];
+}) {
+  const router = useRouter();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [targets, setTargets] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      candidates.map((candidate) => [
+        candidate.modelClubId,
+        clubOptionText({
+          clubId: candidate.wishClubId,
+          clubName: candidate.wishClubName,
+        }),
+      ]),
+    ),
+  );
+  if (!candidates.length) return null;
+
+  async function apply(candidate: ClubAliasCandidate) {
+    const selected = wishClubOptions.find(
+      (option) => clubOptionText(option) === targets[candidate.modelClubId],
+    );
+    if (!selected) {
+      setMessage("Choose a wish club from the list.");
+      return;
+    }
+    setBusyId(candidate.modelClubId);
+    setMessage(null);
+    try {
+      const response = await fetch(
+        withBasePath(`/api/raster/input-sets/${inputSetId}/club-aliases`),
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            sourceClubId: candidate.modelClubId,
+            targetClubId: selected.clubId,
+          }),
+        },
+      );
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setMessage(body.error ?? `Failed (${response.status})`);
+        return;
+      }
+      setMessage("Mapping applied; capacities refreshed.");
+      router.refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <details className="rounded-md border border-[var(--border)] p-3" open>
+      <summary className="cursor-pointer text-sm font-medium">
+        Suspected unmapped clubs ({candidates.length})
+      </summary>
+      <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+        These names look like the same club, but the model and wish import use
+        different ids. Confirm only when the pair is correct.
+      </p>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="text-xs uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+            <tr>
+              <th className="px-2 py-2">Season model</th>
+              <th className="px-2 py-2">Map to wish club</th>
+              <th className="px-2 py-2">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {candidates.map((candidate) => (
+              <tr
+                className="border-t border-[var(--border)]"
+                key={`${candidate.modelClubId}-${candidate.wishClubId}`}
+              >
+                <td className="px-2 py-2">
+                  <span className="font-medium">
+                    {candidate.modelClubName}
+                  </span>
+                  <br />
+                  <span className="text-[var(--muted-foreground)]">
+                    {candidate.modelClubId}
+                  </span>
+                </td>
+                <td className="px-2 py-2">
+                  <input
+                    className="h-9 w-full min-w-72 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
+                    disabled={!canEdit || busyId !== null}
+                    list={`club-alias-targets-${candidate.modelClubId}`}
+                    value={targets[candidate.modelClubId] ?? ""}
+                    onChange={(event) =>
+                      setTargets((current) => ({
+                        ...current,
+                        [candidate.modelClubId]: event.currentTarget.value,
+                      }))
+                    }
+                  />
+                  <datalist id={`club-alias-targets-${candidate.modelClubId}`}>
+                    {wishClubOptions.map((option) => (
+                      <option
+                        key={option.clubId}
+                        value={clubOptionText(option)}
+                      />
+                    ))}
+                  </datalist>
+                </td>
+                <td className="px-2 py-2">
+                  {canEdit ? (
+                    <button
+                      className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                      disabled={
+                        busyId !== null ||
+                        !wishClubOptions.some(
+                          (option) =>
+                            clubOptionText(option) ===
+                            targets[candidate.modelClubId],
+                        )
+                      }
+                      onClick={() => void apply(candidate)}
+                      type="button"
+                    >
+                      {busyId === candidate.modelClubId
+                        ? "Mapping..."
+                        : "Map to wish club"}
+                    </button>
+                  ) : (
+                    <span className="text-[var(--muted-foreground)]">
+                      Scheduler required
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {message ? (
+        <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+          {message}
+        </p>
+      ) : null}
+    </details>
+  );
+}
+
+function clubOptionText(option: WishClubOption) {
+  return `${option.clubName} - ${option.clubId}`;
+}

--- a/webapp/src/components/raster/coverage/coverage-detail.tsx
+++ b/webapp/src/components/raster/coverage/coverage-detail.tsx
@@ -7,73 +7,93 @@ export function CoverageDetail({
 }) {
   const coverage = parseCoverage(coverageJson);
   if (!coverage || coverage.complete) return null;
+  const gapCount =
+    coverage.scopesWithoutInputSet.length +
+    coverage.excludedGroups.length +
+    coverage.wishGaps.length +
+    coverage.capacityGaps.length +
+    (coverage.unresolvedWishConflicts?.count ?? 0) +
+    (coverage.upperLeague.importPresent ? 0 : 1) +
+    coverage.upperLeague.unmatched.length +
+    coverage.upperLeague.excludedNoHall.length +
+    coverage.upperLeague.invalidRasterzahl.length;
 
   return (
-    <section className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
-      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-        Coverage gaps
-      </h2>
-      <div className="mt-3 grid gap-2 text-sm">
-        <p>
+    <details className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
+      <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+        Coverage gaps ({gapCount})
+      </summary>
+      <div className="mt-3 grid gap-4 text-sm">
+        <p className="text-[var(--muted-foreground)]">
           Scopes: {coverage.spannedScopes.join(", ")}
           {coverage.spannedAll ? "" : " (subset)"}
         </p>
-        {coverage.scopesWithoutInputSet?.length ? (
-          <p>
-            Scopes with no inputs at all:{" "}
-            {coverage.scopesWithoutInputSet.join(", ")}
-          </p>
-        ) : null}
-        {coverage.excludedGroups.length ? (
-          <p>Excluded groups: {coverage.excludedGroups.join(", ")}</p>
-        ) : null}
-        {coverage.wishGaps.length ? (
-          <p>
-            Wish gaps:{" "}
-            {coverage.wishGaps
-              .map((gap) => `${gap.teamId} (${gap.missing.join(", ")})`)
-              .join("; ")}
-          </p>
-        ) : null}
-        {coverage.capacityGaps.length ? (
-          <p>
-            Capacity gaps:{" "}
-            {coverage.capacityGaps
-              .map(
-                (gap) =>
-                  `${gap.clubId}/${gap.hall}/${gap.weekday} ${gap.status}`,
-              )
-              .join("; ")}
-          </p>
-        ) : null}
-        {coverage.unresolvedWishConflicts?.count ? (
-          <p>
-            Unresolved wish conflicts:{" "}
-            {coverage.unresolvedWishConflicts.conflicts
-              .map((conflict) => conflict.id)
-              .join(", ")}
-          </p>
-        ) : null}
-        {coverage.upperLeague?.importPresent === false ? (
+        <ListSection
+          items={coverage.scopesWithoutInputSet}
+          title="Scopes with no inputs"
+        />
+        <ListSection items={coverage.excludedGroups} title="Excluded groups" />
+        <ListSection
+          items={coverage.wishGaps.map(
+            (gap) => `${gap.teamId} (${gap.missing.join(", ")})`,
+          )}
+          title="Wish gaps"
+        />
+        <ListSection
+          items={coverage.capacityGaps.map(
+            (gap) => `${gap.clubId}/${gap.hall}/${gap.weekday} ${gap.status}`,
+          )}
+          title="Capacity gaps"
+        />
+        <ListSection
+          items={
+            coverage.unresolvedWishConflicts?.conflicts.map(
+              (conflict) => conflict.id,
+            ) ?? []
+          }
+          title="Unresolved wish conflicts"
+        />
+        {coverage.upperLeague.importPresent === false ? (
           <p>Upper-league raster import missing.</p>
         ) : null}
-        {coverage.upperLeague?.unmatched.length ? (
-          <p>
-            Upper-league unmatched:{" "}
-            {coverage.upperLeague.unmatched
-              .map((row) => `${row.clubId}/${row.label}`)
-              .join(", ")}
-          </p>
-        ) : null}
-        {coverage.upperLeague?.excludedNoHall.length ? (
-          <p>
-            Upper-league missing hall/day:{" "}
-            {coverage.upperLeague.excludedNoHall
-              .map((row) => `${row.clubId}/${row.label}`)
-              .join(", ")}
-          </p>
-        ) : null}
+        <ListSection
+          items={coverage.upperLeague.unmatched.map(
+            (row) => `${row.clubId}/${row.label}`,
+          )}
+          title="Upper-league unmatched"
+        />
+        <ListSection
+          items={coverage.upperLeague.excludedNoHall.map(
+            (row) => `${row.clubId}/${row.label}`,
+          )}
+          title="Upper-league missing hall/day"
+        />
+        <ListSection
+          items={coverage.upperLeague.invalidRasterzahl.map(
+            (row) =>
+              `${row.clubId}/${row.label}: ${row.rasterzahl} for ${row.size}`,
+          )}
+          title="Upper-league invalid Rasterzahl"
+        />
       </div>
+    </details>
+  );
+}
+
+function ListSection({ title, items }: { title: string; items: string[] }) {
+  if (!items.length) return null;
+  return (
+    <section>
+      <h3 className="font-semibold">
+        {title} ({items.length})
+      </h3>
+      <ul className="mt-2 grid max-h-64 gap-1 overflow-auto rounded-md border border-[var(--border)] p-3 text-[var(--muted-foreground)]">
+        {items.map((item) => (
+          <li className="break-words" key={item}>
+            {item}
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/webapp/src/components/raster/group-mode-review.tsx
+++ b/webapp/src/components/raster/group-mode-review.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { withBasePath } from "@/lib/base-path";
 
 export type GroupModeReviewRow = {
@@ -199,6 +199,8 @@ export function GroupPlanningReview({
     initialMatchValues(groups),
   );
   const [messages, setMessages] = useState<Record<string, string>>({});
+  const [savingGroups, setSavingGroups] = useState<Record<string, boolean>>({});
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setStatuses(initialStatuses(groups));
@@ -207,12 +209,18 @@ export function GroupPlanningReview({
     setMatchValues(initialMatchValues(groups));
   }, [groups]);
 
+  function refreshSoon() {
+    if (refreshTimer.current) clearTimeout(refreshTimer.current);
+    refreshTimer.current = setTimeout(() => router.refresh(), 600);
+  }
+
   async function save(
     group: GroupPlanningReviewRow,
     planningStatus: "include" | "exclude",
   ) {
-    setSavingId(group.groupId);
+    setSavingGroups((current) => ({ ...current, [group.groupId]: true }));
     setStatuses((current) => ({ ...current, [group.groupId]: planningStatus }));
+    setMessages((current) => ({ ...current, [group.groupId]: "Saving..." }));
     try {
       const response = await fetch(
         withBasePath(
@@ -230,15 +238,20 @@ export function GroupPlanningReview({
         };
         throw new Error(body.error ?? "Group review update failed");
       }
-      router.refresh();
+      setMessages((current) => ({ ...current, [group.groupId]: "Saved" }));
+      refreshSoon();
     } catch (error) {
       setStatuses((current) => ({
         ...current,
         [group.groupId]: group.planningStatus ?? "",
       }));
+      setMessages((current) => ({
+        ...current,
+        [group.groupId]: error instanceof Error ? error.message : "Save failed",
+      }));
       window.alert(error instanceof Error ? error.message : "Save failed");
     } finally {
-      setSavingId(null);
+      setSavingGroups((current) => ({ ...current, [group.groupId]: false }));
     }
   }
 
@@ -392,6 +405,7 @@ export function GroupPlanningReview({
         {groups.map((group) => {
           const status = statuses[group.groupId] ?? group.planningStatus ?? "";
           const needsReview = groupNeedsDecision(group, status);
+          const savingGroup = savingGroups[group.groupId] === true;
           return (
             <details
               className={`rounded-md border p-3 ${
@@ -416,13 +430,19 @@ export function GroupPlanningReview({
                       : "0 missing"}
                   </span>
                   <span>
-                    {savingId === group.groupId
+                    {savingGroup
                       ? "saving"
                       : statusLabel(status, group.missingTeams)}
+                    {messages[group.groupId] &&
+                    messages[group.groupId] !== "Saving..." ? (
+                      <span className="block text-xs text-[var(--muted-foreground)]">
+                        {messages[group.groupId]}
+                      </span>
+                    ) : null}
                   </span>
                   <button
                     className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                    disabled={savingId === group.groupId}
+                    disabled={savingGroup}
                     onClick={(event) => {
                       event.preventDefault();
                       void save(group, "include");
@@ -433,7 +453,7 @@ export function GroupPlanningReview({
                   </button>
                   <button
                     className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                    disabled={savingId === group.groupId}
+                    disabled={savingGroup}
                     onClick={(event) => {
                       event.preventDefault();
                       void save(group, "exclude");

--- a/webapp/src/components/raster/group-mode-review.tsx
+++ b/webapp/src/components/raster/group-mode-review.tsx
@@ -375,8 +375,12 @@ export function GroupPlanningReview({
     <details className="mt-3 border-t border-[var(--border)] pt-3">
       <summary className="cursor-pointer text-sm font-semibold">
         Group planning and wish matches (
-        {groups.filter((group) => group.missingTeams > 0).length} incomplete /{" "}
-        {groups.length} total)
+        {
+          groups.filter((group) =>
+            groupNeedsDecision(group, group.planningStatus ?? ""),
+          ).length
+        }{" "}
+        incomplete / {groups.length} total)
       </summary>
       <div className="mt-2 space-y-2">
         <p className="mt-1 text-sm text-[var(--muted-foreground)]">
@@ -386,7 +390,8 @@ export function GroupPlanningReview({
           visible here and can be included again once their wishes arrive.
         </p>
         {groups.map((group) => {
-          const needsReview = group.missingTeams > 0;
+          const status = statuses[group.groupId] ?? group.planningStatus ?? "";
+          const needsReview = groupNeedsDecision(group, status);
           return (
             <details
               className={`rounded-md border p-3 ${
@@ -405,16 +410,15 @@ export function GroupPlanningReview({
                     }
                   >
                     {needsReview
-                      ? `Needs review: ${group.missingTeams}`
+                      ? group.missingTeams > 0
+                        ? `Needs review: ${group.missingTeams}`
+                        : "Needs decision"
                       : "0 missing"}
                   </span>
                   <span>
                     {savingId === group.groupId
                       ? "saving"
-                      : statusLabel(
-                          statuses[group.groupId],
-                          group.missingTeams,
-                        )}
+                      : statusLabel(status, group.missingTeams)}
                   </span>
                   <button
                     className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
@@ -572,6 +576,13 @@ function statusLabel(status: "include" | "exclude" | "", missingTeams: number) {
   if (status === "exclude") return "excluded, deferred";
   if (status === "include") return "included";
   return missingTeams > 0 ? "add wishes or exclude" : "undecided";
+}
+
+function groupNeedsDecision(
+  group: GroupPlanningReviewRow,
+  status: "include" | "exclude" | "",
+) {
+  return group.missingTeams > 0 || !status;
 }
 
 function initialStatuses(groups: GroupPlanningReviewRow[]) {

--- a/webapp/src/components/raster/group-mode-review.tsx
+++ b/webapp/src/components/raster/group-mode-review.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { withBasePath } from "@/lib/base-path";
 
 export type GroupModeReviewRow = {
@@ -196,6 +196,14 @@ export function GroupPlanningReview({
   const [matchValues, setMatchValues] = useState<Record<string, string>>(() =>
     initialMatchValues(groups),
   );
+  const [messages, setMessages] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setStatuses(initialStatuses(groups));
+    setMatchCandidates(initialMatchCandidates(groups));
+    setWeekValues(initialWeekValues(groups));
+    setMatchValues(initialMatchValues(groups));
+  }, [groups]);
 
   async function save(
     group: GroupPlanningReviewRow,
@@ -274,11 +282,18 @@ export function GroupPlanningReview({
   async function applyWish(group: GroupPlanningReviewRow, teamId: string) {
     const team = group.teams.find((candidate) => candidate.id === teamId);
     const candidates = matchCandidates[teamId] ?? team?.wishCandidates ?? [];
-    const wishId = candidates.find(
+    const selected = candidates.find(
       (candidate) => candidateText(candidate) === matchValues[teamId],
-    )?.id;
-    if (!wishId) return;
+    );
+    if (!selected) {
+      setMessages((current) => ({
+        ...current,
+        [teamId]: "Choose a PDF match from the list",
+      }));
+      return;
+    }
     setSavingId(teamId);
+    setMessages((current) => ({ ...current, [teamId]: "Applying..." }));
     try {
       const response = await fetch(
         withBasePath(
@@ -287,7 +302,7 @@ export function GroupPlanningReview({
         {
           method: "PATCH",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ wishId }),
+          body: JSON.stringify({ wishId: selected.id }),
         },
       );
       if (!response.ok) {
@@ -296,6 +311,7 @@ export function GroupPlanningReview({
         };
         throw new Error(body.error ?? "Wish match failed");
       }
+      setMessages((current) => ({ ...current, [teamId]: "Applied" }));
       router.refresh();
     } catch (error) {
       setMatchValues((current) => ({
@@ -312,7 +328,10 @@ export function GroupPlanningReview({
           ),
         ),
       }));
-      window.alert(error instanceof Error ? error.message : "Save failed");
+      setMessages((current) => ({
+        ...current,
+        [teamId]: error instanceof Error ? error.message : "Save failed",
+      }));
     } finally {
       setSavingId(null);
     }
@@ -478,8 +497,11 @@ export function GroupPlanningReview({
                             onClick={() => void applyWish(group, team.id)}
                             type="button"
                           >
-                            Apply
+                            {savingId === team.id ? "Applying" : "Apply"}
                           </button>
+                        </div>
+                        <div className="mt-1 min-h-4 text-[var(--muted-foreground)]">
+                          {messages[team.id] ?? ""}
                         </div>
                       </td>
                       <td className="py-2 pr-3">

--- a/webapp/src/components/raster/group-mode-review.tsx
+++ b/webapp/src/components/raster/group-mode-review.tsx
@@ -112,10 +112,12 @@ export function GroupModeReview({ groups }: { groups: GroupModeReviewRow[] }) {
   if (!groups.length) return null;
 
   return (
-    <div className="mt-3 space-y-2 border-t border-[var(--border)] pt-3">
-      <div>
+    <details className="mt-3 border-t border-[var(--border)] pt-3">
+      <summary className="cursor-pointer text-sm font-semibold">
+        Six-team group mode ({groups.length})
+      </summary>
+      <div className="mt-3 space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="text-sm font-semibold">Six-team group mode</h3>
           <button
             className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
             disabled={savingId !== null}
@@ -129,50 +131,50 @@ export function GroupModeReview({ groups }: { groups: GroupModeReviewRow[] }) {
           Choose whether each 6-team group uses the normal 6er schedule or a 6er
           Doppelrunde, then validate again.
         </p>
+        {groups.map((group) => (
+          <div
+            key={`${group.inputSetId}:${group.groupId}`}
+            className="grid grid-cols-[minmax(10rem,1fr)_12rem_5rem_7rem] items-center gap-3 text-sm"
+          >
+            <span>{group.label}</span>
+            <select
+              data-group-id={group.groupId}
+              data-input-set-id={group.inputSetId}
+              data-raster-group-mode=""
+              className="h-9 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
+              value={values[group.groupId] ?? group.rasterMode ?? ""}
+              disabled={savingId === group.groupId || savingId === "__all__"}
+              onChange={(event) => {
+                const value = event.currentTarget.value;
+                if (value === "single" || value === "double" || value === "") {
+                  setValues((current) => ({
+                    ...current,
+                    [group.groupId]: value,
+                  }));
+                }
+              }}
+            >
+              <option value="" disabled>
+                Select mode
+              </option>
+              <option value="single">Normal 6er</option>
+              <option value="double">6er Doppelrunde</option>
+            </select>
+            <button
+              className="h-9 rounded-md border border-[var(--border)] px-2 text-xs font-medium"
+              disabled={savingId === group.groupId || savingId === "__all__"}
+              onClick={() => void save(group)}
+              type="button"
+            >
+              Save
+            </button>
+            <span className="text-xs text-[var(--muted-foreground)]">
+              {messages[group.groupId] ?? ""}
+            </span>
+          </div>
+        ))}
       </div>
-      {groups.map((group) => (
-        <div
-          key={`${group.inputSetId}:${group.groupId}`}
-          className="grid grid-cols-[minmax(10rem,1fr)_12rem_5rem_7rem] items-center gap-3 text-sm"
-        >
-          <span>{group.label}</span>
-          <select
-            data-group-id={group.groupId}
-            data-input-set-id={group.inputSetId}
-            data-raster-group-mode=""
-            className="h-9 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 text-sm"
-            value={values[group.groupId] ?? group.rasterMode ?? ""}
-            disabled={savingId === group.groupId || savingId === "__all__"}
-            onChange={(event) => {
-              const value = event.currentTarget.value;
-              if (value === "single" || value === "double" || value === "") {
-                setValues((current) => ({
-                  ...current,
-                  [group.groupId]: value,
-                }));
-              }
-            }}
-          >
-            <option value="" disabled>
-              Select mode
-            </option>
-            <option value="single">Normal 6er</option>
-            <option value="double">6er Doppelrunde</option>
-          </select>
-          <button
-            className="h-9 rounded-md border border-[var(--border)] px-2 text-xs font-medium"
-            disabled={savingId === group.groupId || savingId === "__all__"}
-            onClick={() => void save(group)}
-            type="button"
-          >
-            Save
-          </button>
-          <span className="text-xs text-[var(--muted-foreground)]">
-            {messages[group.groupId] ?? ""}
-          </span>
-        </div>
-      ))}
-    </div>
+    </details>
   );
 }
 

--- a/webapp/src/components/raster/group-mode-review.tsx
+++ b/webapp/src/components/raster/group-mode-review.tsx
@@ -383,45 +383,62 @@ export function GroupPlanningReview({
           change a PDF match after a mistaken selection. Excluded groups stay
           visible here and can be included again once their wishes arrive.
         </p>
-        {groups.map((group) => (
-          <details
-            className="rounded-md border border-[var(--border)] p-3"
-            key={`${group.inputSetId}:${group.groupId}`}
-          >
-            <summary className="cursor-pointer">
-              <span className="grid grid-cols-[minmax(10rem,1fr)_8rem_7rem_7rem_7rem] items-center gap-3">
-                <span>{group.label}</span>
-                <span>{group.missingTeams} missing</span>
-                <span>
-                  {savingId === group.groupId
-                    ? "saving"
-                    : statusLabel(statuses[group.groupId], group.missingTeams)}
+        {groups.map((group) => {
+          const needsReview = group.missingTeams > 0;
+          return (
+            <details
+              className={`rounded-md border p-3 ${
+                needsReview
+                  ? "border-[var(--primary)] bg-[var(--primary)]/5"
+                  : "border-[var(--border)]"
+              }`}
+              key={`${group.inputSetId}:${group.groupId}`}
+            >
+              <summary className="cursor-pointer">
+                <span className="grid grid-cols-[minmax(10rem,1fr)_8rem_7rem_7rem_7rem] items-center gap-3">
+                  <span>{group.label}</span>
+                  <span
+                    className={
+                      needsReview ? "font-semibold text-[var(--primary)]" : ""
+                    }
+                  >
+                    {needsReview
+                      ? `Needs review: ${group.missingTeams}`
+                      : "0 missing"}
+                  </span>
+                  <span>
+                    {savingId === group.groupId
+                      ? "saving"
+                      : statusLabel(
+                          statuses[group.groupId],
+                          group.missingTeams,
+                        )}
+                  </span>
+                  <button
+                    className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                    disabled={savingId === group.groupId}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      void save(group, "include");
+                    }}
+                    type="button"
+                  >
+                    Include
+                  </button>
+                  <button
+                    className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                    disabled={savingId === group.groupId}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      void save(group, "exclude");
+                    }}
+                    type="button"
+                  >
+                    Exclude
+                  </button>
                 </span>
-                <button
-                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                  disabled={savingId === group.groupId}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    void save(group, "include");
-                  }}
-                  type="button"
-                >
-                  Include
-                </button>
-                <button
-                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                  disabled={savingId === group.groupId}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    void save(group, "exclude");
-                  }}
-                  type="button"
-                >
-                  Exclude
-                </button>
-              </span>
-            </summary>
-            <div className="mt-3 overflow-auto">
+              </summary>
+              <div className="mt-3 overflow-auto">
               <table className="w-full min-w-[56rem] text-left text-xs">
                 <thead className="text-[var(--muted-foreground)]">
                   <tr>
@@ -534,7 +551,8 @@ export function GroupPlanningReview({
               </table>
             </div>
           </details>
-        ))}
+          );
+        })}
       </div>
     </details>
   );

--- a/webapp/src/components/raster/input-set-actions.tsx
+++ b/webapp/src/components/raster/input-set-actions.tsx
@@ -546,7 +546,9 @@ export function InputSetRunActions({
                   <CombinedBadge combined={combined} />
                   <IncompleteBadge complete={run.coverageComplete} />
                 </span>
-                <span>{runOutcomeLabel(run.outcome, run.status)}</span>
+                <span>
+                  {runOutcomeLabel(run.outcome, run.status, run.settings)}
+                </span>
                 <span className="text-[var(--muted-foreground)]">
                   {runStrategyLabel(run.settings)}
                 </span>
@@ -829,10 +831,17 @@ function runStateLabel(run: Pick<RasterRunRow, "outcome" | "status">) {
   return run.status;
 }
 
-function runOutcomeLabel(outcome: string | null | undefined, status: string) {
+function runOutcomeLabel(
+  outcome: string | null | undefined,
+  status: string,
+  settings?: string | null,
+) {
   if (outcome === "INFEASIBLE") return "No feasible assignment";
   if (outcome === "FAILED") return "Software failure";
   if (outcome === "CANCELLED") return "Cancelled";
+  if (outcome === "PROVEN_OPTIMAL" && runStrategyLabel(settings) === "Initial heuristic") {
+    return "Feasible";
+  }
   if (outcome === "PROVEN_OPTIMAL") return "Proven optimal";
   if (outcome === "FEASIBLE") return "Feasible";
   return runStatusLabel(status);

--- a/webapp/src/components/raster/match-review-panel.tsx
+++ b/webapp/src/components/raster/match-review-panel.tsx
@@ -96,7 +96,7 @@ export function MatchReviewPanel({
                   onClick={() => void mark([record.recordId])}
                   type="button"
                 >
-                  Review
+                  Mark reviewed
                 </button>
               ) : null}
             </div>

--- a/webapp/src/components/raster/match-review-panel.tsx
+++ b/webapp/src/components/raster/match-review-panel.tsx
@@ -51,7 +51,7 @@ export function MatchReviewPanel({
   if (!records.length) return null;
 
   return (
-    <details className="mt-3 border-t border-[var(--border)] pt-3" open>
+    <details className="mt-3 border-t border-[var(--border)] pt-3">
       <summary className="cursor-pointer text-sm font-medium">
         Source matches ({outstanding.length} outstanding)
       </summary>

--- a/webapp/src/components/raster/match-review-panel.tsx
+++ b/webapp/src/components/raster/match-review-panel.tsx
@@ -41,7 +41,7 @@ export function MatchReviewPanel({
         setMessage(body.error ?? `Save failed (${response.status})`);
         return;
       }
-      setMessage("Match review saved");
+      setMessage("Acknowledgement saved");
       router.refresh();
     } finally {
       setBusy(false);
@@ -58,8 +58,8 @@ export function MatchReviewPanel({
       {outstanding.length ? (
         <div className="mt-3 grid gap-2">
           <p className="text-sm text-[var(--muted-foreground)]">
-            Review these source-to-model matches before running. Changed source
-            data only reopens the affected teams.
+            Acknowledge these source-to-model matches before running. Changed
+            source data only reopens the affected teams.
           </p>
           {canEdit ? (
             <button
@@ -70,7 +70,7 @@ export function MatchReviewPanel({
               }
               type="button"
             >
-              {busy ? <BusyLabel label="Saving" /> : "Mark all reviewed"}
+              {busy ? <BusyLabel label="Saving" /> : "Acknowledge all"}
             </button>
           ) : null}
           {outstanding.map((record) => (
@@ -96,7 +96,7 @@ export function MatchReviewPanel({
                   onClick={() => void mark([record.recordId])}
                   type="button"
                 >
-                  Mark reviewed
+                  Acknowledge
                 </button>
               ) : null}
             </div>

--- a/webapp/src/components/raster/match-review-panel.tsx
+++ b/webapp/src/components/raster/match-review-panel.tsx
@@ -78,10 +78,15 @@ export function MatchReviewPanel({
               className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm"
               key={record.recordId}
             >
-              <span>
-                {record.label}{" "}
+              <span className="grid gap-1">
+                <span>
+                  {record.label}{" "}
+                  <span className="text-[var(--muted-foreground)]">
+                    {record.reason === "changed" ? "changed" : "not reviewed"}
+                  </span>
+                </span>
                 <span className="text-[var(--muted-foreground)]">
-                  {record.reason === "changed" ? "changed" : "not reviewed"}
+                  {record.detail}
                 </span>
               </span>
               {canEdit ? (

--- a/webapp/src/components/raster/nav/scope-season-picker.tsx
+++ b/webapp/src/components/raster/nav/scope-season-picker.tsx
@@ -22,6 +22,7 @@ export function ScopeSeasonPicker({ scopes }: { scopes: RasterScopeOption[] }) {
   function update(name: "scope" | "season", value: string) {
     const next = new URLSearchParams(searchParams);
     next.set(name, value);
+    next.delete("workspace");
     router.push(`${pathname}?${next.toString()}`);
   }
 

--- a/webapp/src/components/raster/sources/raster-sources-panel.tsx
+++ b/webapp/src/components/raster/sources/raster-sources-panel.tsx
@@ -59,6 +59,7 @@ export function RasterSourcesPanel({
   const [sourceMessages, setSourceMessages] = useState<Record<string, string>>(
     {},
   );
+  const defaultGroupDisplayName = `${scopeCode} group assignment ${season}`;
 
   async function submitLink(formData: FormData) {
     setMessage(null);
@@ -72,7 +73,9 @@ export function RasterSourcesPanel({
       inputSetId: inputSet.id,
       sourceType: String(formData.get("sourceType") ?? ""),
       sourceRef: String(formData.get("sourceRef") ?? ""),
-      displayName: String(formData.get("displayName") ?? ""),
+      displayName:
+        String(formData.get("displayName") ?? "").trim() ||
+        defaultGroupDisplayName,
       contentHash: String(formData.get("contentHash") ?? "") || undefined,
       parsedJson: String(formData.get("parsedJson") ?? "") || undefined,
     };
@@ -117,33 +120,50 @@ export function RasterSourcesPanel({
     router.refresh();
   }
 
-  async function refreshSource(sourceId: string) {
-    setRefreshingId(sourceId);
-    setMessage(null);
+  async function refreshOneSource(sourceId: string) {
     setSourceMessages((messages) => ({
       ...messages,
       [sourceId]: "Parsing...",
     }));
-    try {
-      const response = await fetch(
-        withBasePath(`/api/raster/sources/${sourceId}/refresh`),
-        { method: "POST" },
-      );
-      const body = (await response.json().catch(() => ({}))) as {
-        error?: string;
-        summary?: string;
-      };
-      if (!response.ok) {
-        setSourceMessages((messages) => ({
-          ...messages,
-          [sourceId]: body.error ?? `Parse failed (${response.status})`,
-        }));
-        return;
-      }
+    const response = await fetch(
+      withBasePath(`/api/raster/sources/${sourceId}/refresh`),
+      { method: "POST" },
+    );
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+      summary?: string;
+    };
+    if (!response.ok) {
       setSourceMessages((messages) => ({
         ...messages,
-        [sourceId]: body.summary ?? "Parsed",
+        [sourceId]: body.error ?? `Parse failed (${response.status})`,
       }));
+      return;
+    }
+    setSourceMessages((messages) => ({
+      ...messages,
+      [sourceId]: body.summary ?? "Parsed",
+    }));
+  }
+
+  async function refreshSource(sourceId: string) {
+    setRefreshingId(sourceId);
+    setMessage(null);
+    try {
+      await refreshOneSource(sourceId);
+      router.refresh();
+    } finally {
+      setRefreshingId(null);
+    }
+  }
+
+  async function refreshAllSources() {
+    setRefreshingId("all");
+    setMessage(null);
+    try {
+      for (const source of sources) {
+        await refreshOneSource(source.id);
+      }
       router.refresh();
     } finally {
       setRefreshingId(null);
@@ -231,8 +251,7 @@ export function RasterSourcesPanel({
               <input
                 className="h-10 rounded-md border border-[var(--border)] bg-transparent px-3 text-sm font-normal"
                 name="displayName"
-                placeholder={`${scopeCode} group assignment ${season}`}
-                required
+                placeholder={defaultGroupDisplayName}
               />
             </label>
             <button
@@ -277,7 +296,11 @@ export function RasterSourcesPanel({
             <input name="scopeCode" type="hidden" value={scopeCode} />
             <input name="season" type="hidden" value={season} />
             <input name="inputSetId" type="hidden" value={inputSet.id} />
-            <input name="sourceType" type="hidden" value="UPPER_LEAGUE_RASTER" />
+            <input
+              name="sourceType"
+              type="hidden"
+              value="UPPER_LEAGUE_RASTER"
+            />
             <label className="grid gap-1 text-sm font-medium">
               Upper-league raster PDF
               <input
@@ -318,113 +341,127 @@ export function RasterSourcesPanel({
       )}
       <div className="divide-y divide-[var(--border)]">
         {sources.length ? (
-          sources.map((source) => (
-            <div
-              key={source.id}
-              className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[10rem_minmax(12rem,1fr)_8rem_12rem_7rem_7rem]"
-            >
-              <span className="font-medium">
-                {source.sourceType} {source.season}
-              </span>
-              <span className="break-all">{source.displayName}</span>
-              <span
-                className={
-                  source.parsedJson
-                    ? "text-[var(--primary)]"
-                    : "text-[var(--muted-foreground)]"
-                }
-              >
-                {source.parsedJson ? "Parsed" : "Needs parse"}
-              </span>
-              <span className="text-[var(--muted-foreground)]">
-                {new Date(source.updatedAt).toLocaleDateString()}
-              </span>
-              {canEdit ? (
+          <>
+            {canEdit ? (
+              <div className="flex justify-end px-4 py-3">
                 <button
-                  aria-label={`Parse ${source.displayName}`}
-                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
-                  disabled={refreshingId === source.id}
-                  onClick={() => void refreshSource(source.id)}
+                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                  disabled={refreshingId !== null}
+                  onClick={() => void refreshAllSources()}
                   type="button"
                 >
-                  {refreshingId === source.id ? "..." : "Parse"}
+                  {refreshingId === "all" ? "..." : "Parse all"}
                 </button>
-              ) : null}
-              {canEdit ? (
-                <button
-                  aria-label={`Delete ${source.displayName}`}
-                  className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
-                  disabled={deletingId === source.id}
-                  onClick={() =>
-                    void deleteSource(source.id, source.displayName)
+              </div>
+            ) : null}
+            {sources.map((source) => (
+              <div
+                key={source.id}
+                className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[10rem_minmax(12rem,1fr)_8rem_12rem_7rem_7rem]"
+              >
+                <span className="font-medium">
+                  {source.sourceType} {source.season}
+                </span>
+                <span className="break-all">{source.displayName}</span>
+                <span
+                  className={
+                    source.parsedJson
+                      ? "text-[var(--primary)]"
+                      : "text-[var(--muted-foreground)]"
                   }
-                  type="button"
                 >
-                  {deletingId === source.id ? "..." : "Delete"}
-                </button>
-              ) : null}
-              <a
-                className="break-all text-[var(--primary)] md:col-span-6"
-                href={source.sourceRef}
-                rel="noreferrer"
-                target="_blank"
-              >
-                {source.sourceRef}
-              </a>
-              {sourceMessages[source.id] ? (
-                <p className="text-sm text-[var(--muted-foreground)] md:col-span-6">
-                  {sourceMessages[source.id]}
-                </p>
-              ) : null}
-              {source.parsedJson ? (
-                <details className="md:col-span-6">
-                  <summary className="cursor-pointer text-sm font-medium">
-                    Parsed data: {parsedSourceSummary(source.parsedJson)}
-                  </summary>
-                  {source.sourceType.toUpperCase() === "WISHES_PDF" ? (
-                    <ProjectionReview
-                      inputSet={inputSet}
-                      sourceJson={source.parsedJson}
-                    />
-                  ) : null}
-                  {source.sourceType.toUpperCase() ===
-                  "UPPER_LEAGUE_RASTER" ? (
-                    <UpperLeaguePreview
-                      review={upperLeagueReview}
-                      sourceJson={source.parsedJson}
-                    />
-                  ) : null}
-                  {canEdit ? (
-                    <form
-                      action={(formData) =>
-                        void saveParsedJson(source.id, formData)
-                      }
-                      className="mt-2 grid gap-2"
-                    >
-                      <textarea
-                        className="min-h-80 rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs"
-                        name="parsedJson"
-                        defaultValue={formatParsedJson(source.parsedJson)}
+                  {source.parsedJson ? "Parsed" : "Needs parse"}
+                </span>
+                <span className="text-[var(--muted-foreground)]">
+                  {new Date(source.updatedAt).toLocaleDateString()}
+                </span>
+                {canEdit ? (
+                  <button
+                    aria-label={`Parse ${source.displayName}`}
+                    className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
+                    disabled={refreshingId !== null}
+                    onClick={() => void refreshSource(source.id)}
+                    type="button"
+                  >
+                    {refreshingId === source.id ? "..." : "Parse"}
+                  </button>
+                ) : null}
+                {canEdit ? (
+                  <button
+                    aria-label={`Delete ${source.displayName}`}
+                    className="h-9 rounded-md border border-[var(--border)] px-3 text-sm"
+                    disabled={deletingId === source.id}
+                    onClick={() =>
+                      void deleteSource(source.id, source.displayName)
+                    }
+                    type="button"
+                  >
+                    {deletingId === source.id ? "..." : "Delete"}
+                  </button>
+                ) : null}
+                <a
+                  className="break-all text-[var(--primary)] md:col-span-6"
+                  href={source.sourceRef}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  {source.sourceRef}
+                </a>
+                {sourceMessages[source.id] ? (
+                  <p className="text-sm text-[var(--muted-foreground)] md:col-span-6">
+                    {sourceMessages[source.id]}
+                  </p>
+                ) : null}
+                {source.parsedJson ? (
+                  <details className="md:col-span-6">
+                    <summary className="cursor-pointer text-sm font-medium">
+                      Parsed data: {parsedSourceSummary(source.parsedJson)}
+                    </summary>
+                    {source.sourceType.toUpperCase() === "WISHES_PDF" ? (
+                      <ProjectionReview
+                        inputSet={inputSet}
+                        sourceJson={source.parsedJson}
                       />
-                      <button
-                        className="h-9 w-fit rounded-md border border-[var(--border)] px-3 text-sm font-medium"
-                        disabled={savingParsedId === source.id}
-                        type="submit"
+                    ) : null}
+                    {source.sourceType.toUpperCase() ===
+                    "UPPER_LEAGUE_RASTER" ? (
+                      <UpperLeaguePreview
+                        review={upperLeagueReview}
+                        sourceJson={source.parsedJson}
+                      />
+                    ) : null}
+                    {canEdit ? (
+                      <form
+                        action={(formData) =>
+                          void saveParsedJson(source.id, formData)
+                        }
+                        className="mt-2 grid gap-2"
                       >
-                        {savingParsedId === source.id
-                          ? "..."
-                          : "Save parsed data"}
-                      </button>
-                    </form>
-                  ) : (
-                    <pre className="mt-2 max-h-96 overflow-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 text-xs">
-                      {formatParsedJson(source.parsedJson)}
-                    </pre>
-                  )}
-                </details>
-              ) : null}
-            </div>
-          ))
+                        <textarea
+                          className="min-h-80 rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs"
+                          name="parsedJson"
+                          defaultValue={formatParsedJson(source.parsedJson)}
+                        />
+                        <button
+                          className="h-9 w-fit rounded-md border border-[var(--border)] px-3 text-sm font-medium"
+                          disabled={savingParsedId === source.id}
+                          type="submit"
+                        >
+                          {savingParsedId === source.id
+                            ? "..."
+                            : "Save parsed data"}
+                        </button>
+                      </form>
+                    ) : (
+                      <pre className="mt-2 max-h-96 overflow-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 text-xs">
+                        {formatParsedJson(source.parsedJson)}
+                      </pre>
+                    )}
+                  </details>
+                ) : null}
+              </div>
+            ))}
+          </>
         ) : (
           <p className="px-4 py-6 text-sm text-[var(--muted-foreground)]">
             No sources for {scopeCode}.
@@ -533,7 +570,10 @@ function UpperLeagueReviewList({
       {rows.length ? (
         <ul className="mt-2 grid gap-1 text-[var(--muted-foreground)]">
           {rows.slice(0, 8).map((row, index) => (
-            <li className="flex justify-between gap-2" key={`${row.label}-${index}`}>
+            <li
+              className="flex justify-between gap-2"
+              key={`${row.label}-${index}`}
+            >
               <span className="break-words">{row.label}</span>
               {row.detail ? <span>{row.detail}</span> : null}
             </li>

--- a/webapp/src/components/raster/wish-import-review-panel.tsx
+++ b/webapp/src/components/raster/wish-import-review-panel.tsx
@@ -122,10 +122,7 @@ export function WishImportReviewPanel({
   }
 
   return (
-    <details
-      className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4"
-      open
-    >
+    <details className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
       <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
         {t("title")} ({counts.all})
       </summary>

--- a/webapp/src/components/raster/wish-import-review-panel.tsx
+++ b/webapp/src/components/raster/wish-import-review-panel.tsx
@@ -122,10 +122,13 @@ export function WishImportReviewPanel({
   }
 
   return (
-    <section className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
-      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-        {t("title")}
-      </h2>
+    <details
+      className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4"
+      open
+    >
+      <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
+        {t("title")} ({counts.all})
+      </summary>
       <div
         className="mt-3 flex flex-wrap gap-2"
         role="group"
@@ -279,7 +282,7 @@ export function WishImportReviewPanel({
       {message ? (
         <p className="mt-2 text-sm text-[var(--muted-foreground)]">{message}</p>
       ) : null}
-    </section>
+    </details>
   );
 }
 

--- a/webapp/src/components/raster/wish-import-review-panel.tsx
+++ b/webapp/src/components/raster/wish-import-review-panel.tsx
@@ -99,13 +99,12 @@ export function WishImportReviewPanel({
   const visibleMissing = showMissing ? review.missingWishes : [];
   const { overwrites: overwriteConflicts, sourceChanged: sourceConflicts } =
     partitionConflicts(review.conflicts);
+  const actionableCount =
+    review.conflicts.length +
+    review.unmatchedRows.length +
+    visibleMissing.length;
   const counts: Record<Filter, number> = {
-    all:
-      review.conflicts.length +
-      review.addedWishes.length +
-      review.unmatchedRows.length +
-      review.settledMatches.length +
-      visibleMissing.length,
+    all: actionableCount,
     overwrites: overwriteConflicts.length,
     sourceChanged: sourceConflicts.length,
     added: review.addedWishes.length,
@@ -113,7 +112,11 @@ export function WishImportReviewPanel({
     missing: visibleMissing.length,
     settled: review.settledMatches.length,
   };
-  if (!counts.all) {
+  if (
+    !actionableCount &&
+    !review.addedWishes.length &&
+    !review.settledMatches.length
+  ) {
     return (
       <p className="rounded-lg border border-[var(--border)] bg-[var(--panel)] px-4 py-3 text-sm text-[var(--muted-foreground)]">
         {t("empty")}
@@ -122,9 +125,12 @@ export function WishImportReviewPanel({
   }
 
   return (
-    <details className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4">
+    <details
+      className="rounded-lg border border-[var(--border)] bg-[var(--panel)] p-4"
+      open={actionableCount > 0}
+    >
       <summary className="cursor-pointer text-sm font-semibold uppercase tracking-[0.16em] text-[var(--muted-foreground)]">
-        {t("title")} ({counts.all})
+        {t("title")} ({t("toReview", { count: actionableCount })})
       </summary>
       <div
         className="mt-3 flex flex-wrap gap-2"
@@ -172,7 +178,7 @@ export function WishImportReviewPanel({
       {shows("added") && review.addedWishes.length ? (
         <div className="mt-4 grid gap-2">
           <p className="text-sm text-[var(--muted-foreground)]">
-            {t("addedCount", { count: review.addedWishes.length })}
+            {t("addedInfoCount", { count: review.addedWishes.length })}
           </p>
           {review.addedWishes.map((wish) => (
             <div

--- a/webapp/src/components/raster/wish-import-review-panel.tsx
+++ b/webapp/src/components/raster/wish-import-review-panel.tsx
@@ -103,8 +103,10 @@ export function WishImportReviewPanel({
     review.conflicts.length +
     review.unmatchedRows.length +
     visibleMissing.length;
+  const totalVisibleCount =
+    actionableCount + review.addedWishes.length + review.settledMatches.length;
   const counts: Record<Filter, number> = {
-    all: actionableCount,
+    all: totalVisibleCount,
     overwrites: overwriteConflicts.length,
     sourceChanged: sourceConflicts.length,
     added: review.addedWishes.length,

--- a/webapp/src/i18n/messages/de.json
+++ b/webapp/src/i18n/messages/de.json
@@ -428,7 +428,9 @@
         "overwrites": "Überschreibt Ihre Änderung",
         "sourceChanged": "Quelle geändert"
       },
+      "toReview": "{count, plural, one {# zu prüfen} other {# zu prüfen}}",
       "addedCount": "{count, plural, one {# hinzugefügter Wunsch, noch nicht geprüft} other {# hinzugefügte Wünsche, noch nicht geprüft}}",
+      "addedInfoCount": "{count, plural, one {# Wunsch sauber importiert} other {# Wünsche sauber importiert}}",
       "settledCount": "{count, plural, one {# erledigte Zuordnung} other {# erledigte Zuordnungen}}",
       "noopMatch": "Keine Änderung",
       "acceptedMatch": "Entschieden: {decision}",

--- a/webapp/src/i18n/messages/en.json
+++ b/webapp/src/i18n/messages/en.json
@@ -428,7 +428,9 @@
         "overwrites": "Overwrites your edit",
         "sourceChanged": "Source changed"
       },
+      "toReview": "{count, plural, one {# to review} other {# to review}}",
       "addedCount": "{count, plural, one {# added wish, not yet reviewed} other {# added wishes, not yet reviewed}}",
+      "addedInfoCount": "{count, plural, one {# wish imported cleanly} other {# wishes imported cleanly}}",
       "settledCount": "{count, plural, one {# settled match} other {# settled matches}}",
       "noopMatch": "No change",
       "acceptedMatch": "Decided: {decision}",

--- a/webapp/src/i18n/messages/es.json
+++ b/webapp/src/i18n/messages/es.json
@@ -428,7 +428,9 @@
         "overwrites": "Sobrescribe tu cambio",
         "sourceChanged": "La fuente cambió"
       },
+      "toReview": "{count, plural, one {# por revisar} other {# por revisar}}",
       "addedCount": "{count, plural, one {# deseo añadido, aún sin revisar} other {# deseos añadidos, aún sin revisar}}",
+      "addedInfoCount": "{count, plural, one {# deseo importado sin conflicto} other {# deseos importados sin conflicto}}",
       "settledCount": "{count, plural, one {# emparejamiento resuelto} other {# emparejamientos resueltos}}",
       "noopMatch": "Sin cambios",
       "acceptedMatch": "Decidido: {decision}",

--- a/webapp/src/i18n/messages/fr.json
+++ b/webapp/src/i18n/messages/fr.json
@@ -428,7 +428,9 @@
         "overwrites": "Annule votre modification",
         "sourceChanged": "Source modifiée"
       },
+      "toReview": "{count, plural, one {# à revoir} other {# à revoir}}",
       "addedCount": "{count, plural, one {# souhait ajouté, pas encore révisé} other {# souhaits ajoutés, pas encore révisés}}",
+      "addedInfoCount": "{count, plural, one {# souhait importé sans conflit} other {# souhaits importés sans conflit}}",
       "settledCount": "{count, plural, one {# appariement réglé} other {# appariements réglés}}",
       "noopMatch": "Aucun changement",
       "acceptedMatch": "Décidé : {decision}",

--- a/webapp/src/i18n/messages/pt.json
+++ b/webapp/src/i18n/messages/pt.json
@@ -428,7 +428,9 @@
         "overwrites": "Sobrepõe a sua alteração",
         "sourceChanged": "Origem alterada"
       },
+      "toReview": "{count, plural, one {# a rever} other {# a rever}}",
       "addedCount": "{count, plural, one {# desejo adicionado, ainda por rever} other {# desejos adicionados, ainda por rever}}",
+      "addedInfoCount": "{count, plural, one {# desejo importado sem conflito} other {# desejos importados sem conflito}}",
       "settledCount": "{count, plural, one {# correspondência resolvida} other {# correspondências resolvidas}}",
       "noopMatch": "Sem alterações",
       "acceptedMatch": "Decidido: {decision}",

--- a/webapp/src/lib/raster/match-review.ts
+++ b/webapp/src/lib/raster/match-review.ts
@@ -17,6 +17,7 @@ type TeamMatchRecord = {
 export type RasterMatchReviewState = {
   recordId: string;
   label: string;
+  detail: string;
   fingerprint: string;
   status: "settled" | "outstanding";
   reason: "never_reviewed" | "changed" | null;
@@ -49,7 +50,8 @@ export function deriveMatchReviewState(
     const reviewedFingerprint = reviewByRecord.get(recordId);
     return {
       recordId,
-      label: team.label ?? team.name ?? recordId,
+      label: matchReviewLabel(team),
+      detail: matchReviewDetail(team),
       fingerprint,
       status: reviewedFingerprint === fingerprint ? "settled" : "outstanding",
       reason: !reviewedFingerprint
@@ -59,6 +61,24 @@ export function deriveMatchReviewState(
           : "changed",
     };
   });
+}
+
+function matchReviewLabel(team: TeamMatchRecord) {
+  return [team.clubName ?? team.clubId, team.label ?? team.name ?? team.id]
+    .filter(Boolean)
+    .join(" / ");
+}
+
+function matchReviewDetail(team: TeamMatchRecord) {
+  return [
+    team.homeWeekday ? `home ${team.homeWeekday}` : null,
+    team.hall ? `hall ${team.hall}` : null,
+    team.startTime ? team.startTime : null,
+    team.spielwochePref ? `week ${team.spielwochePref}` : null,
+    team.wishMatchId ? "matched wish data" : "no matched wish data",
+  ]
+    .filter(Boolean)
+    .join(", ");
 }
 
 export async function listMatchReviewState(inputSetId: string) {

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -297,6 +297,7 @@ async function inferCapacityRows(
           homeWeekday?: string;
           startTime?: string;
           spielwochePref?: string;
+          capacityRelevant?: boolean;
         }>;
       })
     : { teams: [] };
@@ -350,6 +351,7 @@ async function findCapacityAliasReview(
   }
   const model = JSON.parse(inputSet.seasonModelJson) as {
     clubs?: Array<{ id?: string; name?: string }>;
+    teams?: Array<{ clubId?: string; capacityRelevant?: boolean }>;
     clubAliases?: Array<{
       sourceClubId?: string;
       sourceClubName?: string;
@@ -370,6 +372,13 @@ async function findCapacityAliasReview(
   }
   const wishClubOptions = [...wishesByName.values()].sort((a, b) =>
     a.clubName.localeCompare(b.clubName),
+  );
+  const wishClubIds = new Set(wishClubOptions.map((wish) => wish.clubId));
+  const capacityClubIds = new Set(
+    (model.teams ?? [])
+      .filter((team) => team.capacityRelevant !== false)
+      .map((team) => team.clubId)
+      .filter((clubId): clubId is string => Boolean(clubId)),
   );
 
   const candidates: HallCapacityAliasCandidate[] = [];
@@ -393,6 +402,8 @@ async function findCapacityAliasReview(
       confirmedSourceIds,
       wishesByName,
       wishClubOptions,
+      wishClubIds,
+      capacityClubIds,
     );
     if (!candidate) continue;
     const key = [candidate.modelClubId, candidate.wishClubId ?? ""].join("\0");
@@ -415,14 +426,16 @@ function capacityAliasCandidateForClub(
   confirmedSourceIds: Set<string | undefined>,
   wishesByName: Map<string, HallCapacityWishClubOption>,
   wishClubOptions: HallCapacityWishClubOption[],
+  wishClubIds: Set<string>,
+  capacityClubIds: Set<string>,
 ): HallCapacityAliasCandidate | null {
   if (!club.id || !club.name || confirmedSourceIds.has(club.id)) return null;
+  if (!capacityClubIds.has(club.id) || wishClubIds.has(club.id)) return null;
   const exactWish = wishesByName.get(capacityClubNameKey(club.name));
   const likelyWishes = exactWish
     ? [exactWish]
     : findLikelyWishClubs(club.name, wishClubOptions);
   const wish = likelyWishes.length === 1 ? likelyWishes[0] : null;
-  if (!wish && likelyWishes.length === 0) return null;
   if (wish?.clubId === club.id) return null;
   return {
     modelClubId: club.id,
@@ -509,10 +522,11 @@ function addCapacitySlot(
     homeWeekday?: string | null;
     startTime?: string | null;
     spielwochePref?: string | null;
+    capacityRelevant?: boolean | null;
   },
 ) {
   const weekday = normalizeWeekday(row.homeWeekday ?? undefined);
-  if (!row.clubId || !weekday) return;
+  if (!row.clubId || !weekday || row.capacityRelevant === false) return;
   const slot: CapacitySlot = {
     clubId: row.clubId,
     hall: row.hall || "1",

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -25,6 +25,11 @@ type CapacitySlot = {
 };
 
 type CapacityAliasClub = { id?: string; name?: string };
+type CapacityAliasTeam = {
+  id?: string;
+  clubId?: string;
+  capacityRelevant?: boolean;
+};
 
 export type HallCapacityReviewRow = Omit<InferredHallCapacity, "scopeId"> & {
   id: string | null;
@@ -45,6 +50,7 @@ export type HallCapacityReview = {
 };
 
 export type HallCapacityAliasCandidate = {
+  capacityRelevant: boolean;
   confirmed?: boolean;
   modelClubId: string;
   modelClubName: string;
@@ -336,9 +342,7 @@ async function inferCapacityRows(
   return [...inferred.values()];
 }
 
-async function findCapacityAliasReview(
-  inputSetId: string,
-) {
+async function findCapacityAliasReview(inputSetId: string) {
   const inputSet = await prisma.rasterInputSet.findUnique({
     where: { id: inputSetId },
     select: {
@@ -352,7 +356,7 @@ async function findCapacityAliasReview(
   const model = JSON.parse(inputSet.seasonModelJson) as {
     clubs?: Array<{ id?: string; name?: string }>;
     groups?: Array<{ planningStatus?: string; teamIds?: string[] }>;
-    teams?: Array<{ id?: string; clubId?: string }>;
+    teams?: CapacityAliasTeam[];
     clubAliases?: Array<{
       sourceClubId?: string;
       sourceClubName?: string;
@@ -386,6 +390,16 @@ async function findCapacityAliasReview(
       .map((team) => team.clubId)
       .filter((clubId): clubId is string => Boolean(clubId)),
   );
+  const capacityRelevantClubIds = new Set(
+    (model.teams ?? [])
+      .filter(
+        (team) =>
+          (!team.id || !excludedTeamIds.has(team.id)) &&
+          team.capacityRelevant !== false,
+      )
+      .map((team) => team.clubId)
+      .filter((clubId): clubId is string => Boolean(clubId)),
+  );
 
   const candidates: HallCapacityAliasCandidate[] = [];
   const seen = new Set<string>();
@@ -396,6 +410,7 @@ async function findCapacityAliasReview(
     seen.add(key);
     candidates.push({
       confirmed: true,
+      capacityRelevant: capacityRelevantClubIds.has(alias.sourceClubId),
       modelClubId: alias.sourceClubId,
       modelClubName: alias.sourceClubName ?? alias.sourceClubId,
       wishClubId: alias.targetClubId,
@@ -410,6 +425,7 @@ async function findCapacityAliasReview(
       wishClubOptions,
       wishClubIds,
       capacityClubIds,
+      capacityRelevantClubIds,
     );
     if (!candidate) continue;
     const key = [candidate.modelClubId, candidate.wishClubId ?? ""].join("\0");
@@ -434,6 +450,7 @@ function capacityAliasCandidateForClub(
   wishClubOptions: HallCapacityWishClubOption[],
   wishClubIds: Set<string>,
   capacityClubIds: Set<string>,
+  capacityRelevantClubIds: Set<string>,
 ): HallCapacityAliasCandidate | null {
   if (!club.id || !club.name || confirmedSourceIds.has(club.id)) return null;
   if (!capacityClubIds.has(club.id) || wishClubIds.has(club.id)) return null;
@@ -444,6 +461,7 @@ function capacityAliasCandidateForClub(
   const wish = likelyWishes.length === 1 ? likelyWishes[0] : null;
   if (wish?.clubId === club.id) return null;
   return {
+    capacityRelevant: capacityRelevantClubIds.has(club.id),
     modelClubId: club.id,
     modelClubName: club.name,
     wishClubId: wish?.clubId,
@@ -483,9 +501,7 @@ function capacityClubTokens(value: string) {
     .split(/[^a-z0-9]+/)
     .filter(
       (token) =>
-        token.length > 1 &&
-        !/^\d+$/.test(token) &&
-        !clubNoiseTokens.has(token),
+        token.length > 1 && !/^\d+$/.test(token) && !clubNoiseTokens.has(token),
     );
 }
 

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -24,6 +24,8 @@ type CapacitySlot = {
   durationMinutes: number;
 };
 
+type CapacityAliasClub = { id?: string; name?: string };
+
 export type HallCapacityReviewRow = Omit<InferredHallCapacity, "scopeId"> & {
   id: string | null;
   storedCapacity: number | null;
@@ -46,8 +48,8 @@ export type HallCapacityAliasCandidate = {
   confirmed?: boolean;
   modelClubId: string;
   modelClubName: string;
-  wishClubId: string;
-  wishClubName: string;
+  wishClubId?: string;
+  wishClubName?: string;
 };
 
 export type HallCapacityWishClubOption = {
@@ -386,19 +388,17 @@ async function findCapacityAliasReview(
     });
   }
   for (const club of model.clubs ?? []) {
-    if (!club.id || !club.name) continue;
-    if (confirmedSourceIds.has(club.id)) continue;
-    const wish = wishesByName.get(capacityClubNameKey(club.name));
-    if (!wish || wish.clubId === club.id) continue;
-    const key = [club.id, wish.clubId].join("\0");
+    const candidate = capacityAliasCandidateForClub(
+      club,
+      confirmedSourceIds,
+      wishesByName,
+      wishClubOptions,
+    );
+    if (!candidate) continue;
+    const key = [candidate.modelClubId, candidate.wishClubId ?? ""].join("\0");
     if (seen.has(key)) continue;
     seen.add(key);
-    candidates.push({
-      modelClubId: club.id,
-      modelClubName: club.name,
-      wishClubId: wish.clubId,
-      wishClubName: wish.clubName,
-    });
+    candidates.push(candidate);
   }
   candidates.sort((a, b) => {
     if (a.confirmed !== b.confirmed) return a.confirmed ? 1 : -1;
@@ -410,12 +410,92 @@ async function findCapacityAliasReview(
   return { aliasCandidates: candidates, wishClubOptions };
 }
 
+function capacityAliasCandidateForClub(
+  club: CapacityAliasClub,
+  confirmedSourceIds: Set<string | undefined>,
+  wishesByName: Map<string, HallCapacityWishClubOption>,
+  wishClubOptions: HallCapacityWishClubOption[],
+): HallCapacityAliasCandidate | null {
+  if (!club.id || !club.name || confirmedSourceIds.has(club.id)) return null;
+  const exactWish = wishesByName.get(capacityClubNameKey(club.name));
+  const likelyWishes = exactWish
+    ? [exactWish]
+    : findLikelyWishClubs(club.name, wishClubOptions);
+  const wish = likelyWishes.length === 1 ? likelyWishes[0] : null;
+  if (!wish && likelyWishes.length === 0) return null;
+  if (wish?.clubId === club.id) return null;
+  return {
+    modelClubId: club.id,
+    modelClubName: club.name,
+    wishClubId: wish?.clubId,
+    wishClubName: wish?.clubName,
+  };
+}
+
 function capacityClubNameKey(value: string) {
   return normalizeClubName(value)
     .replace(/^sportfreunde/, "spfr")
     .replace(/\d/g, "")
     .replace(/ev$/, "");
 }
+
+function findLikelyWishClubs(
+  modelClubName: string,
+  wishes: HallCapacityWishClubOption[],
+) {
+  return wishes.filter((wish) =>
+    hasDistinctiveSubset(
+      capacityClubTokens(modelClubName),
+      capacityClubTokens(wish.clubName),
+    ),
+  );
+}
+
+function capacityClubTokens(value: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/ß/g, "ss")
+    .replace(/\bblau[\s-]*weiss\b/gi, "bw")
+    .replace(/\brot[\s-]*weiss\b/gi, "rw")
+    .replace(/\bschwarz[\s-]*weiss\b/gi, "sw")
+    .replace(/\bgruen[\s-]*weiss\b/gi, "gw")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(
+      (token) =>
+        token.length > 1 &&
+        !/^\d+$/.test(token) &&
+        !clubNoiseTokens.has(token),
+    );
+}
+
+function hasDistinctiveSubset(left: string[], right: string[]) {
+  const shorter = left.length <= right.length ? left : right;
+  const longer = new Set(left.length <= right.length ? right : left);
+  return (
+    shorter.some((token) => token.length >= 5) &&
+    shorter.every((token) => longer.has(token))
+  );
+}
+
+const clubNoiseTokens = new Set([
+  "djk",
+  "fc",
+  "sc",
+  "spfr",
+  "sportfreunde",
+  "ssv",
+  "sv",
+  "tus",
+  "sus",
+  "ttc",
+  "ttg",
+  "ttv",
+  "tsv",
+  "tura",
+  "ev",
+]);
 
 function addCapacitySlot(
   bySlot: Map<string, CapacitySlot[]>,

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -38,6 +38,7 @@ export type HallCapacityReview = {
   higherCount: number;
   blockingCount: number;
   aliasCandidates: HallCapacityAliasCandidate[];
+  wishClubOptions: HallCapacityWishClubOption[];
   rows: HallCapacityReviewRow[];
 };
 
@@ -46,6 +47,11 @@ export type HallCapacityAliasCandidate = {
   modelClubName: string;
   wishClubId: string;
   wishClubName: string;
+};
+
+export type HallCapacityWishClubOption = {
+  clubId: string;
+  clubName: string;
 };
 
 export async function listHallCapacities(scopeId: string) {
@@ -159,9 +165,9 @@ export async function inferHallCapacitiesFromInputSet(
 export async function reviewHallCapacitiesForInputSet(
   inputSetId: string,
 ): Promise<HallCapacityReview> {
-  const [inferred, aliasCandidates] = await Promise.all([
+  const [inferred, aliasReview] = await Promise.all([
     inferCapacityRows(inputSetId),
-    findCapacityAliasCandidates(inputSetId),
+    findCapacityAliasReview(inputSetId),
   ]);
   const existing = await existingCapacityMap(inferred);
   let missingCount = 0;
@@ -216,7 +222,8 @@ export async function reviewHallCapacitiesForInputSet(
     insufficientCount,
     higherCount,
     blockingCount: missingCount + insufficientCount,
-    aliasCandidates,
+    aliasCandidates: aliasReview.aliasCandidates,
+    wishClubOptions: aliasReview.wishClubOptions,
     rows,
   };
 }
@@ -325,9 +332,9 @@ async function inferCapacityRows(
   return [...inferred.values()];
 }
 
-async function findCapacityAliasCandidates(
+async function findCapacityAliasReview(
   inputSetId: string,
-): Promise<HallCapacityAliasCandidate[]> {
+) {
   const inputSet = await prisma.rasterInputSet.findUnique({
     where: { id: inputSetId },
     select: {
@@ -335,10 +342,18 @@ async function findCapacityAliasCandidates(
       wishes: { select: { clubId: true, clubName: true } },
     },
   });
-  if (!inputSet?.seasonModelJson) return [];
+  if (!inputSet?.seasonModelJson) {
+    return { aliasCandidates: [], wishClubOptions: [] };
+  }
   const model = JSON.parse(inputSet.seasonModelJson) as {
     clubs?: Array<{ id?: string; name?: string }>;
+    clubAliases?: Array<{ sourceClubId?: string; targetClubId?: string }>;
   };
+  const confirmed = new Set(
+    (model.clubAliases ?? []).map(
+      (alias) => `${alias.sourceClubId}\0${alias.targetClubId}`,
+    ),
+  );
   const wishesByName = new Map<string, { clubId: string; clubName: string }>();
   for (const wish of inputSet.wishes) {
     if (!wish.clubName) continue;
@@ -347,6 +362,9 @@ async function findCapacityAliasCandidates(
       clubName: wish.clubName,
     });
   }
+  const wishClubOptions = [...wishesByName.values()].sort((a, b) =>
+    a.clubName.localeCompare(b.clubName),
+  );
 
   const candidates: HallCapacityAliasCandidate[] = [];
   const seen = new Set<string>();
@@ -355,7 +373,7 @@ async function findCapacityAliasCandidates(
     const wish = wishesByName.get(capacityClubNameKey(club.name));
     if (!wish || wish.clubId === club.id) continue;
     const key = [club.id, wish.clubId].join("\0");
-    if (seen.has(key)) continue;
+    if (seen.has(key) || confirmed.has(key)) continue;
     seen.add(key);
     candidates.push({
       modelClubId: club.id,
@@ -364,7 +382,7 @@ async function findCapacityAliasCandidates(
       wishClubName: wish.clubName,
     });
   }
-  return candidates;
+  return { aliasCandidates: candidates, wishClubOptions };
 }
 
 function capacityClubNameKey(value: string) {

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -43,6 +43,7 @@ export type HallCapacityReview = {
 };
 
 export type HallCapacityAliasCandidate = {
+  confirmed?: boolean;
   modelClubId: string;
   modelClubName: string;
   wishClubId: string;
@@ -347,12 +348,15 @@ async function findCapacityAliasReview(
   }
   const model = JSON.parse(inputSet.seasonModelJson) as {
     clubs?: Array<{ id?: string; name?: string }>;
-    clubAliases?: Array<{ sourceClubId?: string; targetClubId?: string }>;
+    clubAliases?: Array<{
+      sourceClubId?: string;
+      sourceClubName?: string;
+      targetClubId?: string;
+      targetClubName?: string;
+    }>;
   };
-  const confirmed = new Set(
-    (model.clubAliases ?? []).map(
-      (alias) => `${alias.sourceClubId}\0${alias.targetClubId}`,
-    ),
+  const confirmedSourceIds = new Set(
+    (model.clubAliases ?? []).map((alias) => alias.sourceClubId),
   );
   const wishesByName = new Map<string, { clubId: string; clubName: string }>();
   for (const wish of inputSet.wishes) {
@@ -368,12 +372,26 @@ async function findCapacityAliasReview(
 
   const candidates: HallCapacityAliasCandidate[] = [];
   const seen = new Set<string>();
+  for (const alias of model.clubAliases ?? []) {
+    if (!alias.sourceClubId || !alias.targetClubId) continue;
+    const key = [alias.sourceClubId, alias.targetClubId].join("\0");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    candidates.push({
+      confirmed: true,
+      modelClubId: alias.sourceClubId,
+      modelClubName: alias.sourceClubName ?? alias.sourceClubId,
+      wishClubId: alias.targetClubId,
+      wishClubName: alias.targetClubName ?? alias.targetClubId,
+    });
+  }
   for (const club of model.clubs ?? []) {
     if (!club.id || !club.name) continue;
+    if (confirmedSourceIds.has(club.id)) continue;
     const wish = wishesByName.get(capacityClubNameKey(club.name));
     if (!wish || wish.clubId === club.id) continue;
     const key = [club.id, wish.clubId].join("\0");
-    if (seen.has(key) || confirmed.has(key)) continue;
+    if (seen.has(key)) continue;
     seen.add(key);
     candidates.push({
       modelClubId: club.id,

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -400,6 +400,13 @@ async function findCapacityAliasReview(
       wishClubName: wish.clubName,
     });
   }
+  candidates.sort((a, b) => {
+    if (a.confirmed !== b.confirmed) return a.confirmed ? 1 : -1;
+    return (
+      a.modelClubName.localeCompare(b.modelClubName) ||
+      a.modelClubId.localeCompare(b.modelClubId)
+    );
+  });
   return { aliasCandidates: candidates, wishClubOptions };
 }
 

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -112,7 +112,17 @@ export async function inferHallCapacitiesFromInputSet(
   for (const row of inferred) {
     const stored = existing.get(capacityKey(row));
     if (stored) {
-      if (stored.capacity < row.capacity) needsReview += 1;
+      if (stored.capacity < row.capacity) {
+        if (stored.basis === HallCapacityBasis.INFERRED) {
+          await prisma.rasterHallCapacity.update({
+            where: { id: stored.id },
+            data: { capacity: row.capacity, updatedById },
+          });
+          count += 1;
+        } else {
+          needsReview += 1;
+        }
+      }
       continue;
     }
     await prisma.rasterHallCapacity.create({

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db";
 import { rasterScopeWhere } from "@/lib/raster/access";
+import { normalizeClubName } from "@/lib/raster/club-matching";
 import type { CapacityCsvRowInput } from "@/lib/raster/schemas";
 import {
   HallCapacityBasis,
@@ -36,7 +37,15 @@ export type HallCapacityReview = {
   insufficientCount: number;
   higherCount: number;
   blockingCount: number;
+  aliasCandidates: HallCapacityAliasCandidate[];
   rows: HallCapacityReviewRow[];
+};
+
+export type HallCapacityAliasCandidate = {
+  modelClubId: string;
+  modelClubName: string;
+  wishClubId: string;
+  wishClubName: string;
 };
 
 export async function listHallCapacities(scopeId: string) {
@@ -150,7 +159,10 @@ export async function inferHallCapacitiesFromInputSet(
 export async function reviewHallCapacitiesForInputSet(
   inputSetId: string,
 ): Promise<HallCapacityReview> {
-  const inferred = await inferCapacityRows(inputSetId);
+  const [inferred, aliasCandidates] = await Promise.all([
+    inferCapacityRows(inputSetId),
+    findCapacityAliasCandidates(inputSetId),
+  ]);
   const existing = await existingCapacityMap(inferred);
   let missingCount = 0;
   let insufficientCount = 0;
@@ -204,6 +216,7 @@ export async function reviewHallCapacitiesForInputSet(
     insufficientCount,
     higherCount,
     blockingCount: missingCount + insufficientCount,
+    aliasCandidates,
     rows,
   };
 }
@@ -310,6 +323,55 @@ async function inferCapacityRows(
     });
   }
   return [...inferred.values()];
+}
+
+async function findCapacityAliasCandidates(
+  inputSetId: string,
+): Promise<HallCapacityAliasCandidate[]> {
+  const inputSet = await prisma.rasterInputSet.findUnique({
+    where: { id: inputSetId },
+    select: {
+      seasonModelJson: true,
+      wishes: { select: { clubId: true, clubName: true } },
+    },
+  });
+  if (!inputSet?.seasonModelJson) return [];
+  const model = JSON.parse(inputSet.seasonModelJson) as {
+    clubs?: Array<{ id?: string; name?: string }>;
+  };
+  const wishesByName = new Map<string, { clubId: string; clubName: string }>();
+  for (const wish of inputSet.wishes) {
+    if (!wish.clubName) continue;
+    wishesByName.set(capacityClubNameKey(wish.clubName), {
+      clubId: wish.clubId,
+      clubName: wish.clubName,
+    });
+  }
+
+  const candidates: HallCapacityAliasCandidate[] = [];
+  const seen = new Set<string>();
+  for (const club of model.clubs ?? []) {
+    if (!club.id || !club.name) continue;
+    const wish = wishesByName.get(capacityClubNameKey(club.name));
+    if (!wish || wish.clubId === club.id) continue;
+    const key = [club.id, wish.clubId].join("\0");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    candidates.push({
+      modelClubId: club.id,
+      modelClubName: club.name,
+      wishClubId: wish.clubId,
+      wishClubName: wish.clubName,
+    });
+  }
+  return candidates;
+}
+
+function capacityClubNameKey(value: string) {
+  return normalizeClubName(value)
+    .replace(/^sportfreunde/, "spfr")
+    .replace(/\d/g, "")
+    .replace(/ev$/, "");
 }
 
 function addCapacitySlot(

--- a/webapp/src/services/raster/capacity.ts
+++ b/webapp/src/services/raster/capacity.ts
@@ -351,7 +351,8 @@ async function findCapacityAliasReview(
   }
   const model = JSON.parse(inputSet.seasonModelJson) as {
     clubs?: Array<{ id?: string; name?: string }>;
-    teams?: Array<{ clubId?: string; capacityRelevant?: boolean }>;
+    groups?: Array<{ planningStatus?: string; teamIds?: string[] }>;
+    teams?: Array<{ id?: string; clubId?: string }>;
     clubAliases?: Array<{
       sourceClubId?: string;
       sourceClubName?: string;
@@ -374,9 +375,14 @@ async function findCapacityAliasReview(
     a.clubName.localeCompare(b.clubName),
   );
   const wishClubIds = new Set(wishClubOptions.map((wish) => wish.clubId));
+  const excludedTeamIds = new Set(
+    (model.groups ?? [])
+      .filter((group) => group.planningStatus === "exclude")
+      .flatMap((group) => group.teamIds ?? []),
+  );
   const capacityClubIds = new Set(
     (model.teams ?? [])
-      .filter((team) => team.capacityRelevant !== false)
+      .filter((team) => !team.id || !excludedTeamIds.has(team.id))
       .map((team) => team.clubId)
       .filter((clubId): clubId is string => Boolean(clubId)),
   );

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -55,6 +55,7 @@ type SeasonModelTeam = {
   requestedRasterzahl?: number[];
   wishMatchId?: string;
   wishMatchSource?: "auto" | "manual";
+  spielwochePrefSource?: "auto" | "manual";
   confidence?: "ok" | "review";
 };
 type SeasonModelWithClubs = {
@@ -310,6 +311,9 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
       const manualWishMatches = manualWishMatchesByTeamId(
         inputSet.seasonModelJson,
       );
+      const manualWeekPrefs = manualWeekPrefsByTeamId(
+        inputSet.seasonModelJson,
+      );
       const model =
         await rasterIngest.buildSeasonModelFromAssignments(
           supportedAssignments,
@@ -325,6 +329,7 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
         inputSet.id,
         parsedWishes,
         manualWishMatches,
+        manualWeekPrefs,
       );
       const existingReviews = groupReviewsByKey(inputSet.seasonModelJson);
       model.groups = model.groups.map((group) => ({
@@ -430,6 +435,7 @@ async function applyActiveWishDetails(
   inputSetId: string,
   parsedWishes: WishParseResult[],
   manualWishMatches = new Map<string, string>(),
+  manualWeekPrefs = new Map<string, "A" | "B">(),
 ) {
   const wishClubById = new Map(
     parsedWishes
@@ -468,6 +474,12 @@ async function applyActiveWishDetails(
     const wishId = manualWishMatches.get(team.id);
     const wish = wishId ? activeWishById.get(wishId) : undefined;
     return wish ? applyWishToTeam(team, wish, "manual") : team;
+  });
+  model.teams = (model.teams ?? []).map((team) => {
+    const spielwochePref = manualWeekPrefs.get(team.id);
+    return spielwochePref
+      ? { ...team, spielwochePref, spielwochePrefSource: "manual" }
+      : team;
   });
   model.wishes = (model.clubs ?? []).flatMap((club) =>
     extractRelationalWishes(
@@ -535,6 +547,32 @@ function manualWishMatchesByTeamId(seasonModelJson?: string | null) {
     return matches;
   }
   return matches;
+}
+
+function manualWeekPrefsByTeamId(seasonModelJson?: string | null) {
+  const prefs = new Map<string, "A" | "B">();
+  if (!seasonModelJson) return prefs;
+  try {
+    const model = JSON.parse(seasonModelJson) as {
+      teams?: Array<{
+        id?: string;
+        spielwochePref?: string;
+        spielwochePrefSource?: string;
+      }>;
+    };
+    for (const team of model.teams ?? []) {
+      if (
+        team.id &&
+        (team.spielwochePref === "A" || team.spielwochePref === "B") &&
+        team.spielwochePrefSource === "manual"
+      ) {
+        prefs.set(team.id, team.spielwochePref);
+      }
+    }
+  } catch {
+    return prefs;
+  }
+  return prefs;
 }
 
 function teamIdentityKey(
@@ -672,8 +710,10 @@ export async function updateTeamWishFields(
     }
     if (fields.spielwochePref === null) {
       delete next.spielwochePref;
+      delete next.spielwochePrefSource;
     } else if (fields.spielwochePref) {
       next.spielwochePref = fields.spielwochePref;
+      next.spielwochePrefSource = "manual";
     }
     return next;
   });

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -23,6 +23,12 @@ const INPUT_SET_SOURCE_TYPES = [
   "UPPER_LEAGUE_RASTER",
 ];
 
+export class DuplicateInputSetNameError extends Error {
+  constructor() {
+    super("Planning set name already exists for this scope and season.");
+  }
+}
+
 type SeasonGroup = {
   id?: string;
   ref?: { league?: string; name?: string };
@@ -140,10 +146,18 @@ export async function createInputSet(params: {
     select: { code: true },
   });
   const season = normalizeRasterSeason(params.season);
+  const name =
+    params.name?.trim() || `${scope?.code ?? params.scopeId} ${season}`;
+  const existing = await prisma.rasterInputSet.findFirst({
+    where: { scopeId: params.scopeId, season, name },
+    select: { id: true },
+  });
+  if (existing) throw new DuplicateInputSetNameError();
+
   const inputSet = await prisma.rasterInputSet.create({
     data: {
       ...params,
-      name: params.name?.trim() || `${scope?.code ?? params.scopeId} ${season}`,
+      name,
       season,
     },
   });

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -305,6 +305,9 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
       const skippedGroups = [...groupSizes.entries()].filter(
         ([, size]) => !supportedSizes.has(size),
       );
+      const manualWishMatches = manualWishMatchesByTeamId(
+        inputSet.seasonModelJson,
+      );
       const model =
         await rasterIngest.buildSeasonModelFromAssignments(
           supportedAssignments,
@@ -315,7 +318,12 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
         await importWishesIfChanged(inputSet, parsedWishes, data.wishesJson);
         importedWishes = true;
       }
-      await applyActiveWishDetails(model, inputSet.id, parsedWishes);
+      await applyActiveWishDetails(
+        model,
+        inputSet.id,
+        parsedWishes,
+        manualWishMatches,
+      );
       const existingReviews = groupReviewsByKey(inputSet.seasonModelJson);
       model.groups = model.groups.map((group) => ({
         ...group,
@@ -419,6 +427,7 @@ async function applyActiveWishDetails(
   model: SeasonModelWithClubs,
   inputSetId: string,
   parsedWishes: WishParseResult[],
+  manualWishMatches = new Map<string, string>(),
 ) {
   const wishClubById = new Map(
     parsedWishes
@@ -449,22 +458,14 @@ async function applyActiveWishDetails(
       teamIdentityKey(team.clubId, team.label),
     );
     if (!wishTeam) return team;
-    return {
-      ...team,
-      homeWeekday: wishTeam.homeWeekday.toLowerCase(),
-      ...(wishTeam.hall ? { hall: wishTeam.hall } : {}),
-      ...(wishTeam.startTime ? { startTime: wishTeam.startTime } : {}),
-      ...(wishTeam.spielwochePref
-        ? { spielwochePref: wishTeam.spielwochePref }
-        : {}),
-      ...(wishTeam.requestedRasterzahl
-        ? { requestedRasterzahl: JSON.parse(wishTeam.requestedRasterzahl) }
-        : {}),
-      wishMatchId: wishTeam.id,
-      wishMatchSource: team.wishMatchSource ?? "auto",
-      confidence: wishTeam.confidence === "OK" ? "ok" : "review",
-      capacityRelevant: true,
-    };
+    return applyWishToTeam(team, wishTeam, team.wishMatchSource ?? "auto");
+  });
+
+  const activeWishById = new Map(activeWishes.map((wish) => [wish.id, wish]));
+  model.teams = (model.teams ?? []).map((team) => {
+    const wishId = manualWishMatches.get(team.id);
+    const wish = wishId ? activeWishById.get(wishId) : undefined;
+    return wish ? applyWishToTeam(team, wish, "manual") : team;
   });
   model.wishes = (model.clubs ?? []).flatMap((club) =>
     extractRelationalWishes(
@@ -473,6 +474,65 @@ async function applyActiveWishDetails(
       (model.teams ?? []) as Team[],
     ),
   );
+}
+
+function applyWishToTeam(
+  team: SeasonModelTeam,
+  wishTeam: {
+    id: string;
+    clubId: string;
+    homeWeekday: string;
+    hall?: string | null;
+    startTime?: string | null;
+    spielwochePref?: string | null;
+    requestedRasterzahl?: string | null;
+    confidence?: string | null;
+  },
+  wishMatchSource: "auto" | "manual",
+) {
+  return {
+    ...team,
+    clubId: wishTeam.clubId,
+    homeWeekday: wishTeam.homeWeekday.toLowerCase(),
+    ...(wishTeam.hall ? { hall: wishTeam.hall } : {}),
+    ...(wishTeam.startTime ? { startTime: wishTeam.startTime } : {}),
+    ...(wishTeam.spielwochePref
+      ? { spielwochePref: wishTeam.spielwochePref }
+      : {}),
+    ...(wishTeam.requestedRasterzahl
+      ? { requestedRasterzahl: JSON.parse(wishTeam.requestedRasterzahl) }
+      : {}),
+    wishMatchId: wishTeam.id,
+    wishMatchSource,
+    confidence: wishTeam.confidence === "OK" ? "ok" : "review",
+    capacityRelevant: true,
+  };
+}
+
+function manualWishMatchesByTeamId(seasonModelJson?: string | null) {
+  const matches = new Map<string, string>();
+  if (!seasonModelJson) return matches;
+  try {
+    const model = JSON.parse(seasonModelJson) as {
+      teams?: Array<{
+        id?: string;
+        wishMatchId?: string;
+        wishMatchSource?: string;
+      }>;
+    };
+    for (const team of model.teams ?? []) {
+      if (
+        team.id &&
+        team.wishMatchId &&
+        team.wishMatchSource === "manual"
+      ) {
+        matches.set(team.id, team.wishMatchId);
+      }
+    }
+  } catch {
+    return matches;
+  }
+  return matches;
 }
 
 function teamIdentityKey(

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -203,7 +203,9 @@ export async function validateInputSet(id: string) {
       );
       if (undecidedGroups.length) {
         errors.push(
-          `${undecidedGroups.length} group(s) contain teams without parsed wish PDFs. Choose include or exclude before running.`,
+          `${undecidedGroups.length} group(s) contain teams without parsed wish PDFs: ${undecidedGroups
+            .map(groupLabel)
+            .join("; ")}. Choose include or exclude before running.`,
         );
       }
     }

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -58,10 +58,17 @@ type SeasonModelTeam = {
   spielwochePrefSource?: "auto" | "manual";
   confidence?: "ok" | "review";
 };
+type ClubAliasMapping = {
+  sourceClubId: string;
+  sourceClubName?: string;
+  targetClubId: string;
+  targetClubName?: string;
+};
 type SeasonModelWithClubs = {
   clubs?: SeasonModelClub[];
   teams?: SeasonModelTeam[];
   wishes?: unknown[];
+  clubAliases?: ClubAliasMapping[];
 };
 
 export async function listInputSets(
@@ -314,10 +321,12 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
       const manualWeekPrefs = manualWeekPrefsByTeamId(
         inputSet.seasonModelJson,
       );
+      const clubAliases = clubAliasesFromModel(inputSet.seasonModelJson);
       const model =
         await rasterIngest.buildSeasonModelFromAssignments(
           supportedAssignments,
         );
+      applyClubAliasesToModel(model, clubAliases);
       alignParsedWishClubIds(model, parsedWishes);
       if (wishSources.length) {
         data.wishesJson = stringifyWishSources(wishSources, parsedWishes);
@@ -341,6 +350,7 @@ export async function syncInputSetSourceCaches(inputSetId: string) {
           existingReviews.get(groupKey(group))?.planningStatus,
       }));
       applyPlanningStatusToTeamCapacity(model);
+      (model as SeasonModelWithClubs).clubAliases = clubAliases;
       model.warnings.push(
         ...skippedGroups.map(
           ([group, size]) =>
@@ -737,6 +747,38 @@ export async function updateTeamWishFields(
   return updateSeasonModel(inputSetId, model);
 }
 
+export async function updateClubAliasMapping(
+  inputSetId: string,
+  sourceClubId: string,
+  targetClubId: string,
+) {
+  const inputSet = await getInputSet(inputSetId);
+  if (!inputSet?.seasonModelJson) return null;
+  const targetWish = await prisma.rasterWish.findFirst({
+    where: { inputSetId, clubId: targetClubId },
+    select: { clubId: true, clubName: true },
+  });
+  if (!targetWish) return null;
+
+  const model = seasonModelSchema.parse(JSON.parse(inputSet.seasonModelJson));
+  const typedModel = model as unknown as SeasonModelWithClubs;
+  const sourceClub = typedModel.clubs?.find((club) => club.id === sourceClubId);
+  if (!sourceClub) return null;
+  const aliases = clubAliasesFromModel(inputSet.seasonModelJson).filter(
+    (alias) => alias.sourceClubId !== sourceClubId,
+  );
+  aliases.push({
+    sourceClubId,
+    sourceClubName: sourceClub.name,
+    targetClubId: targetWish.clubId,
+    targetClubName: targetWish.clubName,
+  });
+  applyClubAliasesToModel(typedModel, aliases);
+  typedModel.clubAliases = aliases;
+
+  return updateSeasonModel(inputSetId, model);
+}
+
 function groupsWithMissingWishData(model: SeasonModelInput) {
   const teams = new Map(
     (model.teams as Array<{ id?: string; capacityRelevant?: boolean }>).map(
@@ -777,6 +819,58 @@ function applyPlanningStatusToTeamCapacity(model: {
     if (status === "include" && team.wishMatchId)
       return { ...team, capacityRelevant: true };
     return team;
+  });
+}
+
+function clubAliasesFromModel(seasonModelJson?: string | null) {
+  if (!seasonModelJson) return [];
+  try {
+    const model = JSON.parse(seasonModelJson) as {
+      clubAliases?: ClubAliasMapping[];
+    };
+    return (model.clubAliases ?? []).filter(
+      (alias) => alias.sourceClubId && alias.targetClubId,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function applyClubAliasesToModel(
+  model: SeasonModelWithClubs,
+  aliases: ClubAliasMapping[],
+) {
+  const aliasBySource = new Map(
+    aliases.map((alias) => [alias.sourceClubId, alias]),
+  );
+  if (!aliasBySource.size) return;
+
+  model.clubs = (model.clubs ?? []).flatMap((club) => {
+    const alias = aliasBySource.get(club.id);
+    if (!alias) return [club];
+    if ((model.clubs ?? []).some((item) => item.id === alias.targetClubId)) {
+      return [];
+    }
+    return [
+      {
+        ...club,
+        id: alias.targetClubId,
+        name: alias.targetClubName ?? club.name,
+      },
+    ];
+  });
+  model.teams = (model.teams ?? []).map((team) => ({
+    ...team,
+    clubId: aliasBySource.get(team.clubId)?.targetClubId ?? team.clubId,
+  }));
+  model.wishes = (model.wishes ?? []).map((wish) => {
+    if (!wish || typeof wish !== "object" || !("clubId" in wish)) return wish;
+    const row = wish as Record<string, unknown>;
+    const clubId = typeof row.clubId === "string" ? row.clubId : "";
+    return {
+      ...row,
+      clubId: aliasBySource.get(clubId)?.targetClubId ?? clubId,
+    };
   });
 }
 

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -762,9 +762,37 @@ export async function updateClubAliasMapping(
 
   const model = seasonModelSchema.parse(JSON.parse(inputSet.seasonModelJson));
   const typedModel = model as unknown as SeasonModelWithClubs;
-  const sourceClub = typedModel.clubs?.find((club) => club.id === sourceClubId);
-  if (!sourceClub) return null;
-  const aliases = clubAliasesFromModel(inputSet.seasonModelJson).filter(
+  const existingAliases = clubAliasesFromModel(inputSet.seasonModelJson);
+  const previousAlias = existingAliases.find(
+    (alias) => alias.sourceClubId === sourceClubId,
+  );
+  const sourceClub = typedModel.clubs?.find((club) => club.id === sourceClubId) ?? {
+    id: previousAlias?.sourceClubId ?? "",
+    name: previousAlias?.sourceClubName,
+  };
+  if (previousAlias) {
+    typedModel.teams = (typedModel.teams ?? []).map((team) => ({
+      ...team,
+      clubId:
+        team.clubId === previousAlias.targetClubId ? sourceClubId : team.clubId,
+    }));
+    typedModel.wishes = (typedModel.wishes ?? []).map((wish) => {
+      if (!wish || typeof wish !== "object" || !("clubId" in wish)) return wish;
+      const row = wish as Record<string, unknown>;
+      return {
+        ...row,
+        clubId:
+          row.clubId === previousAlias.targetClubId
+            ? sourceClubId
+            : row.clubId,
+      };
+    });
+  }
+  if (!sourceClub.id) return null;
+  if (!(typedModel.clubs ?? []).some((club) => club.id === sourceClub.id)) {
+    typedModel.clubs = [...(typedModel.clubs ?? []), sourceClub];
+  }
+  const aliases = existingAliases.filter(
     (alias) => alias.sourceClubId !== sourceClubId,
   );
   aliases.push({

--- a/webapp/src/services/raster/inputSets.ts
+++ b/webapp/src/services/raster/inputSets.ts
@@ -504,6 +504,8 @@ function applyWishToTeam(
   },
   wishMatchSource: "auto" | "manual",
 ) {
+  const confidence: SeasonModelTeam["confidence"] =
+    wishTeam.confidence === "OK" ? "ok" : "review";
   return {
     ...team,
     clubId: wishTeam.clubId,
@@ -518,7 +520,7 @@ function applyWishToTeam(
       : {}),
     wishMatchId: wishTeam.id,
     wishMatchSource,
-    confidence: wishTeam.confidence === "OK" ? "ok" : "review",
+    confidence,
     capacityRelevant: true,
   };
 }

--- a/webapp/tests/e2e/raster-generate.spec.ts
+++ b/webapp/tests/e2e/raster-generate.spec.ts
@@ -65,7 +65,9 @@ test("OWL raster page shows workspace sources without refreshing them on reload"
   await loginWithPassword(page, email, password);
   await expectOnDashboard(page);
 
-  await page.goto(`${appBasePath}/raster/import?${rasterQuery}&workspace=${inputSetId}`);
+  await page.goto(
+    `${appBasePath}/raster/import?${rasterQuery}&workspace=${inputSetId}`,
+  );
   await expect(page.getByText(sourceName)).toBeVisible();
   expect(refreshRequests).toEqual([]);
 
@@ -140,7 +142,7 @@ test("admin can generate and review a raster snapshot", async ({ page }) => {
     .first()
     .click();
   await expect(page.getByText(/Inferred \d+; \d+ need review/)).toBeVisible();
-  await page.getByRole("button", { name: "Mark all reviewed" }).click();
+  await page.getByRole("button", { name: "Acknowledge all" }).click();
   await expect(page.getByText("Source matches (0 outstanding)")).toBeVisible();
   await page.getByRole("link", { name: /^Run optimizer/ }).click();
   await page.getByRole("button", { name: "Validate" }).click();

--- a/webapp/tests/e2e/upper-league-import.spec.ts
+++ b/webapp/tests/e2e/upper-league-import.spec.ts
@@ -195,7 +195,7 @@ test("unmatched upper-league sources do not inject teams", async ({ page }) => {
     .first()
     .click();
   await expect(page.getByText(/Inferred \d+; \d+ need review/)).toBeVisible();
-  await page.getByRole("button", { name: "Mark all reviewed" }).click();
+  await page.getByRole("button", { name: "Acknowledge all" }).click();
   await expect(page.getByText("Source matches (0 outstanding)")).toBeVisible();
   await page.getByRole("link", { name: /^Run optimizer/ }).click();
   await page.getByRole("button", { name: "Validate" }).click();

--- a/webapp/tests/e2e/upper-league-import.spec.ts
+++ b/webapp/tests/e2e/upper-league-import.spec.ts
@@ -95,6 +95,12 @@ test("scheduler imports an upper-league raster PDF and sees the preview on mobil
   await expectStatus(upload, 201);
 
   await page.reload();
+  await expect(page.getByText("Needs parse")).toBeVisible();
+  await page.getByRole("button", { name: "Parse", exact: true }).click();
+  await expect(page.getByText("Parsed 31 leagues")).toBeVisible({
+    timeout: 20000,
+  });
+  await page.reload();
   await page.getByText("Parsed data: 31 leagues").click();
   await expect(
     page.getByRole("cell", { name: "Verbandsliga 1 Erwachsene" }),
@@ -102,9 +108,7 @@ test("scheduler imports an upper-league raster PDF and sees the preview on mobil
   await expect(page.getByText("TuRa Elsen").first()).toBeVisible();
 });
 
-test("malformed upper-league uploads fail and non-matching clubs do not inject teams", async ({
-  page,
-}) => {
+test("unmatched upper-league sources do not inject teams", async ({ page }) => {
   const suffix = Date.now();
   const email = `e2e-upper-constraints-${suffix}@example.com`;
   const password = "UpperConstraints123";
@@ -135,24 +139,6 @@ test("malformed upper-league uploads fail and non-matching clubs do not inject t
     inputSet: { id: string };
   };
 
-  const malformed = await page.request.post(
-    `${appBasePath}/api/raster/sources/upload`,
-    {
-      multipart: {
-        scopeCode: constraintScope.code,
-        season,
-        inputSetId: inputSet.id,
-        sourceType: "UPPER_LEAGUE_RASTER",
-        file: {
-          name: "broken.pdf",
-          mimeType: "application/pdf",
-          buffer: Buffer.from("%PDF-1.4\nnot the expected fixture"),
-        },
-      },
-    },
-  );
-  expect(malformed.status()).toBe(422);
-
   const pdf = await readFile(fixture);
   const valid = await page.request.post(
     `${appBasePath}/api/raster/sources/upload`,
@@ -175,9 +161,12 @@ test("malformed upper-league uploads fail and non-matching clubs do not inject t
   const model = buildNoMatchModel();
   expect(
     await page.request
-      .post(`${appBasePath}/api/raster/input-sets/${inputSet.id}/season-model`, {
-        data: model,
-      })
+      .post(
+        `${appBasePath}/api/raster/input-sets/${inputSet.id}/season-model`,
+        {
+          data: model,
+        },
+      )
       .then((response) => response.status()),
   ).toBe(200);
   expect(
@@ -201,7 +190,10 @@ test("malformed upper-league uploads fail and non-matching clubs do not inject t
   await page.goto(
     `${appBasePath}/raster/review?scope=${constraintScope.code}&season=${encodeURIComponent(season)}`,
   );
-  await page.getByRole("button", { name: "Recheck capacities" }).first().click();
+  await page
+    .getByRole("button", { name: "Recheck capacities" })
+    .first()
+    .click();
   await expect(page.getByText(/Inferred \d+; \d+ need review/)).toBeVisible();
   await page.getByRole("button", { name: "Mark all reviewed" }).click();
   await expect(page.getByText("Source matches (0 outstanding)")).toBeVisible();
@@ -257,6 +249,9 @@ function buildNoMatchModel() {
   };
 }
 
-async function expectStatus(response: { status(): number; text(): Promise<string> }, status: number) {
+async function expectStatus(
+  response: { status(): number; text(): Promise<string> },
+  status: number,
+) {
   expect(response.status(), await response.text()).toBe(status);
 }

--- a/webapp/tests/integration/raster-step-access.test.tsx
+++ b/webapp/tests/integration/raster-step-access.test.tsx
@@ -164,6 +164,7 @@ describe("raster step access", () => {
       insufficientCount: 0,
       higherCount: 0,
       blockingCount: 0,
+      aliasCandidates: [],
       rows: [],
     });
     services.listWishImportReview.mockResolvedValue(null);

--- a/webapp/tests/integration/raster-step-access.test.tsx
+++ b/webapp/tests/integration/raster-step-access.test.tsx
@@ -26,10 +26,14 @@ const services = vi.hoisted(() => ({
   listScenarios: vi.fn(),
   reviewHallCapacitiesForInputSet: vi.fn(),
 }));
+const matchReview = vi.hoisted(() => ({
+  listMatchReviewState: vi.fn(),
+}));
 
 vi.mock("@/lib/auth", () => ({ requireSession }));
 vi.mock("@/lib/db", () => ({ prisma }));
 vi.mock("@/services/raster", () => services);
+vi.mock("@/lib/raster/match-review", () => matchReview);
 
 import ImportPage from "@/app/(dashboard)/raster/import/page";
 import ReviewPage from "@/app/(dashboard)/raster/review/page";
@@ -84,9 +88,7 @@ describe("raster step access", () => {
       });
       prisma.scope.findMany.mockResolvedValue([scope("OWL")]);
       services.listInputSets.mockResolvedValue(
-        load === services.listRasterSourcesForInputSet
-          ? [inputSet()]
-          : [],
+        load === services.listRasterSourcesForInputSet ? [inputSet()] : [],
       );
       services.listHallCapacities.mockResolvedValue([]);
       services.listRasterSourcesForInputSet.mockResolvedValue([]);
@@ -143,16 +145,64 @@ describe("raster step access", () => {
 
     expect(services.adoptLegacyRasterSources).toHaveBeenCalledWith("input-1");
   });
+
+  it("loads the requested workspace on review and run steps", async () => {
+    requireSession.mockResolvedValue({
+      id: "scheduler-1",
+      role: Role.SCOPE_ADMIN,
+    });
+    prisma.scope.findMany.mockResolvedValue([scope("OWL")]);
+    prisma.scope.findFirst.mockResolvedValue({ id: "scope-OWL" });
+    services.listInputSets.mockResolvedValue([
+      inputSet("input-1"),
+      inputSet("input-2"),
+    ]);
+    services.listHallCapacities.mockResolvedValue([]);
+    services.reviewHallCapacitiesForInputSet.mockResolvedValue({
+      inferredCount: 0,
+      missingCount: 0,
+      insufficientCount: 0,
+      higherCount: 0,
+      blockingCount: 0,
+      rows: [],
+    });
+    services.listWishImportReview.mockResolvedValue(null);
+    matchReview.listMatchReviewState.mockResolvedValue([]);
+
+    await ReviewPage({
+      searchParams: Promise.resolve({
+        scope: "OWL",
+        season: "2026/27",
+        workspace: "input-2",
+      }),
+    });
+    await RunPage({
+      searchParams: Promise.resolve({
+        scope: "OWL",
+        season: "2026/27",
+        workspace: "input-2",
+      }),
+    });
+
+    expect(matchReview.listMatchReviewState).toHaveBeenCalledWith("input-2");
+    expect(services.reviewHallCapacitiesForInputSet).toHaveBeenCalledWith(
+      "input-2",
+    );
+  });
 });
 
-function inputSet() {
+function inputSet(id = "input-1") {
   return {
-    id: "input-1",
+    id,
     name: "OWL 2026/27",
     scopeId: "scope-OWL",
     season: "2026/27",
     status: "DRAFT",
     seasonModelJson: null,
+    fixedRasterzahlen: [],
+    wishes: [],
+    runs: [],
+    spannedScopes: [],
     _count: { wishes: 0, fixedRasterzahlen: 0, runs: 0 },
   };
 }

--- a/webapp/tests/integration/raster-step-access.test.tsx
+++ b/webapp/tests/integration/raster-step-access.test.tsx
@@ -165,6 +165,7 @@ describe("raster step access", () => {
       higherCount: 0,
       blockingCount: 0,
       aliasCandidates: [],
+      wishClubOptions: [],
       rows: [],
     });
     services.listWishImportReview.mockResolvedValue(null);

--- a/webapp/tests/unit/coverage-detail.test.tsx
+++ b/webapp/tests/unit/coverage-detail.test.tsx
@@ -59,7 +59,8 @@ function collectText(node: ReactNode): string[] {
   if (isValidElement(node)) {
     const element = node as ReactElement<{ children?: ReactNode }>;
     if (typeof element.type === "function") {
-      return collectText(element.type(element.props));
+      const render = element.type as (props: typeof element.props) => ReactNode;
+      return collectText(render(element.props));
     }
     return collectText(element.props.children);
   }

--- a/webapp/tests/unit/coverage-detail.test.tsx
+++ b/webapp/tests/unit/coverage-detail.test.tsx
@@ -1,0 +1,67 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { CoverageDetail } from "@/components/raster/coverage/coverage-detail";
+import type { CoverageRecord } from "@/lib/raster/coverage";
+
+describe("coverage detail", () => {
+  it("collapses and groups coverage gaps", () => {
+    const coverage: CoverageRecord = {
+      complete: false,
+      spannedScopes: ["scope-a"],
+      spannedAll: false,
+      scopesWithoutInputSet: [],
+      excludedGroups: ["group-a", "group-b"],
+      wishGaps: [{ teamId: "team-a", missing: ["wish", "gym"] }],
+      capacityGaps: [],
+      upperLeague: {
+        importPresent: true,
+        matched: [],
+        unmatched: [{ clubId: "club-a", label: "Erwachsene" }],
+        excludedNoHall: [{ clubId: "club-b", label: "Damen" }],
+        invalidRasterzahl: [],
+      },
+    };
+
+    const detail = CoverageDetail({ coverageJson: JSON.stringify(coverage) });
+    const details = collectElements(detail, "details")[0];
+    const text = collectText(detail).join(" ");
+
+    expect(details?.props.open).toBeUndefined();
+    expect(text).toMatch(/Coverage gaps\s+\(\s*5\s*\)/);
+    expect(text).toMatch(/Excluded groups\s+\(\s*2\s*\)/);
+    expect(text).toMatch(/Wish gaps\s+\(\s*1\s*\)/);
+    expect(text).toMatch(/Upper-league unmatched\s+\(\s*1\s*\)/);
+    expect(text).toMatch(/Upper-league missing hall\/day\s+\(\s*1\s*\)/);
+  });
+});
+
+function collectElements(
+  node: ReactNode,
+  type: string,
+): Array<ReactElement<{ open?: boolean; children?: ReactNode }>> {
+  if (!isValidElement(node)) return [];
+  const element = node as ReactElement<{ children?: ReactNode }>;
+  const matches =
+    element.type === type
+      ? [element as ReactElement<{ open?: boolean; children?: ReactNode }>]
+      : [];
+  return [...matches, ...collectElements(element.props.children, type)];
+}
+
+function collectText(node: ReactNode): string[] {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return [];
+  }
+  if (typeof node === "string" || typeof node === "number") {
+    return [String(node)];
+  }
+  if (Array.isArray(node)) return node.flatMap(collectText);
+  if (isValidElement(node)) {
+    const element = node as ReactElement<{ children?: ReactNode }>;
+    if (typeof element.type === "function") {
+      return collectText(element.type(element.props));
+    }
+    return collectText(element.props.children);
+  }
+  return [];
+}

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -105,6 +105,7 @@ describe("raster capacity service", () => {
       higherCount: 1,
       blockingCount: 0,
       aliasCandidates: [],
+      wishClubOptions: [],
       rows: [
         {
           id: undefined,
@@ -174,6 +175,7 @@ describe("raster capacity service", () => {
       higherCount: 0,
       blockingCount: 1,
       aliasCandidates: [],
+      wishClubOptions: [],
       rows: [
         {
           id: "capacity-1",
@@ -289,6 +291,16 @@ describe("raster capacity service", () => {
           modelClubName: "Spfr. Berlebeck-Heiligenkirchen",
           wishClubId: "sportfreunde-berlebeck-heiligenkirchen-e-v-42634",
           wishClubName: "Sportfreunde Berlebeck-Heiligenkirchen e.V.",
+        },
+      ],
+      wishClubOptions: [
+        {
+          clubId: "fc-b-hne-1929-42518",
+          clubName: "FC Bühne 1929",
+        },
+        {
+          clubId: "sportfreunde-berlebeck-heiligenkirchen-e-v-42634",
+          clubName: "Sportfreunde Berlebeck-Heiligenkirchen e.V.",
         },
       ],
       rows: [

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -104,6 +104,7 @@ describe("raster capacity service", () => {
       insufficientCount: 0,
       higherCount: 1,
       blockingCount: 0,
+      aliasCandidates: [],
       rows: [
         {
           id: undefined,
@@ -172,6 +173,7 @@ describe("raster capacity service", () => {
       insufficientCount: 1,
       higherCount: 0,
       blockingCount: 1,
+      aliasCandidates: [],
       rows: [
         {
           id: "capacity-1",
@@ -223,6 +225,84 @@ describe("raster capacity service", () => {
       where: { id: "capacity-1" },
       data: { capacity: 1, updatedById: "admin-1" },
     });
+  });
+
+  it("surfaces suspected club aliases without applying them", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      seasonModelJson: JSON.stringify({
+        clubs: [
+          { id: "fc-bu-hne", name: "FC Bühne" },
+          {
+            id: "spfr-berlebeck-heiligenkirchen",
+            name: "Spfr. Berlebeck-Heiligenkirchen",
+          },
+        ],
+        teams: [
+          {
+            clubId: "fc-bu-hne",
+            hall: "1",
+            homeWeekday: "friday",
+            spielwochePref: "A",
+          },
+          {
+            clubId: "spfr-berlebeck-heiligenkirchen",
+            hall: "1",
+            homeWeekday: "friday",
+            spielwochePref: "A",
+          },
+        ],
+      }),
+      wishes: [
+        {
+          clubId: "fc-b-hne-1929-42518",
+          clubName: "FC Bühne 1929",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+          spielwochePref: "A",
+        },
+        {
+          clubId: "sportfreunde-berlebeck-heiligenkirchen-e-v-42634",
+          clubName: "Sportfreunde Berlebeck-Heiligenkirchen e.V.",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+          spielwochePref: "A",
+        },
+      ],
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      reviewHallCapacitiesForInputSet("input-1"),
+    ).resolves.toMatchObject({
+      aliasCandidates: [
+        {
+          modelClubId: "fc-bu-hne",
+          modelClubName: "FC Bühne",
+          wishClubId: "fc-b-hne-1929-42518",
+          wishClubName: "FC Bühne 1929",
+        },
+        {
+          modelClubId: "spfr-berlebeck-heiligenkirchen",
+          modelClubName: "Spfr. Berlebeck-Heiligenkirchen",
+          wishClubId: "sportfreunde-berlebeck-heiligenkirchen-e-v-42634",
+          wishClubName: "Sportfreunde Berlebeck-Heiligenkirchen e.V.",
+        },
+      ],
+      rows: [
+        expect.objectContaining({ clubId: "fc-bu-hne" }),
+        expect.objectContaining({
+          clubId: "spfr-berlebeck-heiligenkirchen",
+        }),
+        expect.objectContaining({ clubId: "fc-b-hne-1929-42518" }),
+        expect.objectContaining({
+          clubId: "sportfreunde-berlebeck-heiligenkirchen-e-v-42634",
+        }),
+      ],
+    });
+    expect(prismaMock.rasterHallCapacity.deleteMany).not.toHaveBeenCalled();
   });
 
   it("infers capacities from parsed wishes when the season model has no week preference", async () => {

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { prismaMock } from "@/lib/__mocks__/db";
 import {
@@ -315,6 +316,52 @@ describe("raster capacity service", () => {
       ],
     });
     expect(prismaMock.rasterHallCapacity.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps reviewed club aliases visible for correction", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      seasonModelJson: JSON.stringify({
+        clubAliases: [
+          {
+            sourceClubId: "fc-bu-hne",
+            sourceClubName: "FC Bühne",
+            targetClubId: "fc-b-hne-1929-42518",
+            targetClubName: "FC Bühne 1929",
+          },
+        ],
+        clubs: [{ id: "fc-b-hne-1929-42518", name: "FC Bühne 1929" }],
+        teams: [
+          {
+            clubId: "fc-b-hne-1929-42518",
+            hall: "1",
+            homeWeekday: "friday",
+          },
+        ],
+      }),
+      wishes: [
+        {
+          clubId: "fc-b-hne-1929-42518",
+          clubName: "FC Bühne 1929",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+      ],
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      reviewHallCapacitiesForInputSet("input-1"),
+    ).resolves.toMatchObject({
+      aliasCandidates: [
+        {
+          confirmed: true,
+          modelClubId: "fc-bu-hne",
+          wishClubId: "fc-b-hne-1929-42518",
+        },
+      ],
+    });
   });
 
   it("infers capacities from parsed wishes when the season model has no week preference", async () => {

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -419,6 +419,78 @@ describe("raster capacity service", () => {
     });
   });
 
+  it("asks for a club alias when no likely match is found", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      seasonModelJson: JSON.stringify({
+        clubs: [{ id: "model-club", name: "Model Club" }],
+        teams: [
+          {
+            clubId: "model-club",
+            hall: "1",
+            homeWeekday: "friday",
+          },
+        ],
+      }),
+      wishes: [
+        {
+          clubId: "wish-club",
+          clubName: "Different Wish Club",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+      ],
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      reviewHallCapacitiesForInputSet("input-1"),
+    ).resolves.toMatchObject({
+      aliasCandidates: [
+        {
+          modelClubId: "model-club",
+          wishClubId: undefined,
+          wishClubName: undefined,
+        },
+      ],
+    });
+  });
+
+  it("does not ask for aliases for excluded capacity teams", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      seasonModelJson: JSON.stringify({
+        clubs: [{ id: "excluded-club", name: "Excluded Club" }],
+        teams: [
+          {
+            clubId: "excluded-club",
+            hall: "1",
+            homeWeekday: "friday",
+            capacityRelevant: false,
+          },
+        ],
+      }),
+      wishes: [
+        {
+          clubId: "wish-club",
+          clubName: "Excluded Club 1920",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+      ],
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      reviewHallCapacitiesForInputSet("input-1"),
+    ).resolves.toMatchObject({
+      inferredCount: 1,
+      aliasCandidates: [],
+    });
+  });
+
   it("keeps reviewed club aliases visible for correction", async () => {
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       ...inputScope,

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -429,6 +429,7 @@ describe("raster capacity service", () => {
             clubId: "model-club",
             hall: "1",
             homeWeekday: "friday",
+            capacityRelevant: false,
           },
         ],
       }),
@@ -462,8 +463,10 @@ describe("raster capacity service", () => {
       ...inputScope,
       seasonModelJson: JSON.stringify({
         clubs: [{ id: "excluded-club", name: "Excluded Club" }],
+        groups: [{ planningStatus: "exclude", teamIds: ["team-1"] }],
         teams: [
           {
+            id: "team-1",
             clubId: "excluded-club",
             hall: "1",
             homeWeekday: "friday",

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -450,6 +450,7 @@ describe("raster capacity service", () => {
     ).resolves.toMatchObject({
       aliasCandidates: [
         {
+          capacityRelevant: false,
           modelClubId: "model-club",
           wishClubId: undefined,
           wishClubName: undefined,

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -188,6 +188,43 @@ describe("raster capacity service", () => {
     });
   });
 
+  it("raises stale inferred capacities", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      wishes: [],
+      seasonModelJson: JSON.stringify({
+        teams: [
+          {
+            id: "team-a",
+            clubId: "club-a",
+            hall: "1",
+            homeWeekday: "friday",
+            spielwochePref: "A",
+          },
+        ],
+      }),
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([
+      {
+        id: "capacity-1",
+        scopeId: "scope-owl",
+        clubId: "club-a",
+        hall: "1",
+        weekday: "FRIDAY",
+        capacity: 0,
+        basis: HallCapacityBasis.INFERRED,
+      },
+    ] as never);
+
+    await expect(
+      inferHallCapacitiesFromInputSet("input-1", "admin-1"),
+    ).resolves.toEqual({ count: 1, needsReview: 0, pruned: 0 });
+    expect(prismaMock.rasterHallCapacity.update).toHaveBeenCalledWith({
+      where: { id: "capacity-1" },
+      data: { capacity: 1, updatedById: "admin-1" },
+    });
+  });
+
   it("infers capacities from parsed wishes when the season model has no week preference", async () => {
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       ...inputScope,

--- a/webapp/tests/unit/raster-capacity-service.test.ts
+++ b/webapp/tests/unit/raster-capacity-service.test.ts
@@ -318,6 +318,107 @@ describe("raster capacity service", () => {
     expect(prismaMock.rasterHallCapacity.deleteMany).not.toHaveBeenCalled();
   });
 
+  it("surfaces likely club aliases for review when official names differ", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      seasonModelJson: JSON.stringify({
+        clubs: [
+          { id: "djk-delbru-ck", name: "DJK Delbrück" },
+          { id: "ssv-bw-blankenau", name: "SSV BW Blankenau" },
+        ],
+        teams: [
+          {
+            clubId: "djk-delbru-ck",
+            hall: "1",
+            homeWeekday: "friday",
+          },
+          {
+            clubId: "ssv-bw-blankenau",
+            hall: "1",
+            homeWeekday: "friday",
+          },
+        ],
+      }),
+      wishes: [
+        {
+          clubId: "djk-graf-sporck-1920-e-v-delbr-ck-42722",
+          clubName: "DJK Graf Sporck 1920 e.V. Delbrück",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+        {
+          clubId: "ssv-blau-wei-blankenau-42515",
+          clubName: "SSV Blau-Weiß Blankenau",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+      ],
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      reviewHallCapacitiesForInputSet("input-1"),
+    ).resolves.toMatchObject({
+      aliasCandidates: [
+        {
+          modelClubId: "djk-delbru-ck",
+          wishClubId: "djk-graf-sporck-1920-e-v-delbr-ck-42722",
+        },
+        {
+          modelClubId: "ssv-bw-blankenau",
+          wishClubId: "ssv-blau-wei-blankenau-42515",
+        },
+      ],
+    });
+  });
+
+  it("asks for a club alias without preselecting an ambiguous match", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      ...inputScope,
+      seasonModelJson: JSON.stringify({
+        clubs: [{ id: "tus-senne", name: "TuS Senne" }],
+        teams: [
+          {
+            clubId: "tus-senne",
+            hall: "1",
+            homeWeekday: "friday",
+          },
+        ],
+      }),
+      wishes: [
+        {
+          clubId: "tus-senne-i",
+          clubName: "TuS Senne I",
+          teamLabel: "Erwachsene",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+        {
+          clubId: "tus-senne-ii",
+          clubName: "TuS Senne II",
+          teamLabel: "Erwachsene II",
+          hall: "1",
+          homeWeekday: "FRIDAY",
+        },
+      ],
+    } as never);
+    prismaMock.rasterHallCapacity.findMany.mockResolvedValue([] as never);
+
+    await expect(
+      reviewHallCapacitiesForInputSet("input-1"),
+    ).resolves.toMatchObject({
+      aliasCandidates: [
+        {
+          modelClubId: "tus-senne",
+          wishClubId: undefined,
+          wishClubName: undefined,
+        },
+      ],
+    });
+  });
+
   it("keeps reviewed club aliases visible for correction", async () => {
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       ...inputScope,

--- a/webapp/tests/unit/raster-input-sets-route.test.ts
+++ b/webapp/tests/unit/raster-input-sets-route.test.ts
@@ -85,4 +85,32 @@ describe("raster input set route", () => {
       },
     });
   });
+
+  it("rejects duplicate planning set names", async () => {
+    requireApiUser.mockResolvedValue({
+      user: {
+        id: "admin-1",
+        role: Role.PLATFORM_ADMIN,
+        status: UserStatus.ACTIVE,
+      },
+    });
+    prismaMock.scope.findFirst.mockResolvedValue({ id: "scope-1" } as never);
+    prismaMock.scope.findUnique.mockResolvedValue({ code: "OWL" } as never);
+    prismaMock.rasterInputSet.findFirst.mockResolvedValue({
+      id: "input-1",
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/raster/input-sets", {
+        method: "POST",
+        body: JSON.stringify({ scope: "OWL", name: "OWL 2026" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Planning set name already exists for this scope and season.",
+    });
+    expect(prismaMock.rasterInputSet.create).not.toHaveBeenCalled();
+  });
 });

--- a/webapp/tests/unit/raster-input-sets-service.test.ts
+++ b/webapp/tests/unit/raster-input-sets-service.test.ts
@@ -317,6 +317,52 @@ describe("raster input set service", () => {
     ]);
   });
 
+  it("updates reviewed club aliases after a wrong mapping", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      id: "input-1",
+      status: InputSetStatus.DRAFT,
+      seasonModelJson: JSON.stringify({
+        ...model,
+        clubAliases: [
+          {
+            sourceClubId: "fc-bu-hne",
+            sourceClubName: "FC Bühne",
+            targetClubId: "wrong-club",
+            targetClubName: "Wrong Club",
+          },
+        ],
+        clubs: [{ id: "wrong-club", name: "Wrong Club" }],
+        teams: [{ id: "t1", clubId: "wrong-club" }],
+        wishes: [{ clubId: "wrong-club", text: "parallel" }],
+      }),
+    } as never);
+    prismaMock.rasterWish.findFirst.mockResolvedValue({
+      clubId: "fc-b-hne-1929-42518",
+      clubName: "FC Bühne 1929",
+    } as never);
+    prismaMock.rasterInputSet.update.mockResolvedValue({} as never);
+
+    await updateClubAliasMapping(
+      "input-1",
+      "fc-bu-hne",
+      "fc-b-hne-1929-42518",
+    );
+
+    const saved = JSON.parse(
+      prismaMock.rasterInputSet.update.mock.calls[0]?.[0].data
+        .seasonModelJson as string,
+    );
+    expect(saved.clubAliases).toEqual([
+      expect.objectContaining({
+        sourceClubId: "fc-bu-hne",
+        targetClubId: "fc-b-hne-1929-42518",
+      }),
+    ]);
+    expect(saved.teams).toEqual([
+      expect.objectContaining({ clubId: "fc-b-hne-1929-42518" }),
+    ]);
+  });
+
   it("syncs selected workspace source caches into input sets", async () => {
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       id: "input-1",

--- a/webapp/tests/unit/raster-input-sets-service.test.ts
+++ b/webapp/tests/unit/raster-input-sets-service.test.ts
@@ -5,6 +5,7 @@ import {
   syncInputSetSourceCaches,
   updateGroupPlanningStatus,
   updateGroupRasterMode,
+  updateTeamWishFields,
   validateInputSet,
 } from "@/services/raster";
 import { InputSetStatus } from "../../generated/prisma/enums";
@@ -245,6 +246,30 @@ describe("raster input set service", () => {
     ]);
   });
 
+  it("marks manual week preferences for source sync preservation", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      id: "input-1",
+      status: InputSetStatus.DRAFT,
+      seasonModelJson: JSON.stringify(model),
+      _count: { wishes: 1, fixedRasterzahlen: 0 },
+    } as never);
+    prismaMock.rasterInputSet.update.mockResolvedValue({} as never);
+
+    await updateTeamWishFields("input-1", "t1", { spielwochePref: "B" });
+
+    const saved = JSON.parse(
+      prismaMock.rasterInputSet.update.mock.calls[0]?.[0].data
+        .seasonModelJson as string,
+    );
+    expect(saved.teams).toEqual([
+      expect.objectContaining({
+        id: "t1",
+        spielwochePref: "B",
+        spielwochePrefSource: "manual",
+      }),
+    ]);
+  });
+
   it("syncs selected workspace source caches into input sets", async () => {
     prismaMock.rasterInputSet.findUnique.mockResolvedValue({
       id: "input-1",
@@ -447,6 +472,12 @@ describe("raster input set service", () => {
       startTime: "20:00",
     });
   });
+});
+
+describe("raster input set sync preservation", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("preserves manual wish matches while syncing source caches", async () => {
     const parsedWish = {
@@ -494,6 +525,8 @@ describe("raster input set service", () => {
             label: "Erwachsene",
             wishMatchId: "wish-bergheim",
             wishMatchSource: "manual",
+            spielwochePref: "B",
+            spielwochePrefSource: "manual",
           },
         ],
         groups: [],
@@ -550,6 +583,8 @@ describe("raster input set service", () => {
       teams: Array<{
         id: string;
         clubId?: string;
+        spielwochePref?: string;
+        spielwochePrefSource?: string;
         wishMatchId?: string;
         wishMatchSource?: string;
       }>;
@@ -560,6 +595,8 @@ describe("raster input set service", () => {
       ),
     ).toMatchObject({
       clubId: "sportverein-1930-bergheim",
+      spielwochePref: "B",
+      spielwochePrefSource: "manual",
       wishMatchId: "wish-bergheim",
       wishMatchSource: "manual",
     });

--- a/webapp/tests/unit/raster-input-sets-service.test.ts
+++ b/webapp/tests/unit/raster-input-sets-service.test.ts
@@ -126,7 +126,11 @@ describe("raster input set service", () => {
     } as never);
 
     await expect(validateInputSet("input-1")).resolves.toMatchObject({
-      errors: [expect.stringContaining("without parsed wish PDFs")],
+      errors: [
+        expect.stringContaining(
+          "L::G6. Choose include or exclude before running.",
+        ),
+      ],
     });
   });
 

--- a/webapp/tests/unit/raster-input-sets-service.test.ts
+++ b/webapp/tests/unit/raster-input-sets-service.test.ts
@@ -443,4 +443,121 @@ describe("raster input set service", () => {
       startTime: "20:00",
     });
   });
+
+  it("preserves manual wish matches while syncing source caches", async () => {
+    const parsedWish = {
+      clubs: [
+        {
+          id: "sportverein-1930-bergheim",
+          name: "Sportverein 1930 Bergheim",
+        },
+      ],
+      teams: [
+        {
+          clubId: "sportverein-1930-bergheim",
+          label: "Erwachsene",
+          homeWeekday: "friday",
+          hall: "1",
+          startTime: "20:00",
+          spielwochePref: "A",
+          rasterzahl: { kind: "assignable" },
+          confidence: "review",
+        },
+      ],
+      warnings: [],
+    };
+    const wishesJson = JSON.stringify({
+      sources: [
+        {
+          sourceId: "wish-source",
+          sourceRef: "wishes",
+          parsed: parsedWish,
+        },
+      ],
+    });
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      id: "input-1",
+      scopeId: "owl",
+      season: "2026/27",
+      createdById: "user-1",
+      wishesJson,
+      seasonModelJson: JSON.stringify({
+        clubs: [],
+        teams: [
+          {
+            id: "bezirksoberliga-erwachsene-ttc-auto",
+            clubId: "sportverein-1930-bergheim",
+            label: "Erwachsene",
+            wishMatchId: "wish-bergheim",
+            wishMatchSource: "manual",
+          },
+        ],
+        groups: [],
+        wishes: [],
+        absoluteConstraints: [],
+        warnings: [],
+      }),
+    } as never);
+    prismaMock.rasterWish.findMany.mockResolvedValue([
+      {
+        id: "wish-bergheim",
+        clubId: "sportverein-1930-bergheim",
+        clubName: "Sportverein 1930 Bergheim",
+        teamLabel: "Erwachsene",
+        homeWeekday: "FRIDAY",
+        hall: "1",
+        startTime: "20:00",
+        spielwochePref: "A",
+        requestedRasterzahl: null,
+        notes: null,
+        confidence: "REVIEW",
+      },
+    ] as never);
+    prismaMock.rasterSource.findMany.mockResolvedValue([
+      {
+        id: "group-source",
+        sourceType: "GROUP_ASSIGNMENT",
+        sourceRef: "groups",
+        parsedJson: JSON.stringify({
+          assignments: [1, 2, 3, 4, 5].map((rasterzahl) => ({
+            league: "L",
+            group: "Bezirksoberliga Erwachsene",
+            rasterzahl,
+            team: rasterzahl === 1 ? "TTC Auto" : `Other Club ${rasterzahl}`,
+            sourceUrl: "https://example.test/group",
+          })),
+        }),
+      },
+      {
+        id: "wish-source",
+        sourceType: "WISHES_PDF",
+        sourceRef: "wishes",
+        parsedJson: JSON.stringify(parsedWish),
+      },
+    ] as never);
+    prismaMock.rasterInputSet.update.mockResolvedValue({} as never);
+
+    await syncInputSetSourceCaches("input-1");
+
+    const update = prismaMock.rasterInputSet.update.mock.calls.at(-1)?.[0] as {
+      data: { seasonModelJson?: string };
+    };
+    const synced = JSON.parse(update.data.seasonModelJson ?? "{}") as {
+      teams: Array<{
+        id: string;
+        clubId?: string;
+        wishMatchId?: string;
+        wishMatchSource?: string;
+      }>;
+    };
+    expect(
+      synced.teams.find(
+        (team) => team.id === "bezirksoberliga-erwachsene-ttc-auto",
+      ),
+    ).toMatchObject({
+      clubId: "sportverein-1930-bergheim",
+      wishMatchId: "wish-bergheim",
+      wishMatchSource: "manual",
+    });
+  });
 });

--- a/webapp/tests/unit/raster-input-sets-service.test.ts
+++ b/webapp/tests/unit/raster-input-sets-service.test.ts
@@ -3,6 +3,7 @@ import { prismaMock } from "@/lib/__mocks__/db";
 import {
   listInputSets,
   syncInputSetSourceCaches,
+  updateClubAliasMapping,
   updateGroupPlanningStatus,
   updateGroupRasterMode,
   updateTeamWishFields,
@@ -267,6 +268,52 @@ describe("raster input set service", () => {
         spielwochePref: "B",
         spielwochePrefSource: "manual",
       }),
+    ]);
+  });
+
+  it("stores reviewed club aliases and rewrites model club ids", async () => {
+    prismaMock.rasterInputSet.findUnique.mockResolvedValue({
+      id: "input-1",
+      status: InputSetStatus.DRAFT,
+      seasonModelJson: JSON.stringify({
+        ...model,
+        clubs: [{ id: "fc-bu-hne", name: "FC Bühne" }],
+        teams: [{ id: "t1", clubId: "fc-bu-hne" }],
+        wishes: [{ clubId: "fc-bu-hne", text: "parallel" }],
+      }),
+    } as never);
+    prismaMock.rasterWish.findFirst.mockResolvedValue({
+      clubId: "fc-b-hne-1929-42518",
+      clubName: "FC Bühne 1929",
+    } as never);
+    prismaMock.rasterInputSet.update.mockResolvedValue({} as never);
+
+    await updateClubAliasMapping(
+      "input-1",
+      "fc-bu-hne",
+      "fc-b-hne-1929-42518",
+    );
+
+    const saved = JSON.parse(
+      prismaMock.rasterInputSet.update.mock.calls[0]?.[0].data
+        .seasonModelJson as string,
+    );
+    expect(saved.clubAliases).toEqual([
+      {
+        sourceClubId: "fc-bu-hne",
+        sourceClubName: "FC Bühne",
+        targetClubId: "fc-b-hne-1929-42518",
+        targetClubName: "FC Bühne 1929",
+      },
+    ]);
+    expect(saved.clubs).toEqual([
+      expect.objectContaining({ id: "fc-b-hne-1929-42518" }),
+    ]);
+    expect(saved.teams).toEqual([
+      expect.objectContaining({ clubId: "fc-b-hne-1929-42518" }),
+    ]);
+    expect(saved.wishes).toEqual([
+      expect.objectContaining({ clubId: "fc-b-hne-1929-42518" }),
     ]);
   });
 

--- a/webapp/tests/unit/raster-sources-upload-route.test.ts
+++ b/webapp/tests/unit/raster-sources-upload-route.test.ts
@@ -12,14 +12,14 @@ const {
   upsertRasterSource,
   parseUpperLeagueRasterPdf,
 } = vi.hoisted(() => ({
-    requireApiUser: vi.fn(),
-    saveFile: vi.fn(),
-    getFilePath: vi.fn((value: string) => `D:/storage/${value}`),
-    importRasterRoster: vi.fn(),
-    replaceRasterSource: vi.fn(),
-    upsertRasterSource: vi.fn(),
-    parseUpperLeagueRasterPdf: vi.fn(),
-  }));
+  requireApiUser: vi.fn(),
+  saveFile: vi.fn(),
+  getFilePath: vi.fn((value: string) => `D:/storage/${value}`),
+  importRasterRoster: vi.fn(),
+  replaceRasterSource: vi.fn(),
+  upsertRasterSource: vi.fn(),
+  parseUpperLeagueRasterPdf: vi.fn(),
+}));
 
 vi.mock("@/lib/db", () => ({
   prisma: prismaMock,
@@ -226,7 +226,7 @@ describe("raster source upload route", () => {
     expect(replaceRasterSource).not.toHaveBeenCalled();
   });
 
-  it("imports an upper-league raster PDF as a replacing parsed source", async () => {
+  it("uploads an upper-league raster PDF as a replacing unparsed source", async () => {
     requireApiUser.mockResolvedValue({
       user: {
         id: "scheduler-1",
@@ -245,10 +245,6 @@ describe("raster source upload route", () => {
       id: "input-1",
     } as never);
     saveFile.mockResolvedValue("uploads/gruppen.pdf");
-    parseUpperLeagueRasterPdf.mockResolvedValue({
-      sourceLabel: "gruppen.pdf",
-      leagues: [{ league: "Verbandsliga 1 Erwachsene", size: 11, entries: [] }],
-    });
     replaceRasterSource.mockResolvedValue({ id: "upper-source" });
 
     const formData = new FormData();
@@ -265,9 +261,7 @@ describe("raster source upload route", () => {
     );
 
     expect(response.status).toBe(201);
-    expect(parseUpperLeagueRasterPdf).toHaveBeenCalledWith(
-      "D:/storage/uploads/gruppen.pdf",
-    );
+    expect(parseUpperLeagueRasterPdf).not.toHaveBeenCalled();
     expect(replaceRasterSource).toHaveBeenCalledWith({
       scopeId: "owl",
       inputSetId: "input-1",
@@ -275,51 +269,7 @@ describe("raster source upload route", () => {
       sourceType: "UPPER_LEAGUE_RASTER",
       sourceRef: "uploads/gruppen.pdf",
       displayName: "gruppen.pdf",
-      parsedJson: JSON.stringify({
-        sourceLabel: "gruppen.pdf",
-        leagues: [
-          { league: "Verbandsliga 1 Erwachsene", size: 11, entries: [] },
-        ],
-      }),
     });
-  });
-
-  it("rejects malformed upper-league raster PDFs without recording a source", async () => {
-    requireApiUser.mockResolvedValue({
-      user: {
-        id: "scheduler-1",
-        role: Role.SCOPE_ADMIN,
-        status: UserStatus.ACTIVE,
-      },
-    });
-    prismaMock.scope.findFirst
-      .mockResolvedValueOnce({ id: "owl" } as never)
-      .mockResolvedValueOnce({
-        id: "owl",
-        code: "OWL",
-        name: "Ostwestfalen/Lippe",
-      } as never);
-    prismaMock.rasterInputSet.findFirst.mockResolvedValue({
-      id: "input-1",
-    } as never);
-    saveFile.mockResolvedValue("uploads/gruppen.pdf");
-    parseUpperLeagueRasterPdf.mockRejectedValue(new Error("no readable entries"));
-
-    const formData = new FormData();
-    formData.set("scopeCode", "OWL");
-    formData.set("inputSetId", "input-1");
-    formData.set("sourceType", "UPPER_LEAGUE_RASTER");
-    formData.set("file", new File(["%PDF-1.4"], "gruppen.pdf"));
-
-    const response = await POST(
-      new Request("http://localhost/api/raster/sources/upload", {
-        method: "POST",
-        body: formData,
-      }),
-    );
-
-    expect(response.status).toBe(422);
-    expect(replaceRasterSource).not.toHaveBeenCalled();
   });
 
   it("imports a roster CSV before recording the source", async () => {

--- a/webapp/tests/unit/raster/match-review-fingerprint.test.ts
+++ b/webapp/tests/unit/raster/match-review-fingerprint.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { rasterMatchFingerprint } from "@/lib/raster/match-review";
+import {
+  deriveMatchReviewState,
+  rasterMatchFingerprint,
+} from "@/lib/raster/match-review";
 
 describe("raster match review fingerprint", () => {
   it("ignores whitespace, diacritics and object ordering churn", () => {
@@ -48,5 +51,33 @@ describe("raster match review fingerprint", () => {
     expect(rasterMatchFingerprint({ ...base, ...patch })).not.toBe(
       rasterMatchFingerprint(base),
     );
+  });
+
+  it("shows club and slot details for review rows", () => {
+    expect(
+      deriveMatchReviewState(
+        JSON.stringify({
+          teams: [
+            {
+              id: "team-1",
+              clubId: "ttc-koln",
+              clubName: "TTC Köln",
+              label: "Erwachsene",
+              wishMatchId: "wish-1",
+              homeWeekday: "FRIDAY",
+              hall: "1",
+              startTime: "19:30",
+              spielwochePref: "A",
+            },
+          ],
+        }),
+        [],
+      ),
+    ).toMatchObject([
+      {
+        label: "TTC Köln / Erwachsene",
+        detail: "home FRIDAY, hall 1, 19:30, week A, matched wish data",
+      },
+    ]);
   });
 });

--- a/webapp/tests/unit/raster/review-helpers.test.tsx
+++ b/webapp/tests/unit/raster/review-helpers.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { extractPlanningGroups } from "@/app/(dashboard)/raster/_lib/review-helpers";
+
+describe("raster review helpers", () => {
+  it("does not count excluded group teams as missing", () => {
+    const groups = extractPlanningGroups(
+      "input-1",
+      JSON.stringify({
+        teams: [
+          { id: "t1", capacityRelevant: false },
+          { id: "t2", capacityRelevant: false },
+        ],
+        groups: [
+          {
+            id: "g1",
+            planningStatus: "exclude",
+            teamIds: ["t1", "t2"],
+          },
+        ],
+      }),
+      [],
+    );
+
+    expect(groups[0]?.missingTeams).toBe(0);
+    expect(groups[0]?.teams.map((team) => team.missing)).toEqual([
+      "deferred",
+      "deferred",
+    ]);
+  });
+});

--- a/webapp/tests/unit/raster/wish-import-review-panel.test.tsx
+++ b/webapp/tests/unit/raster/wish-import-review-panel.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "filter.all") return "All";
+    if (key === "filter.added") return "Added";
+    if (key === "title") return "Wish Import Review";
+    if (key === "toReview") return `${values?.count} to review`;
+    if (key === "addedInfoCount") return `${values?.count} wishes imported cleanly`;
+    return key;
+  },
+}));
+
+import { WishImportReviewPanel } from "@/components/raster/wish-import-review-panel";
+
+describe("WishImportReviewPanel", () => {
+  it("counts cleanly added wishes in the All tab", () => {
+    const html = renderToStaticMarkup(
+      <WishImportReviewPanel
+        canEdit
+        inputSetId="input-1"
+        review={{
+          conflicts: [],
+          unmatchedRows: [],
+          addedWishes: [wish("1"), wish("2")],
+          settledMatches: [],
+          missingWishes: [],
+        }}
+      />,
+    );
+
+    expect(html).toContain("Wish Import Review (0 to review)");
+    expect(html).toContain("All (2)");
+    expect(html).toContain("Added (2)");
+  });
+});
+
+function wish(id: string) {
+  return {
+    id,
+    clubId: `club-${id}`,
+    clubName: `Club ${id}`,
+    teamLabel: "Erwachsene",
+    homeWeekday: "FRIDAY",
+    hall: null,
+    startTime: null,
+    spielwochePref: null,
+    requestedRasterzahl: null,
+    notes: null,
+  };
+}

--- a/webapp/worker/src/starter_worker/db.py
+++ b/webapp/worker/src/starter_worker/db.py
@@ -306,6 +306,7 @@ class JobStore:
         spanned_scope_ids: list[str] | None = None,
         model: dict[str, Any],
         solver_output: dict[str, Any],
+        strategy: str = "cp_sat",
     ) -> str:
         snapshot_id = _new_id()
         metadata = solver_output["metadata"]
@@ -314,7 +315,7 @@ class JobStore:
         total_excess = sum(int(row["excess"]) for row in overages)
         affected_clubs = len({str(row["clubId"]) for row in overages})
         max_excess = max([int(row["excess"]) for row in overages], default=0)
-        optimality = _raster_success_outcome(str(metadata.get("status") or ""))
+        optimality = _raster_success_outcome(str(metadata.get("status") or ""), strategy)
         outcome = optimality
         assignments = _assignment_rows(snapshot_id, model, assignment)
         objective_breakdown = json.dumps(
@@ -842,9 +843,9 @@ def _objective_breakdown(overages: list[dict[str, Any]], weights: object) -> dic
     }
 
 
-def _raster_success_outcome(status: str) -> str:
+def _raster_success_outcome(status: str, strategy: str = "cp_sat") -> str:
     normalized = status.strip().upper()
-    if normalized == "OPTIMAL":
+    if normalized == "OPTIMAL" and strategy != "initial_heuristic":
         return "PROVEN_OPTIMAL"
     return "FEASIBLE"
 
@@ -950,6 +951,7 @@ def _find_overage_rows(model: dict[str, Any], assignment: dict[str, Any]) -> lis
                     "assignedRasterzahl": rasterzahl,
                     "requestedRasterzahl": team.get("requestedRasterzahl"),
                     "assignmentStatus": _assignment_status(str(raster.get("kind") or "")),
+                    "planned": team.get("planned"),
                     "weekSlot": team.get("spielwochePref"),
                     "startTime": team.get("startTime"),
                     "start_minutes": _parse_start_minutes(team.get("startTime")),
@@ -1010,6 +1012,7 @@ def _unique_team_refs(teams: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     "assignedRasterzahl": team.get("assignedRasterzahl"),
                     "requestedRasterzahl": team.get("requestedRasterzahl"),
                     "assignmentStatus": team.get("assignmentStatus"),
+                    "planned": team.get("planned"),
                     "weekSlot": team.get("weekSlot"),
                     "startTime": team.get("startTime"),
                     "durationMinutes": team.get("duration_minutes"),

--- a/webapp/worker/src/starter_worker/main.py
+++ b/webapp/worker/src/starter_worker/main.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import time
 import shutil
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
@@ -493,11 +494,7 @@ def _raster_solver_command(
         os.environ.get("RASTER_SOLVER_SCRIPT") or repo_root / "scripts" / "solve-raster-cpsat.py"
     )
     return [
-        "uv",
-        "run",
-        "--project",
-        str(Path(__file__).resolve().parents[2]),
-        "python",
+        sys.executable,
         str(solver_script),
         *common,
         "--time-limit",

--- a/webapp/worker/src/starter_worker/main.py
+++ b/webapp/worker/src/starter_worker/main.py
@@ -131,6 +131,7 @@ def process_raster_run(store: JobStore, job: BackgroundJob) -> dict[str, object]
         spanned_scope_ids=context.get("scopeIds") or [],
         model=model,
         solver_output=solver_output,
+        strategy=str(settings.get("strategy") or "cp_sat"),
     )
     metadata = solver_output.get("metadata") if isinstance(solver_output, dict) else {}
     return {

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -47,7 +47,9 @@ from starter_worker.main import (
 class WorkerTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory()
-        if self._testMethodName.startswith("test_combined_raster_model_"):
+        if self._testMethodName.startswith(
+            ("test_combined_raster_model_", "test_raster_solver_", "test_worker_runtime_")
+        ):
             return
         self.database_url = ensure_worker_database()
         truncate_all(self.database_url)
@@ -479,7 +481,7 @@ class WorkerTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_raster_solver_uses_worker_uv_project(self) -> None:
+    def test_raster_solver_uses_worker_python(self) -> None:
         completed = subprocess.CompletedProcess(
             args=[],
             returncode=0,
@@ -494,7 +496,7 @@ class WorkerTests(unittest.TestCase):
             _solve_raster_model({"clubs": [], "teams": [], "groups": []}, {})
 
         command = run.call_args.args[0]
-        self.assertEqual(command[:4], ["uv", "run", "--project", str(Path(__file__).parents[1])])
+        self.assertEqual(command[0], sys.executable)
 
     def test_raster_solver_can_use_initial_heuristic(self) -> None:
         completed = subprocess.CompletedProcess(

--- a/webapp/worker/tests/test_main.py
+++ b/webapp/worker/tests/test_main.py
@@ -22,7 +22,9 @@ from starter_worker.db import (
     BackgroundJob,
     JobStore,
     _assignment_rows,
+    _conflict_rows,
     _find_overage_rows,
+    _raster_success_outcome,
     normalize_postgres_database_url,
 )
 from starter_worker.main import (
@@ -568,6 +570,38 @@ class WorkerTests(unittest.TestCase):
 
         self.assertTrue(rows)
         self.assertEqual(rows[0]["capacity"], 1)
+
+    def test_raster_solver_initial_heuristic_optimal_status_is_not_proven_optimal(self) -> None:
+        self.assertEqual(_raster_success_outcome("OPTIMAL", "initial_heuristic"), "FEASIBLE")
+        self.assertEqual(_raster_success_outcome("OPTIMAL", "cp_sat"), "PROVEN_OPTIMAL")
+
+    def test_raster_solver_conflict_rows_keep_unplanned_team_marker(self) -> None:
+        model = {"clubs": [{"id": "club", "name": "Club"}]}
+        rows = _conflict_rows(
+            "snapshot-1",
+            model,
+            [
+                {
+                    "week": 1,
+                    "clubId": "club",
+                    "weekday": "friday",
+                    "hall": "1",
+                    "capacity": 1,
+                    "actualCount": 2,
+                    "excess": 1,
+                    "teams": [
+                        {
+                            "id": "upper",
+                            "assignmentStatus": "FIXED",
+                            "planned": False,
+                        }
+                    ],
+                }
+            ],
+        )
+
+        teams = json.loads(rows[0][10])
+        self.assertEqual(teams[0]["planned"], False)
 
     def test_persisted_overages_do_not_duplicate_same_team_home_week(self) -> None:
         model = {


### PR DESCRIPTION
## Summary
- prevent duplicate planning workspace names per scope and season
- make click-TT display names optional, add Parse all, and keep upper-league uploads unparsed until explicit parse
- sync parsed sources before gym-capacity inference and raise stale inferred capacity rows
- update Feature 011 spec/tasks for the follow-up behavior

## Verification
- pnpm --dir webapp exec vitest run tests/unit/raster-sources-upload-route.test.ts tests/unit/raster-sources-route.test.ts tests/unit/raster-sources-service.test.ts tests/unit/raster-input-sets-route.test.ts tests/unit/raster-input-sets-service.test.ts
- pnpm --dir webapp exec vitest run tests/unit/raster-capacity-service.test.ts tests/unit/raster-input-sets-service.test.ts
- pnpm --dir webapp run lint